### PR TITLE
fix(firebase-auth): throw HTTPException instead of reponse null

### DIFF
--- a/.changeset/make-http-exception.md
+++ b/.changeset/make-http-exception.md
@@ -1,0 +1,5 @@
+---
+'@hono/firebase-auth': patch
+---
+
+fixed to make HTTPException instead of reponse null

--- a/packages/firebase-auth/src/index.ts
+++ b/packages/firebase-auth/src/index.ts
@@ -1,6 +1,7 @@
 import type { KeyStorer, FirebaseIdToken } from 'firebase-auth-cloudflare-workers'
 import { Auth, WorkersKVStoreSingle } from 'firebase-auth-cloudflare-workers'
 import type { Context, MiddlewareHandler } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 
 export type VerifyFirebaseAuthEnv = {
   PUBLIC_JWK_CACHE_KEY?: string | undefined
@@ -61,9 +62,11 @@ export const verifyFirebaseAuth = (userConfig: VerifyFirebaseAuthConfig): Middle
           err,
         })
       }
-      return new Response(null, {
+
+      const res = new Response('Unauthorized', {
         status: 401,
       })
+      throw new HTTPException(401, { res })
     }
     await next()
   }


### PR DESCRIPTION
I made to throw HTTPException instead of response null 401.

See: https://github.com/honojs/middleware/issues/185

Now, we can achieve our own error handling like the below:
```ts
app.onError((e, c) => {
  if (e instanceof HTTPException && e.status === 401) {
    return c.json(
      {
        message: 'Custom error message!',
      },
      401
    )
  }
  return c.text('Internal Server Error', 500)
})
```