### PR TITLE
Replaces TypeCompiler with Value

### DIFF
--- a/.changeset/clean-worms-thank.md
+++ b/.changeset/clean-worms-thank.md
@@ -1,0 +1,5 @@
+---
+'@hono/typebox-validator': minor
+---
+
+Fixed EvalError


### PR DESCRIPTION
Cloudflare worker throws an EvalError when using TypeCompiler.Compile(schema).Check(data)

`Uncaught Error: EvalError: Code generation from strings disallowed for this context at index.js:5110:45 in Compile
`

https://github.com/sinclairzx81/typebox/issues/253