### PR TITLE
add: Async zod support.

### DIFF
--- a/.changeset/neat-mangos-compare.md
+++ b/.changeset/neat-mangos-compare.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': patch
+---
+
+add: Async zod support

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -24,8 +24,8 @@ export const zValidator = <
   schema: T,
   hook?: Hook<z.infer<T>, E, P>
 ): MiddlewareHandler<E, P, V> =>
-  validator(target, (value, c) => {
-    const result = schema.safeParse(value)
+  validator(target, async (value, c) => {
+    const result = await schema.safeParseAsync(value)
 
     if (hook) {
       const hookResult = hook({ data: value, ...result }, c)


### PR DESCRIPTION
Useful for weird stuff like this where it's needed to async parse a schema, since the parser does not parse requests such as the one below correctly it's an acceptable way to reach around it and make it work.

```
const formData = new FormData();
formData.append("input[0][id]", "1");
formData.append("input[1][id]", "2");
formData.append("input[2][id]", "3");
```

for context the above should parse as the following, but since we're using Response I understand why it doesn't
```json
{
  "input": [
    { "id": "1" },
    { "id": "2" },
    { "id": "3" }
 ]
}
```

Example of code this PR enables below:
```ts
z.object({
  zones: z.instanceof(File)
    .refine(item => item.type === 'application/json')
    .transform(async item => {
      return JSON.parse(await item.text()) as LayerSchema;
    })
    .refine(items => {
      return z.array(layerSchema).safeParse(items).success;
    })
})
```