### PR TITLE
Sentry middleware: fix undefined DSN environment variable error

### DIFF
--- a/.changeset/kind-parents-play.md
+++ b/.changeset/kind-parents-play.md
@@ -1,0 +1,5 @@
+---
+'@hono/sentry': patch
+---
+
+Use optional chaining for determining Sentry DSN from environment (#89)

--- a/packages/sentry/deno_dist/index.ts
+++ b/packages/sentry/deno_dist/index.ts
@@ -41,7 +41,7 @@ export const sentry = (
       hasExecutionContext = false
     }
     const sentry = new Toucan({
-      dsn: c.env.SENTRY_DSN ?? c.env.NEXT_PUBLIC_SENTRY_DSN,
+      dsn: c.env?.SENTRY_DSN ?? c.env?.NEXT_PUBLIC_SENTRY_DSN,
       allowedHeaders: ['user-agent'],
       allowedSearchParams: /(.*)/,
       request: c.req.raw,

--- a/packages/sentry/deno_test/deps.ts
+++ b/packages/sentry/deno_test/deps.ts
@@ -1,2 +1,2 @@
 export { assert, assertEquals } from 'https://deno.land/std@0.148.0/testing/asserts.ts'
-export { Hono } from 'https://deno.land/x/hono@v2.6.1/mod.ts'
+export { Hono } from 'https://deno.land/x/hono@v3.2.3/mod.ts'

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "hono": "^3.0.2"
+    "hono": "^3.2.3"
   },
   "dependencies": {
     "toucan-js": "^2.6.1"

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -41,7 +41,7 @@ export const sentry = (
       hasExecutionContext = false
     }
     const sentry = new Toucan({
-      dsn: c.env.SENTRY_DSN ?? c.env.NEXT_PUBLIC_SENTRY_DSN,
+      dsn: c.env?.SENTRY_DSN ?? c.env?.NEXT_PUBLIC_SENTRY_DSN,
       allowedHeaders: ['user-agent'],
       allowedSearchParams: /(.*)/,
       request: c.req.raw,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5376,6 +5376,11 @@ hono@3.1.5:
   resolved "https://registry.yarnpkg.com/hono/-/hono-3.1.5.tgz#a1c5314bb1cf0fd8b72bd2b6b6698eee16fbc520"
   integrity sha512-ypFLhNYoXXtep4I9zJt3VpB5/Ze3p9BLU4dpnAp7fxHOmSg8lu/Wwjs5sTJnb2GwVdfjbt9KFB9alA4Zt/P0jw==
 
+hono@^2.7.2:
+  version "2.7.8"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-2.7.8.tgz#5f6916c7f6838fe1f909f6046b30e6a0900f3128"
+  integrity sha512-LXLXw6LilE16QO0siFBDiNzmaRP6ca5ZyF0gDWcaiUqJJtE/d4lV/Hpst2O33AmJB5n0DQa5w53gZLUVf7uXNg==
+
 hono@^3.0.0, hono@^3.0.2, hono@^3.0.3, hono@^3.1.0, hono@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/hono/-/hono-3.1.2.tgz#896231b8940c201212bb3d440bebce637e68be26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5376,11 +5376,6 @@ hono@3.1.5:
   resolved "https://registry.yarnpkg.com/hono/-/hono-3.1.5.tgz#a1c5314bb1cf0fd8b72bd2b6b6698eee16fbc520"
   integrity sha512-ypFLhNYoXXtep4I9zJt3VpB5/Ze3p9BLU4dpnAp7fxHOmSg8lu/Wwjs5sTJnb2GwVdfjbt9KFB9alA4Zt/P0jw==
 
-hono@^2.7.2:
-  version "2.7.8"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-2.7.8.tgz#5f6916c7f6838fe1f909f6046b30e6a0900f3128"
-  integrity sha512-LXLXw6LilE16QO0siFBDiNzmaRP6ca5ZyF0gDWcaiUqJJtE/d4lV/Hpst2O33AmJB5n0DQa5w53gZLUVf7uXNg==
-
 hono@^3.0.0, hono@^3.0.2, hono@^3.0.3, hono@^3.1.0, hono@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/hono/-/hono-3.1.2.tgz#896231b8940c201212bb3d440bebce637e68be26"


### PR DESCRIPTION
Sentry middleware currently expects that `SENTRY_DSN` or `NEXT_PUBLIC_SENTRY_DSN` are available in the request context. This causes the middleware to throw an undefined property error when given variables are not set.

This PR also bumps the Hono version due to changes in `MiddlewareHandler` type definition.