### PR TITLE
feat(firebase-auth): support Hono v3

### DIFF
--- a/.changeset/thirty-snails-develop.md
+++ b/.changeset/thirty-snails-develop.md
@@ -1,0 +1,5 @@
+---
+'@hono/firebase-auth': minor
+---
+
+feat: support Hono v3

--- a/packages/firebase-auth/package.json
+++ b/packages/firebase-auth/package.json
@@ -31,13 +31,13 @@
     "firebase-auth-cloudflare-workers": "^1.0.0"
   },
   "peerDependencies": {
-    "hono": "^2.7.2"
+    "hono": "3.*"
   },
   "devDependencies": {
-    "hono": "^2.7.2",
     "@cloudflare/workers-types": "^3.14.1",
     "@types/jest": "^28.1.4",
     "firebase-tools": "^11.4.0",
+    "hono": "^3.0.3",
     "jest": "^28.1.2",
     "jest-environment-miniflare": "^2.6.0",
     "prettier": "^2.7.1",

--- a/packages/firebase-auth/src/index.ts
+++ b/packages/firebase-auth/src/index.ts
@@ -1,10 +1,11 @@
-import type { EmulatorEnv, KeyStorer, FirebaseIdToken } from 'firebase-auth-cloudflare-workers'
+import type { KeyStorer, FirebaseIdToken } from 'firebase-auth-cloudflare-workers'
 import { Auth, WorkersKVStoreSingle } from 'firebase-auth-cloudflare-workers'
 import type { Context, MiddlewareHandler } from 'hono'
 
-export interface VerifyFirebaseAuthEnv extends EmulatorEnv {
+export type VerifyFirebaseAuthEnv = {
   PUBLIC_JWK_CACHE_KEY?: string | undefined
   PUBLIC_JWK_CACHE_KV?: KVNamespace | undefined
+  FIREBASE_AUTH_EMULATOR_HOST: string | undefined
 }
 
 export interface VerifyFirebaseAuthConfig {
@@ -22,12 +23,6 @@ const defaultKeyStoreInitializer = (c: Context): KeyStorer => {
     c.env.PUBLIC_JWK_CACHE_KEY ?? defaultKVStoreJWKCacheKey,
     c.env.PUBLIC_JWK_CACHE_KV
   )
-}
-
-type Env = {
-  Bindings: {
-    FIREBASE_AUTH_EMULATOR_HOST: string
-  }
 }
 
 export const verifyFirebaseAuth = (userConfig: VerifyFirebaseAuthConfig): MiddlewareHandler => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5232,6 +5232,11 @@ hono@^3.0.2:
   resolved "https://registry.yarnpkg.com/hono/-/hono-3.0.2.tgz#807a1b0514c6563917d8c278e6da7101bdac1d19"
   integrity sha512-jhb0eCiUTOzbOXZyXQCOk1gf3MKjV4ZXY3PRT6lzma0XPsnnHuDOHYF7RCMHYe7jhl4Y0IAzrmWXneXhOMHypA==
 
+hono@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-3.0.3.tgz#26b62bece753941dd3d290d03ff3338f71535017"
+  integrity sha512-6Lb/TPH7Me1GAjFR7k/duzTcHS5y+rxFyL6Ky0kYQQlu92l99t53CFMVcdNUpHeStarPOs4Uzl413zIvxaI15A==
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"


### PR DESCRIPTION
This PR enables Firebase Auth Middleware support Hono v3.

This may fix #59