### PR TITLE
feat(zod-openapi): implement Zod schema validation on response

### DIFF
--- a/.changeset/itchy-games-fail.md
+++ b/.changeset/itchy-games-fail.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+add response Zod schema validation on response

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -189,15 +189,15 @@ export class OpenAPIHono<
 > extends Hono<E, S, BasePath> {
   openAPIRegistry: OpenAPIRegistry
   defaultHook?: OpenAPIHonoOptions<E>['defaultHook']
-  strictResponseCode?: OpenAPIHonoOptions<E>['strictStatusCode']
-  strictResponseSchema?: OpenAPIHonoOptions<E>['strictResponse']
+  strictStatusCode?: OpenAPIHonoOptions<E>['strictStatusCode']
+  strictResponse?: OpenAPIHonoOptions<E>['strictResponse']
 
   constructor(init?: HonoInit<E>) {
     super(init)
     this.openAPIRegistry = new OpenAPIRegistry()
     this.defaultHook = init?.defaultHook
-    this.strictResponseCode = init?.strictStatusCode
-    this.strictResponseSchema = init?.strictResponse
+    this.strictStatusCode = init?.strictStatusCode
+    this.strictResponse = init?.strictResponse
   }
 
   openapi = <
@@ -262,7 +262,7 @@ export class OpenAPIHono<
       }
     }
 
-    if (this.strictResponseSchema) {
+    if (this.strictResponse) {
       const responseZodSchemaObject: Record<string, ZodType<any>> = {}
       for (const [statusCode, responseConfig] of Object.entries(route.responses)) {
         for (const mediaTypeObject of Object.values(responseConfig.content ?? {})) {
@@ -292,7 +292,7 @@ export class OpenAPIHono<
       }
     }
 
-    if (this.strictResponseCode) {
+    if (this.strictStatusCode) {
       validators.push(async (c, next) => {
         await next()
 

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -153,7 +153,8 @@ type HandlerResponse<O> = TypedResponse<O> | Promise<TypedResponse<O>>
 
 export type OpenAPIHonoOptions<E extends Env> = {
   defaultHook?: Hook<any, E, any, any>
-  validateResponse?: boolean
+  strictStatusCode?: boolean
+  strictResponse?: boolean
 }
 type HonoInit<E extends Env> = ConstructorParameters<typeof Hono>[0] & OpenAPIHonoOptions<E>
 
@@ -188,13 +189,15 @@ export class OpenAPIHono<
 > extends Hono<E, S, BasePath> {
   openAPIRegistry: OpenAPIRegistry
   defaultHook?: OpenAPIHonoOptions<E>['defaultHook']
-  validateResponse?: OpenAPIHonoOptions<E>['validateResponse']
+  strictResponseCode?: OpenAPIHonoOptions<E>['strictStatusCode']
+  strictResponseSchema?: OpenAPIHonoOptions<E>['strictResponse']
 
   constructor(init?: HonoInit<E>) {
     super(init)
     this.openAPIRegistry = new OpenAPIRegistry()
     this.defaultHook = init?.defaultHook
-    this.validateResponse = init?.validateResponse
+    this.strictResponseCode = init?.strictStatusCode
+    this.strictResponseSchema = init?.strictResponse
   }
 
   openapi = <
@@ -214,38 +217,6 @@ export class OpenAPIHono<
     this.openAPIRegistry.registerPath(route)
 
     const validators: MiddlewareHandler[] = []
-
-    if (this.validateResponse) {
-      const responseZodSchemaObject: Record<string, ZodType<any>> = {}
-
-      const responseEntries = Object.entries(route.responses)
-      for (const [statusCode, response] of responseEntries) {
-        if (response.content) {
-          for (const mediaType of Object.keys(response.content)) {
-            const schema = response.content[mediaType]['schema']
-            if (schema instanceof ZodType) {
-              responseZodSchemaObject[statusCode] = schema
-            }
-          }
-        }
-      }
-
-      validators.push((async (c, next) => {
-        await next()
-
-        const schema = responseZodSchemaObject[c.res.status]
-        if (schema) {
-          const originalBody = await c.res.json()
-          const result = await schema.safeParseAsync(originalBody)
-          if (!result.success) {
-            throw result.error
-          }
-
-          const data = result.data as z.infer<typeof schema>
-          return data
-        }
-      }))
-    }
 
     if (route.request?.query) {
       const validator = zValidator('query', route.request.query as any, hook as any)
@@ -289,6 +260,55 @@ export class OpenAPIHono<
           }
         }
       }
+    }
+
+    if (this.strictResponseSchema) {
+      const responseZodSchemaObject: Record<string, ZodType<any>> = {}
+      for (const [statusCode, responseConfig] of Object.entries(route.responses)) {
+        for (const mediaTypeObject of Object.values(responseConfig.content ?? {})) {
+          if (mediaTypeObject.schema instanceof ZodType) {
+            responseZodSchemaObject[statusCode] = mediaTypeObject.schema
+          }
+        }
+      }
+
+      if (Object.keys(responseZodSchemaObject).length > 0) {
+        validators.push(async (c, next) => {
+          await next()
+
+          const schema = responseZodSchemaObject[c.res.status]
+          if (schema) {
+            const originalBody = await c.res.json()
+            const result = await schema.safeParseAsync(originalBody)
+            if (!result.success) {
+              c.res = c.json(result.error, {
+                status: 500,
+              })
+            } else {
+              c.res = c.json(result.data)
+            }
+          }
+        })
+      }
+    }
+
+    if (this.strictResponseCode) {
+      validators.push(async (c, next) => {
+        await next()
+
+        if (!route.responses[c.res.status]) {
+          c.res = c.json(
+            {
+              success: false,
+              error: 'Response code does not match any of the defined responses.',
+            },
+            {
+              status: 500,
+            }
+          )
+          return
+        }
+      })
     }
 
     this.on([route.method], route.path.replaceAll(/\/{(.+?)}/g, '/:$1'), ...validators, handler)

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -153,6 +153,7 @@ type HandlerResponse<O> = TypedResponse<O> | Promise<TypedResponse<O>>
 
 export type OpenAPIHonoOptions<E extends Env> = {
   defaultHook?: Hook<any, E, any, any>
+  validateResponse?: boolean
 }
 type HonoInit<E extends Env> = ConstructorParameters<typeof Hono>[0] & OpenAPIHonoOptions<E>
 
@@ -187,11 +188,13 @@ export class OpenAPIHono<
 > extends Hono<E, S, BasePath> {
   openAPIRegistry: OpenAPIRegistry
   defaultHook?: OpenAPIHonoOptions<E>['defaultHook']
+  validateResponse?: OpenAPIHonoOptions<E>['validateResponse']
 
   constructor(init?: HonoInit<E>) {
     super(init)
     this.openAPIRegistry = new OpenAPIRegistry()
     this.defaultHook = init?.defaultHook
+    this.validateResponse = init?.validateResponse
   }
 
   openapi = <
@@ -211,6 +214,38 @@ export class OpenAPIHono<
     this.openAPIRegistry.registerPath(route)
 
     const validators: MiddlewareHandler[] = []
+
+    if (this.validateResponse) {
+      const responseZodSchemaObject: Record<string, ZodType<any>> = {}
+
+      const responseEntries = Object.entries(route.responses)
+      for (const [statusCode, response] of responseEntries) {
+        if (response.content) {
+          for (const mediaType of Object.keys(response.content)) {
+            const schema = response.content[mediaType]['schema']
+            if (schema instanceof ZodType) {
+              responseZodSchemaObject[statusCode] = schema
+            }
+          }
+        }
+      }
+
+      validators.push((async (c, next) => {
+        await next()
+
+        const schema = responseZodSchemaObject[c.res.status]
+        if (schema) {
+          const originalBody = await c.res.json()
+          const result = await schema.safeParseAsync(originalBody)
+          if (!result.success) {
+            throw result.error
+          }
+
+          const data = result.data as z.infer<typeof schema>
+          return data
+        }
+      }))
+    }
 
     if (route.request?.query) {
       const validator = zValidator('query', route.request.query as any, hook as any)

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -1051,12 +1051,12 @@ describe('Validate response schema', () => {
     },
   })
 
-  const appWithStrictSchema = new OpenAPIHono({
+  const appWithStrictResponse = new OpenAPIHono({
     strictStatusCode: true,
     strictResponse: true,
   })
 
-  appWithStrictSchema.openapi(routeWithMultipleStatusCode, async (c) => {
+  appWithStrictResponse.openapi(routeWithMultipleStatusCode, async (c) => {
     const { returnCode } = c.req.valid('query')
     if (returnCode === '500') {
       c.status(500)
@@ -1079,7 +1079,7 @@ describe('Validate response schema', () => {
   })
 
   it('Should validate response based on status code (200)', async () => {
-    const res = await appWithStrictSchema.request('/multiple-status-code')
+    const res = await appWithStrictResponse.request('/multiple-status-code')
     const body = await res.json()
     expect(res.status).toBe(200)
     expect(body).toStrictEqual({
@@ -1089,14 +1089,14 @@ describe('Validate response schema', () => {
   })
 
   it('Should validate response based on status code (404)', async () => {
-    const res = await appWithStrictSchema.request('/multiple-status-code?returnCode=404')
+    const res = await appWithStrictResponse.request('/multiple-status-code?returnCode=404')
     const body = await res.json()
     expect(res.status).toBe(404)
     expect(body).toHaveProperty('not', 'found')
   })
 
   it('Should validate response based on status code (500)', async () => {
-    const res = await appWithStrictSchema.request('/multiple-status-code?returnCode=500')
+    const res = await appWithStrictResponse.request('/multiple-status-code?returnCode=500')
     const body = await res.json()
     expect(res.status).toBe(500)
     expect(body).toStrictEqual({
@@ -1104,7 +1104,7 @@ describe('Validate response schema', () => {
     })
   })
 
-  const routeWithBase = createRoute({
+  const routeWithPlainZodObject = createRoute({
     method: 'get',
     path: '/strip',
     responses: {
@@ -1121,7 +1121,7 @@ describe('Validate response schema', () => {
       },
     },
   })
-  appWithStrictSchema.openapi(routeWithBase, async (c) => {
+  appWithStrictResponse.openapi(routeWithPlainZodObject, async (c) => {
     return c.jsonT({
       name: 'John Doe',
       age: 20,
@@ -1130,7 +1130,7 @@ describe('Validate response schema', () => {
   })
 
   it('Should strip response from extra property keys when using plain Zod object schema', async () => {
-    const res = await appWithStrictSchema.request('/strip')
+    const res = await appWithStrictResponse.request('/strip')
     const body = await res.json()
     expect(res.status).toBe(200)
     expect(body).toStrictEqual({
@@ -1139,7 +1139,7 @@ describe('Validate response schema', () => {
     })
   })
 
-  const routeWithStrict = createRoute({
+  const routeWithStrictZodObject = createRoute({
     method: 'get',
     path: '/strict',
     responses: {
@@ -1158,7 +1158,7 @@ describe('Validate response schema', () => {
       },
     },
   })
-  appWithStrictSchema.openapi(routeWithStrict, async (c) => {
+  appWithStrictResponse.openapi(routeWithStrictZodObject, async (c) => {
     return c.jsonT({
       name: 'John Doe',
       age: 20,
@@ -1167,13 +1167,13 @@ describe('Validate response schema', () => {
   })
 
   it('Should throw error because of extra property keys when using Zod object schema with .strict()', async () => {
-    const res = await appWithStrictSchema.request('/strict')
+    const res = await appWithStrictResponse.request('/strict')
     const body = await res.json()
     expect(res.status).toBe(500)
     expect(body).toHaveProperty('name', 'ZodError')
   })
 
-  const routeWithPassthrough = createRoute({
+  const routeWithPassthroughZodObject = createRoute({
     method: 'get',
     path: '/passthrough',
     responses: {
@@ -1192,7 +1192,7 @@ describe('Validate response schema', () => {
       },
     },
   })
-  appWithStrictSchema.openapi(routeWithPassthrough, async (c) => {
+  appWithStrictResponse.openapi(routeWithPassthroughZodObject, async (c) => {
     return c.jsonT({
       name: 'John Doe',
       age: 20,
@@ -1201,7 +1201,7 @@ describe('Validate response schema', () => {
   })
 
   it('Should return extra property keys when using Zod object schema with .passthrough()', async () => {
-    const res = await appWithStrictSchema.request('/passthrough')
+    const res = await appWithStrictResponse.request('/passthrough')
     const body = await res.json()
     expect(res.status).toBe(200)
     expect(body).toHaveProperty('extra', 'property')
@@ -1243,7 +1243,7 @@ describe('Validate response schema', () => {
       },
     },
   })
-  appWithStrictSchema.openapi(routeWithVariousZodTypes, async (c) => {
+  appWithStrictResponse.openapi(routeWithVariousZodTypes, async (c) => {
     const { type } = c.req.valid('query')
     if (type === 'string') {
       c.status(200)
@@ -1258,21 +1258,21 @@ describe('Validate response schema', () => {
   })
 
   it('Should be able to parse and return string', async () => {
-    const res = await appWithStrictSchema.request('/zod-types?type=string')
+    const res = await appWithStrictResponse.request('/zod-types?type=string')
     const body = await res.json()
     expect(res.status).toBe(200)
     expect(body).toBe('string')
   })
 
   it('Should be able to parse and return number', async () => {
-    const res = await appWithStrictSchema.request('/zod-types?type=number')
+    const res = await appWithStrictResponse.request('/zod-types?type=number')
     const body = await res.json()
     expect(res.status).toBe(201)
     expect(body).toBe(123)
   })
 
   it('Should be able to parse and return boolean', async () => {
-    const res = await appWithStrictSchema.request('/zod-types?type=boolean')
+    const res = await appWithStrictResponse.request('/zod-types?type=boolean')
     const body = await res.json()
     expect(res.status).toBe(202)
     expect(body).toBe(true)

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -942,3 +942,339 @@ describe('With hc', () => {
     })
   })
 })
+
+describe('Validate response status code', () => {
+  const routeWithA200StatusCode = createRoute({
+    method: 'get',
+    path: '/validate-status-code',
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              name: z.string().min(3).max(10).openapi({}),
+              age: z.number().min(18),
+            }),
+          },
+        },
+        description: 'Response with 200 status code',
+      },
+    },
+  })
+
+  const appWithStrictStatusCode = new OpenAPIHono({
+    strictStatusCode: true,
+  })
+
+  appWithStrictStatusCode.openapi(routeWithA200StatusCode, async (c) => {
+    c.status(200)
+    return c.jsonT({
+      name: 'John Doe',
+      age: 20,
+    })
+  })
+
+  it('Should return response as the status code is defined on the schema (200)', async () => {
+    const res = await appWithStrictStatusCode.request('/validate-status-code')
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toStrictEqual({
+      name: 'John Doe',
+      age: 20,
+    })
+  })
+
+  const appWithStrictStatusCodeUnmatched = new OpenAPIHono({
+    strictStatusCode: true,
+  })
+
+  appWithStrictStatusCodeUnmatched.openapi(routeWithA200StatusCode, async (c) => {
+    c.status(404)
+    return c.jsonT({
+      name: 'John Doe',
+      age: 20,
+    })
+  })
+
+  it('Should throw an error when status code is not defined on the schema (404)', async () => {
+    const res = await appWithStrictStatusCodeUnmatched.request('/validate-status-code')
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body).toStrictEqual({
+      error: 'Response code does not match any of the defined responses.',
+      success: false,
+    })
+  })
+})
+
+describe('Validate response schema', () => {
+  const routeWithMultipleStatusCode = createRoute({
+    method: 'get',
+    path: '/multiple-status-code',
+    request: {
+      query: z.object({
+        returnCode: z.string().optional(),
+      }),
+    },
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              name: z.string().min(3).max(10).openapi({}),
+              age: z.number().min(18),
+            }),
+          },
+        },
+        description: 'Get user',
+      },
+      404: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              not: z.literal('found')
+            }),
+          },
+        },
+        description: 'Get error',
+      },
+      500: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string(),
+            }),
+          },
+        },
+        description: 'Get error',
+      },
+    },
+  })
+
+  const appWithStrictSchema = new OpenAPIHono({
+    strictStatusCode: true,
+    strictResponse: true,
+  })
+
+  appWithStrictSchema.openapi(routeWithMultipleStatusCode, async (c) => {
+    const { returnCode } = c.req.valid('query')
+    if (returnCode === '500') {
+      c.status(500)
+      return c.jsonT({
+        error: returnCode,
+      })
+    }
+
+    if (returnCode === '404') {
+      c.status(404)
+      return c.jsonT({
+        not: 'found' as const,
+      })
+    }
+
+    return c.jsonT({
+      name: 'John Doe',
+      age: 20,
+    })
+  })
+
+  it('Should validate response based on status code (200)', async () => {
+    const res = await appWithStrictSchema.request('/multiple-status-code')
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toStrictEqual({
+      name: 'John Doe',
+      age: 20,
+    })
+  })
+
+  it('Should validate response based on status code (404)', async () => {
+    const res = await appWithStrictSchema.request('/multiple-status-code?returnCode=404')
+    const body = await res.json()
+    expect(res.status).toBe(404)
+    expect(body).toHaveProperty('not', 'found')
+  })
+
+  it('Should validate response based on status code (500)', async () => {
+    const res = await appWithStrictSchema.request('/multiple-status-code?returnCode=500')
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body).toStrictEqual({
+      error: '500',
+    })
+  })
+
+  const routeWithBase = createRoute({
+    method: 'get',
+    path: '/strip',
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              name: z.string().min(3).max(10).openapi({}),
+              age: z.number().min(18),
+            }),
+          },
+        },
+        description: 'Get user',
+      },
+    },
+  })
+  appWithStrictSchema.openapi(routeWithBase, async (c) => {
+    return c.jsonT({
+      name: 'John Doe',
+      age: 20,
+      extra: 'property',
+    })
+  })
+
+  it('Should strip response from extra property keys when using plain Zod object schema', async () => {
+    const res = await appWithStrictSchema.request('/strip')
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toStrictEqual({
+      name: 'John Doe',
+      age: 20,
+    })
+  })
+
+  const routeWithStrict = createRoute({
+    method: 'get',
+    path: '/strict',
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z
+              .object({
+                name: z.string().min(3).max(10).openapi({}),
+                age: z.number().min(18),
+              })
+              .strict(),
+          },
+        },
+        description: 'Get user',
+      },
+    },
+  })
+  appWithStrictSchema.openapi(routeWithStrict, async (c) => {
+    return c.jsonT({
+      name: 'John Doe',
+      age: 20,
+      extra: 'property',
+    })
+  })
+
+  it('Should throw error because of extra property keys when using Zod object schema with .strict()', async () => {
+    const res = await appWithStrictSchema.request('/strict')
+    const body = await res.json()
+    expect(res.status).toBe(500)
+    expect(body).toHaveProperty('name', 'ZodError')
+  })
+
+  const routeWithPassthrough = createRoute({
+    method: 'get',
+    path: '/passthrough',
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z
+              .object({
+                name: z.string().min(3).max(10).openapi({}),
+                age: z.number().min(18),
+              })
+              .passthrough(),
+          },
+        },
+        description: 'Get user',
+      },
+    },
+  })
+  appWithStrictSchema.openapi(routeWithPassthrough, async (c) => {
+    return c.jsonT({
+      name: 'John Doe',
+      age: 20,
+      extra: 'property',
+    })
+  })
+
+  it('Should return extra property keys when using Zod object schema with .passthrough()', async () => {
+    const res = await appWithStrictSchema.request('/passthrough')
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toHaveProperty('extra', 'property')
+  })
+
+  const routeWithVariousZodTypes = createRoute({
+    method: 'get',
+    path: '/zod-types',
+    request: {
+      query: z.object({
+        type: z.enum(['string', 'number', 'boolean']),
+      }),
+    },
+    responses: {
+      // We use status codes as discriminator
+      200: {
+        content: {
+          'application/json': {
+            schema: z.string(),
+          },
+        },
+        description: 'When type=string',
+      },
+      201: {
+        content: {
+          'application/json': {
+            schema: z.number(),
+          },
+        },
+        description: 'When type=number',
+      },
+      202: {
+        content: {
+          'application/json': {
+            schema: z.boolean(),
+          },
+        },
+        description: 'When type=boolean',
+      },
+    },
+  })
+  appWithStrictSchema.openapi(routeWithVariousZodTypes, async (c) => {
+    const { type } = c.req.valid('query')
+    if (type === 'string') {
+      c.status(200)
+      return c.jsonT('string')
+    }
+    if (type === 'number') {
+      c.status(201)
+      return c.jsonT(123)
+    }
+    c.status(202)
+    return c.jsonT(true)
+  })
+
+  it('Should be able to parse and return string', async () => {
+    const res = await appWithStrictSchema.request('/zod-types?type=string')
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body).toBe('string')
+  })
+
+  it('Should be able to parse and return number', async () => {
+    const res = await appWithStrictSchema.request('/zod-types?type=number')
+    const body = await res.json()
+    expect(res.status).toBe(201)
+    expect(body).toBe(123)
+  })
+
+  it('Should be able to parse and return boolean', async () => {
+    const res = await appWithStrictSchema.request('/zod-types?type=boolean')
+    const body = await res.json()
+    expect(res.status).toBe(202)
+    expect(body).toBe(true)
+  })
+})


### PR DESCRIPTION
Hi, here is my try to implement a fix for #181.

Because this (might be) a breaking change, and not all people might want to use the feature, I implemented them behind the flag `strictStatusCode?: boolean`, `strictResponse?: boolean` so we can enable the feature when initializing `OpenAPIHono`

- `strictStatusCode`: basically we read from `RouterConfig` about the list of possible status codes, and just return an error whenever the schema doesn't contain the status code.
- `strictResponse` basically matches the status code, get that status code's schema, then do `safeParseAsync` against the data.

Honestly I still don't know the best practice in Hono on how throw and/or modify the response (and if this is a minor or major bump). I hope the tests can make it more clear though. Thank you