### PR TITLE
refactor(valibot-validator): update to latest valibot version

### DIFF
--- a/.changeset/fuzzy-spoons-crash.md
+++ b/.changeset/fuzzy-spoons-crash.md
@@ -1,0 +1,5 @@
+---
+'@hono/valibot-validator': minor
+---
+
+update valibot version

--- a/packages/valibot-validator/package.json
+++ b/packages/valibot-validator/package.json
@@ -29,10 +29,10 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": "3.*",
-    "valibot": "^0.12.0"
+    "valibot": "^0.13.1"
   },
   "devDependencies": {
     "hono": "^3.1.0",
-    "valibot": "^0.12.0"
+    "valibot": "^0.13.1"
   }
 }

--- a/packages/valibot-validator/src/index.ts
+++ b/packages/valibot-validator/src/index.ts
@@ -1,10 +1,10 @@
 import type { Context, MiddlewareHandler, Env, ValidationTargets } from 'hono'
 import { validator } from 'hono/validator'
-import type { BaseSchema, Input, Output, ValiError } from 'valibot'
+import type { BaseSchema, Input, Output, SafeParseResult } from 'valibot'
 import { safeParse } from 'valibot'
 
-type Hook<T, E extends Env, P extends string> = (
-  result: { success: true; data: T } | { success: false; error: ValiError },
+type Hook<T extends BaseSchema, E extends Env, P extends string> = (
+  result: SafeParseResult<T>,
   c: Context<E, P>
 ) => Response | Promise<Response> | void | Promise<Response | void>
 
@@ -23,7 +23,7 @@ export const vValidator = <
 >(
   target: Target,
   schema: T,
-  hook?: Hook<Output<T>, E, P>
+  hook?: Hook<T, E, P>
 ): MiddlewareHandler<E, P, V> =>
   validator(target, (value, c) => {
     const result = safeParse(schema, value)
@@ -39,6 +39,6 @@ export const vValidator = <
       return c.json(result, 400)
     }
 
-    const data = result.data as Output<T>
+    const data = result.output as Output<T>
     return data
   })

--- a/packages/valibot-validator/test/index.test.ts
+++ b/packages/valibot-validator/test/index.test.ts
@@ -90,7 +90,7 @@ describe('With Hook', () => {
       if (!result.success) {
         return c.text('Invalid!', 400)
       }
-      const data = result.data
+      const data = result.output
       return c.text(`${data.id} is valid!`)
     }),
     (c) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11929,10 +11929,10 @@ vali-date@^1.0.0:
   resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"
   integrity sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==
 
-valibot@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/valibot/-/valibot-0.12.0.tgz#3206191f4af551768bfddf041f40ad3b3d3037df"
-  integrity sha512-EGx/uDUpRa9wB9NkD7fsktc02rvXWlJzDTC/ihbE+NybhzAsMhns2OOdNv2R4BtdGnDvaCEGi/DbgR5RvgCS8A==
+valibot@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/valibot/-/valibot-0.13.1.tgz#34196211c5b4293829a9e4e6b0cf29a9227f410b"
+  integrity sha512-SG2W1RHqE2LShl3p6tyERt6I+G6PQa9ZFVfkyNKXz01HBzL+tBeH5kXw/5AQeAzPJSjI3djVGBl1CyozA1kyBQ==
 
 valid-url@^1:
   version "1.0.9"


### PR DESCRIPTION
closes #110 

Uses the exported `safeParse` result type.