### PR TITLE
test(zod-openapi): additional headers test for `Authorization`

### DIFF
--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -37,7 +37,6 @@
     "zod": "3.*"
   },
   "devDependencies": {
-    "@hono/zod-validator": "^0.1.9",
     "hono": "^3.7.2",
     "zod": "^3.22.1"
   },

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -263,19 +263,9 @@ describe('Query', () => {
 
 describe('Header', () => {
   const HeaderSchema = z.object({
-    'x-request-id': z.string().uuid(),
-  })
-
-  const HeaderSchemaAuth = z.object({
     authorization: z.string(),
     'x-request-id': z.string().uuid(),
   })
-
-  const PingSchema = z
-    .object({
-      'x-request-id': z.string().uuid(),
-    })
-    .openapi('Post')
 
   const PongSchema = z
     .object({
@@ -286,27 +276,9 @@ describe('Header', () => {
 
   const route = createRoute({
     method: 'get',
-    path: '/ping',
-    request: {
-      headers: HeaderSchema,
-    },
-    responses: {
-      200: {
-        content: {
-          'application/json': {
-            schema: PingSchema,
-          },
-        },
-        description: 'Ping',
-      },
-    },
-  })
-
-  const routeWithAuth = createRoute({
-    method: 'get',
     path: '/pong',
     request: {
-      headers: HeaderSchemaAuth,
+      headers: HeaderSchema,
     },
     responses: {
       200: {
@@ -329,38 +301,25 @@ describe('Header', () => {
 
   app.openapi(route, controller)
 
-  app.openapi(routeWithAuth, controller)
-
   it('Should return 200 response with correct contents', async () => {
-    const res = await app.request('/ping', {
-      headers: {
-        'x-request-id': '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b',
-      },
-    })
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({
-      'x-request-id': '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b',
-    })
-  })
-
-  it('Should return 200 response for array of headers with Authorization included', async () => {
     const res = await app.request('/pong', {
       headers: {
-        Authorization: 'Bearer helloworld',
         'x-request-id': '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b',
+        Authorization: 'Bearer helloworld',
       },
     })
-    expect(await res.json()).toEqual({
-      'authorization': 'Bearer helloworld',
-      'x-request-id': '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b',
-    })
     expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      'x-request-id': '6ec0bd7f-11c0-43da-975e-2a8ad9ebae0b',
+      'authorization': 'Bearer helloworld',
+    })
   })
 
   it('Should return 400 response with correct contents', async () => {
-    const res = await app.request('/ping', {
+    const res = await app.request('/pong', {
       headers: {
         'x-request-id': 'invalid-strings',
+        Authorization: 'Bearer helloworld',
       },
     })
     expect(res.status).toBe(400)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,10 +1765,15 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
   integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
 
-"@sinclair/typebox@^0.25.16", "@sinclair/typebox@^0.25.24":
+"@sinclair/typebox@^0.25.16":
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
   integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
+
+"@sinclair/typebox@^0.31.15":
+  version "0.31.17"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.31.17.tgz#f9ceed480957b919b203bb0b3e27bc559d1e8e19"
+  integrity sha512-GVYVHHOGINx+DT2DwjXoCQO0mRpztYKyb3d48tucuqhjhHpQYGp7Xx7dhhQGzILx/beuBrzfITMC7/5X7fw+UA==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
I was trying to figure out how Authorisation headers will work with this repository. I discovered that there is some interesting behaviour with the capitalisation, and as such have added a test into the package to note this behaviour as seen here.

Additionally, I have removed a duplicate dependency from the `package.json` as this is already listed as a full dependency. In most scenarios, having a package listed twice the the `package.json` file is erroneous - I am sure if this was intentional someone will let me know 🙂 