### PR TITLE
feat: Swagger UI middleware

### DIFF
--- a/.changeset/strange-spoons-nail.md
+++ b/.changeset/strange-spoons-nail.md
@@ -1,0 +1,5 @@
+---
+'@hono/swagger-ui': patch
+---
+
+introduce Swagger UI

--- a/packages/swagger-ui/package.json
+++ b/packages/swagger-ui/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@hono/swagger-ui",
+  "version": "0.0.0",
+  "description": "A middleware for Hono that serves the Swagger UI",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "build": "tsup ./src/index.ts --format esm,cjs --dts",
+    "publint": "publint",
+    "release": "yarn build && yarn test && yarn publint && yarn publish"
+  },
+  "license": "MIT",
+  "private": false,
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/honojs/middleware.git"
+  },
+  "homepage": "https://github.com/honojs/middleware",
+  "peerDependencies": {
+    "hono": "*"
+  },
+  "devDependencies": {
+    "hono": "^3.7.1"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/packages/swagger-ui/src/index.ts
+++ b/packages/swagger-ui/src/index.ts
@@ -1,0 +1,59 @@
+import type { MiddlewareHandler } from 'hono'
+
+export interface SwaggerUIOptions {
+  /**
+   * The path to get openapi doc from.
+   * @default '/openapi.json'
+   * @example
+   * ```ts
+   * app.use('/docs', swaggerUI({ docPath: '/api/openapi.json' }))
+   * ```
+   */
+  docPath?: string
+  /**
+   * The version of Swagger UI. See https://www.npmjs.com/package/swagger-ui-dist.
+   * @default 'latest'
+   */
+  version?: string
+}
+
+/**
+ * Returns a middleware that serves Swagger UI.
+ * Using `swagger-ui-dist` from CDN by default.
+ * @param options The options.
+ * @example
+ * ```ts
+ * app.use('/docs', swaggerUI())
+ * ```
+ */
+export function swaggerUI(options: SwaggerUIOptions = {}): MiddlewareHandler {
+  const { docPath = '/openapi.json', version = 'latest' } = options
+
+  return async (c) =>
+    c.html(`
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@${version}/swagger-ui-bundle.min.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@${version}/swagger-ui.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script>
+      window.onload = function() {
+        SwaggerUIBundle({
+          url: '${docPath}',
+          dom_id: '#swagger-ui',
+          presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIBundle.SwaggerUIStandalonePreset
+          ],
+        })
+      }
+    </script>
+  </body>
+</html>
+`)
+}

--- a/packages/swagger-ui/test/index.test.ts
+++ b/packages/swagger-ui/test/index.test.ts
@@ -1,0 +1,17 @@
+/* eslint-disable node/no-extraneous-import */
+import { Hono } from 'hono'
+import { describe, it, expect } from 'vitest'
+import { swaggerUI } from '../src'
+
+describe('Swagger UI', () => {
+  it('Should work with default options', async () => {
+    const app = new Hono()
+    app.use('/docs', swaggerUI())
+    const res = await app.request('http://localhost/docs', {
+      method: 'GET',
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).includes('text/html')
+    expect(await res.text()).includes('<title>Swagger UI</title>')
+  })
+})

--- a/packages/swagger-ui/tsconfig.json
+++ b/packages/swagger-ui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false,
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5869,6 +5869,11 @@ hono@^3.6.3:
   resolved "https://registry.yarnpkg.com/hono/-/hono-3.6.3.tgz#0dab94a9e49dadc0f99bf8b8ffc70b223f53ab9f"
   integrity sha512-8WszeHGzUm45qJy2JcCXkEFXMsAysciGGQs+fbpdUYPO2bRMbjJznZE3LX8tCXBqR4f/3e6225B3YOX6pQZWvA==
 
+hono@^3.7.1:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-3.7.2.tgz#c3839d7ffbb5120850b2b926363d065020f4d18c"
+  integrity sha512-5SWYrAQJlfjHggcDTnmKZd5zlUEXmoUiBjnmL6C1W8MX39/bUw6ZIvfEJZgpo7d7Z/vCJ5FRfkjIQPRH5yV/dQ==
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"


### PR DESCRIPTION
Hi, @yusukebe.
I've implemented the SwaggerUI middleware you mentioned the other day.

---

This is a suggestion, but for integration with zod-openapi,

adding this to `@hono/zod-openapi`

```diff
export class OpenAPIHono<
  E extends Env = Env,
  S extends Schema = {},
  BasePath extends string = '/'
 > extends Hono<E, S, BasePath> {
  openAPIRegistry: OpenAPIRegistry
+ docPath?: string

  // ...

  doc = (path: string, config: OpenAPIObjectConfig) => {
+   this.docPath = path
    this.get(path, (c) => {
      const document = this.getOpenAPIDocument(config)
      return c.json(document)
    })
  }
```

and adding this to `@hono/swagger-ui`

```ts
export function swaggerUIWithOpenAPIHono<
  E extends Env = Env,
  S extends Schema = {},
  BasePath extends string = '/'
>(path: string, app: OpenAPIHono<E, S, BasePath>, options: Omit<SwaggerUIOptions, 'docPath'> = {}) {
  if (app.docPath === undefined) {
    throw new Error('swaggerUIWithOpenAPIHono requires app.docPath to be set')
  }

  app.use(path, swaggerUI({ docPath: app.docPath, ...options }))
}
```

that so we can use this middleware without `docPath` setting like this.

```ts
app.doc('/custom/path.json', {
  openapi: '3.0.0',
  info: {
    version: '1.0.0',
    title: 'My API',
  },
  tags: [
    {
      name: 'language',
      description: 'en',
    },
  ],
})

swaggerUIWithOpenAPIHono('/docs', app)
```

This may not be a good solution as it would encroach on @zod/hono-openapi. If you have any ideas, please let me know!
What do you think?