### PR TITLE
feat(zod-openapi): add support for defaultHook in initializer

### DIFF
--- a/.changeset/witty-dolls-raise.md
+++ b/.changeset/witty-dolls-raise.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+Add defaultHook as an option for OpenAPIHono

--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -174,6 +174,57 @@ app.openapi(
 )
 ```
 
+### A DRY approach to handling validation errors
+
+In the case that you have a common error formatter, you can initialize the `OpenAPIHono` instance with a `defaultHook`.
+
+```ts
+const app = new OpenAPIHono({
+  defaultHook: (result, c) => {
+    if (!result.success) {
+      return c.jsonT(
+        {
+          ok: false,
+          errors: formatZodErrors(result),
+          source: 'custom_error_handler',
+        },
+        422
+      )
+    }
+  },
+})
+```
+
+You can still override the `defaultHook` by providing the hook at the call site when appropriate.
+
+```ts
+// uses the defaultHook
+app.openapi(createPostRoute, (c) => {
+  const { title } = c.req.valid('json')
+  return c.jsonT({ title })
+})
+
+// override the defaultHook by passing in a hook
+app.openapi(
+  createBookRoute,
+  (c) => {
+    const { title } = c.req.valid('json')
+    return c.jsonT({ title })
+  },
+  (result, c) => {
+    if (!result.success) {
+      return c.jsonT(
+        {
+          ok: false,
+          source: 'routeHook' as const,
+        },
+        400
+      )
+    }
+  }
+)
+```
+
 ### OpenAPI v3.1
 
 You can generate OpenAPI v3.1 spec using the following methods:
@@ -211,7 +262,7 @@ You can configure middleware for each endpoint from a route created by `createRo
 import { prettyJSON } from 'hono/pretty-json'
 import { cache } from 'honoc/cache'
 
-app.use(route.getRoutingPath(), prettyJSON(), cache({ cacheName: "my-cache" }))
+app.use(route.getRoutingPath(), prettyJSON(), cache({ cacheName: 'my-cache' }))
 app.openapi(route, handler)
 ```
 

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -151,7 +151,10 @@ type ConvertPathType<T extends string> = T extends `${infer _}/{${infer Param}}$
 
 type HandlerResponse<O> = TypedResponse<O> | Promise<TypedResponse<O>>
 
-type HonoInit = ConstructorParameters<typeof Hono>[0]
+export type OpenAPIHonoOptions<E extends Env> = {
+  defaultHook?: Hook<any, E, any, any>
+}
+type HonoInit<E extends Env> = ConstructorParameters<typeof Hono>[0] & OpenAPIHonoOptions<E>
 
 export type RouteHandler<
   R extends RouteConfig,
@@ -183,10 +186,12 @@ export class OpenAPIHono<
   BasePath extends string = '/'
 > extends Hono<E, S, BasePath> {
   openAPIRegistry: OpenAPIRegistry
+  defaultHook?: OpenAPIHonoOptions<E>['defaultHook']
 
-  constructor(init?: HonoInit) {
+  constructor(init?: HonoInit<E>) {
     super(init)
     this.openAPIRegistry = new OpenAPIRegistry()
+    this.defaultHook = init?.defaultHook
   }
 
   openapi = <
@@ -201,7 +206,7 @@ export class OpenAPIHono<
   >(
     route: R,
     handler: Handler<E, P, I, HandlerResponse<OutputType<R>>>,
-    hook?: Hook<I, E, P, OutputType<R>>
+    hook: Hook<I, E, P, OutputType<R>> | undefined = this.defaultHook
   ): OpenAPIHono<E, S & ToSchema<R['method'], P, I['in'], OutputType<R>>, BasePath> => {
     this.openAPIRegistry.registerPath(route)
 


### PR DESCRIPTION
Adds support for a `defaultHook` to avoid needing to pass the same error reformatter to every route.

If we're okay with this approach, I can add docs to the README.

Another option would be to export the types for `.openapi` and allow someone to create an `applyDefaultHook` similar to what I've shown here: https://tsplay.dev/NnMyaw