### PR TITLE
fix: properly convert openapi path type to hono

### DIFF
--- a/.changeset/slimy-singers-begin.md
+++ b/.changeset/slimy-singers-begin.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+properly convert openapi path type to hono

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -145,8 +145,8 @@ type Hook<T, E extends Env, P extends string, O> = (
   c: Context<E, P>
 ) => TypedResponse<O> | Promise<TypedResponse<T>> | void
 
-type ConvertPathType<T extends string> = T extends `${infer _}/{${infer Param}}${infer _}`
-  ? `/:${Param}`
+type ConvertPathType<T extends string> = T extends `${infer Start}/{${infer Param}}${infer Rest}`
+  ? `${Start}/:${Param}${ConvertPathType<Rest>}`
   : T
 
 type HandlerResponse<O> = TypedResponse<O> | Promise<TypedResponse<O>>


### PR DESCRIPTION
This fixes the conversion from the openapi path type.
It's also recursive to convert all params instead of just one.

E.g.:
`/user/{id}/posts/{postId}/comments/{commentId}` to `/user/:id/posts/:postId/comments/:commentId`