### PR TITLE
tRPCOptions extends `FetchHandlerRequestOptions`-ish

### DIFF
--- a/.changeset/loud-poems-retire.md
+++ b/.changeset/loud-poems-retire.md
@@ -1,0 +1,5 @@
+---
+'@hono/trpc-server': patch
+---
+
+`trpcServer` options extends FetchHandlerRequestOptions

--- a/packages/trpc-server/src/index.ts
+++ b/packages/trpc-server/src/index.ts
@@ -1,18 +1,20 @@
 import type { AnyRouter } from '@trpc/server'
+import type { FetchHandlerRequestOptions} from '@trpc/server/adapters/fetch'
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
 import type { MiddlewareHandler } from 'hono'
 
-type tRPCOptions = {
-  endpoint?: string
-  router: AnyRouter
-}
+type tRPCOptions =
+  Omit<
+    FetchHandlerRequestOptions<AnyRouter>,
+    'req' | 'endpoint'
+  > & Partial<Pick<FetchHandlerRequestOptions<AnyRouter>, 'endpoint'>>
 
-export const trpcServer = ({ router, endpoint = '/trpc' }: tRPCOptions): MiddlewareHandler => {
-  return async (c) => {
+export const trpcServer = ({ endpoint = '/trpc', ...rest }: tRPCOptions): MiddlewareHandler => {
+  return async (c) => {  
     const res = fetchRequestHandler({
-      endpoint: endpoint,
+      ...rest,
+      endpoint,
       req: c.req,
-      router: router,
     })
     return res
   }

--- a/packages/trpc-server/src/index.ts
+++ b/packages/trpc-server/src/index.ts
@@ -10,7 +10,7 @@ type tRPCOptions =
   > & Partial<Pick<FetchHandlerRequestOptions<AnyRouter>, 'endpoint'>>
 
 export const trpcServer = ({ endpoint = '/trpc', ...rest }: tRPCOptions): MiddlewareHandler => {
-  return async (c) => {  
+  return async (c) => {
     const res = fetchRequestHandler({
       ...rest,
       endpoint,


### PR DESCRIPTION
This allows the use of options like `responseMeta` or `createContext`.