### PR TITLE
chore(zod-validator): bump up Hono

### DIFF
--- a/.changeset/brown-zebras-tan.md
+++ b/.changeset/brown-zebras-tan.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': patch
+---
+
+bump up Hono version

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -28,11 +28,11 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "^3.0.0-rc.9",
+    "hono": "^3.0.0-rc.11",
     "zod": "^3.19.1"
   },
   "devDependencies": {
-    "hono": "3.0.0-rc.9",
+    "hono": "3.0.0-rc.11",
     "zod": "3.19.1"
   }
 }

--- a/packages/zod-validator/test/index.test.ts
+++ b/packages/zod-validator/test/index.test.ts
@@ -15,7 +15,7 @@ describe('Basic', () => {
   })
 
   const route = app.post('/author', zValidator('json', schema), (c) => {
-    const data = c.req.valid()
+    const data = c.req.valid('json')
     return c.jsonT({
       success: true,
       message: `${data.name} is ${data.age}`,
@@ -94,7 +94,7 @@ describe('With Hook', () => {
       return c.text(`${data.id} is valid!`)
     }),
     (c) => {
-      const data = c.req.valid()
+      const data = c.req.valid('json')
       return c.json({
         success: true,
         message: `${data.id} is ${data.title}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5180,15 +5180,15 @@ heap-js@^2.2.0:
   resolved "https://registry.yarnpkg.com/heap-js/-/heap-js-2.2.0.tgz#f4418874cd2aedc2cf3a7492d579afe23b627c5d"
   integrity sha512-G3uM72G9F/zo9Hph/T7m4ZZVlVu5bx2f5CiCS78TBHz2mNIXnB5KRdEEYssXZJ7ldLDqID29bZ1D5ezCKQD2Zw==
 
+hono@3.0.0-rc.11:
+  version "3.0.0-rc.11"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-3.0.0-rc.11.tgz#512054df8a2ebaaccd6f34210226c0066b17b588"
+  integrity sha512-MC0TaLMKuV8yds3wldPMvA8YUOs3rI7FyD0LQlFfkWY4+kKvJpXeAd1rfXN+dy1QqK9lNwd0nSk2FZjJ/MUJ2w==
+
 hono@3.0.0-rc.4:
   version "3.0.0-rc.4"
   resolved "https://registry.yarnpkg.com/hono/-/hono-3.0.0-rc.4.tgz#7bfe8c89d4b004ff90d587c8ba45279a175fbce7"
   integrity sha512-76R3mb8kPeuD9TOmQ1WZi59w4QbpaUOlyX3wC7zQpt7IM7iFVBTxj2fpv++6ROPtd5iUBMCrmH/65ZrNXYYgmg==
-
-hono@3.0.0-rc.9:
-  version "3.0.0-rc.9"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-3.0.0-rc.9.tgz#6077bc67fce850dca99cd58452bda21ff8984da8"
-  integrity sha512-gW/I51Uay6RhrDhtRN/3WTg7ALT3VRdk0NZBdGpkEOgF+TrzFwmWHDbzHUPa9MffiXSlrkFtMmJVvdKO3Iab8Q==
 
 hono@^2.6.1, hono@^2.7.5:
   version "2.7.5"


### PR DESCRIPTION
Bum up Hono version to "3.0.0-rc.11" and fixed tests.