### PR TITLE
feat: Update to Hono v3.0.0

### DIFF
--- a/.changeset/sharp-rocks-prove.md
+++ b/.changeset/sharp-rocks-prove.md
@@ -1,0 +1,5 @@
+---
+'@hono/graphql-server': minor
+---
+
+feat: bump up Hono to version 3.0.0

--- a/packages/graphql-server/deno_dist/README.md
+++ b/packages/graphql-server/deno_dist/README.md
@@ -53,3 +53,7 @@ app.use(
 
 app.fire()
 ```
+
+## Author
+
+Minghe Huang <h.minghe@gmail.com>

--- a/packages/graphql-server/deno_dist/index.ts
+++ b/packages/graphql-server/deno_dist/index.ts
@@ -7,7 +7,7 @@ import {
   specifiedRules,
   getOperationAST,
   GraphQLError,
-} from 'https://esm.sh/graphql@16.6.0'
+} from 'https://cdn.skypack.dev/graphql@16.6.0?dts'
 
 import type {
   GraphQLSchema,
@@ -15,11 +15,10 @@ import type {
   ValidationRule,
   FormattedExecutionResult,
   GraphQLFormattedError,
-} from 'https://esm.sh/graphql@16.6.0'
+} from 'https://cdn.skypack.dev/graphql@16.6.0?dts'
 
 import type { Context } from 'https://deno.land/x/hono@v3.0.0/mod.ts'
 import { parseBody } from './parse-body.ts'
-import { HonoRequest } from "https://deno.land/x/hono@v3.0.0/request.ts";
 
 export type RootResolver = (ctx?: Context) => Promise<unknown> | unknown
 
@@ -47,7 +46,7 @@ export const graphqlServer = (options: Options) => {
 
     let params: GraphQLParams
     try {
-      params = await getGraphQLParams(c.req)
+      params = await getGraphQLParams(c.req.raw)
     } catch (e) {
       if (e instanceof Error) {
         console.error(`${e.stack || e.message}`)
@@ -170,7 +169,7 @@ export interface GraphQLParams {
   raw: boolean
 }
 
-export const getGraphQLParams = async (request: HonoRequest): Promise<GraphQLParams> => {
+export const getGraphQLParams = async (request: Request): Promise<GraphQLParams> => {
   const urlData = new URLSearchParams(request.url.split('?')[1])
   const bodyData = await parseBody(request)
 

--- a/packages/graphql-server/deno_dist/index.ts
+++ b/packages/graphql-server/deno_dist/index.ts
@@ -7,7 +7,7 @@ import {
   specifiedRules,
   getOperationAST,
   GraphQLError,
-} from 'https://cdn.skypack.dev/graphql@16.6.0?dts'
+} from 'https://esm.sh/graphql@16.6.0'
 
 import type {
   GraphQLSchema,
@@ -15,10 +15,11 @@ import type {
   ValidationRule,
   FormattedExecutionResult,
   GraphQLFormattedError,
-} from 'https://cdn.skypack.dev/graphql@16.6.0?dts'
+} from 'https://esm.sh/graphql@16.6.0'
 
-import type { Context } from 'https://deno.land/x/hono@v2.7.5/mod.ts'
+import type { Context } from 'https://deno.land/x/hono@v3.0.0/mod.ts'
 import { parseBody } from './parse-body.ts'
+import { HonoRequest } from "https://deno.land/x/hono@v3.0.0/request.ts";
 
 export type RootResolver = (ctx?: Context) => Promise<unknown> | unknown
 
@@ -169,7 +170,7 @@ export interface GraphQLParams {
   raw: boolean
 }
 
-export const getGraphQLParams = async (request: Request): Promise<GraphQLParams> => {
+export const getGraphQLParams = async (request: HonoRequest): Promise<GraphQLParams> => {
   const urlData = new URLSearchParams(request.url.split('?')[1])
   const bodyData = await parseBody(request)
 

--- a/packages/graphql-server/deno_dist/parse-body.ts
+++ b/packages/graphql-server/deno_dist/parse-body.ts
@@ -1,4 +1,6 @@
-export async function parseBody(req: Request): Promise<Record<string, unknown>> {
+import { HonoRequest } from "https://deno.land/x/hono@v3.0.0/request.ts";
+
+export async function parseBody(req: HonoRequest): Promise<Record<string, unknown>> {
   const contentType = req.headers.get('content-type')
 
   switch (contentType) {
@@ -20,7 +22,7 @@ export async function parseBody(req: Request): Promise<Record<string, unknown>> 
   return {}
 }
 
-const parseFormURL = async (req: Request) => {
+const parseFormURL = async (req: HonoRequest) => {
   const text = await req.text()
   const searchParams = new URLSearchParams(text)
   const res: { [params: string]: string } = {}

--- a/packages/graphql-server/deno_dist/parse-body.ts
+++ b/packages/graphql-server/deno_dist/parse-body.ts
@@ -1,6 +1,4 @@
-import { HonoRequest } from "https://deno.land/x/hono@v3.0.0/request.ts";
-
-export async function parseBody(req: HonoRequest): Promise<Record<string, unknown>> {
+export async function parseBody(req: Request): Promise<Record<string, unknown>> {
   const contentType = req.headers.get('content-type')
 
   switch (contentType) {
@@ -22,7 +20,7 @@ export async function parseBody(req: HonoRequest): Promise<Record<string, unknow
   return {}
 }
 
-const parseFormURL = async (req: HonoRequest) => {
+const parseFormURL = async (req: Request) => {
   const text = await req.text()
   const searchParams = new URLSearchParams(text)
   const res: { [params: string]: string } = {}

--- a/packages/graphql-server/deno_test/hono.test.ts
+++ b/packages/graphql-server/deno_test/hono.test.ts
@@ -1,4 +1,4 @@
-import { buildSchema } from 'https://esm.sh/graphql@16.6.0'
+import { buildSchema } from 'https://cdn.skypack.dev/graphql@16.6.0?dts'
 import { assertEquals } from 'https://deno.land/std@0.177.0/testing/asserts.ts'
 import { Hono } from 'https://deno.land/x/hono@v3.0.0/mod.ts'
 import { graphqlServer } from '../deno_dist/index.ts'

--- a/packages/graphql-server/deno_test/hono.test.ts
+++ b/packages/graphql-server/deno_test/hono.test.ts
@@ -1,6 +1,6 @@
-import { buildSchema } from 'https://cdn.skypack.dev/graphql@16.6.0?dts'
-import { assertEquals } from 'https://deno.land/std@0.149.0/testing/asserts.ts'
-import { Hono } from 'https://deno.land/x/hono@v2.7.5/mod.ts'
+import { buildSchema } from 'https://esm.sh/graphql@16.6.0'
+import { assertEquals } from 'https://deno.land/std@0.177.0/testing/asserts.ts'
+import { Hono } from 'https://deno.land/x/hono@v3.0.0/mod.ts'
 import { graphqlServer } from '../deno_dist/index.ts'
 
 Deno.test('graphql-server', async (t) => {

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono/graphql-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": "git@github.com:honojs/middleware.git",
   "author": "Minghe Huang <h.minghe@gmail.com>",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
     "release": "np"
   },
   "peerDependencies": {
-    "hono": "^2.6.1"
+    "hono": "^3.0.0"
   },
   "dependencies": {
     "graphql": "^16.5.0"
@@ -46,7 +46,7 @@
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
-    "hono": "^2.6.1",
+    "hono": "^3.0.0",
     "jest": "^28.1.2",
     "jest-environment-miniflare": "^2.6.0",
     "np": "^7.6.2",

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -46,7 +46,7 @@ export const graphqlServer = (options: Options) => {
 
     let params: GraphQLParams
     try {
-      params = await getGraphQLParams(c.req)
+      params = await getGraphQLParams(c.req.raw)
     } catch (e) {
       if (e instanceof Error) {
         console.error(`${e.stack || e.message}`)


### PR DESCRIPTION
This PR updates the GraphQL middleware to [Hono v3.0.0](https://github.com/honojs/hono/releases/tag/v3.0.0).

Overview of the changes:
- Update Hono dependencies from v2.7.5 to v.3.0.0
- ~`Requests` is now `HonoRequest` [src](https://github.com/honojs/hono/blob/main/docs/MIGRATION.md#creq-is-now-honorequest)~
- ~Update `graphql@16.6.0` import from `cdn.skypack.dev` to `esm.sh` due to Deno incompatibility~

EDIT:

- For this PR I think a version bump is needed 
