### PR TITLE
Zod-Openapi-Middleware: Export types to allow handlers and hooks to be declared in more places.

### DIFF
--- a/.changeset/rare-pillows-change.md
+++ b/.changeset/rare-pillows-change.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+Export types that allow for separate declaratins of route handlers and hooks

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -153,6 +153,30 @@ type HandlerResponse<O> = TypedResponse<O> | Promise<TypedResponse<O>>
 
 type HonoInit = ConstructorParameters<typeof Hono>[0]
 
+export type RouteHandler<
+  R extends RouteConfig,
+  E extends Env = Env,
+  I extends Input = InputTypeParam<R> &
+    InputTypeQuery<R> &
+    InputTypeHeader<R> &
+    InputTypeCookie<R> &
+    InputTypeForm<R> &
+    InputTypeJson<R>,
+  P extends string = ConvertPathType<R['path']>
+> = Handler<E, P, I, HandlerResponse<OutputType<R>>>
+
+export type RouteHook<
+  R extends RouteConfig,
+  E extends Env = Env,
+  I extends Input = InputTypeParam<R> &
+    InputTypeQuery<R> &
+    InputTypeHeader<R> &
+    InputTypeCookie<R> &
+    InputTypeForm<R> &
+    InputTypeJson<R>,
+  P extends string = ConvertPathType<R['path']>
+> = Hook<I, E, P, OutputType<R>>
+
 export class OpenAPIHono<
   E extends Env = Env,
   S extends Schema = {},
@@ -176,8 +200,8 @@ export class OpenAPIHono<
     P extends string = ConvertPathType<R['path']>
   >(
     route: R,
-    handler: Handler<E, P, I, HandlerResponse<OutputType<R>>>,
-    hook?: Hook<I, E, P, OutputType<R>>
+    handler: RouteHandler<R, E, I, P>,
+    hook?: RouteHook<R, E, I, P>
   ): OpenAPIHono<E, ToSchema<R['method'], P, I['in'], OutputType<R>>, BasePath> => {
     this.openAPIRegistry.registerPath(route)
 


### PR DESCRIPTION
Exported intermediate types representing the handler and the hook for a route so that handlers can be declared outside of the register method.

Like such

```ts
const route = createRoute({
  method: 'get',
  path: '/users/{id}',
  request: {
    params: ParamsSchema,
  },
  responses: {
    200: {
      content: {
        'application/json': {
          schema: UserSchema,
        },
      },
      description: 'Retrieve the user',
    },
  },
})

const handler: RouteHandler<typeof route> = (c) => {
 const { id } = c.req.valid('param')
  return c.jsonT({
    id,
    age: 20,
    name: 'Ultra-man',
  })
}

app.openapi(route, handler)

```