### PR TITLE
fix(graphql-server): enhance type safety of RootResolvers and Options

### DIFF
--- a/.changeset/old-readers-complain.md
+++ b/.changeset/old-readers-complain.md
@@ -1,0 +1,5 @@
+---
+'@hono/graphql-server': patch
+---
+
+add type safety to RootResolvers and Options

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -17,26 +17,36 @@ import type {
   GraphQLFormattedError,
 } from 'graphql'
 
-import type { Context } from 'hono'
+import type { Context, Env, Input } from 'hono'
 import { parseBody } from './parse-body'
 
-export type RootResolver = (ctx?: Context) => Promise<unknown> | unknown
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RootResolver<E extends Env = any, P extends string = any, I extends Input = {}> = (
+  // eslint-enable-next-line @typescript-eslint/no-explicit-any
+  ctx?: Context<E, P, I>
+) => Promise<unknown> | unknown
 
-type Options = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Options<E extends Env = any, P extends string = any, I extends Input = {}> = {
+  // eslint-enable-next-line @typescript-eslint/no-explicit-any
   schema: GraphQLSchema
-  rootResolver?: RootResolver
+  rootResolver?: RootResolver<E, P, I>
   pretty?: boolean
   validationRules?: ReadonlyArray<ValidationRule>
   // graphiql?: boolean
 }
 
-export const graphqlServer = (options: Options) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const graphqlServer = <E extends Env = any, P extends string = any, I extends Input = {}>(
+  // eslint-enable-next-line @typescript-eslint/no-explicit-any
+  options: Options<E, P, I>
+) => {
   const schema = options.schema
   const pretty = options.pretty ?? false
   const validationRules = options.validationRules ?? []
   // const showGraphiQL = options.graphiql ?? false
 
-  return async (c: Context) => {
+  return async (c: Context<E, P, I>) => {
     // GraphQL HTTP only supports GET and POST methods.
     if (c.req.method !== 'GET' && c.req.method !== 'POST') {
       return c.json(errorMessages(['GraphQL only supports GET and POST requests.']), 405, {


### PR DESCRIPTION
related #198 (I'm not familiar with Pothos, so I'm not sure...)

## Summary

This commit introduces more specific type annotations to the following modules:
* `RootResolvers`
* `Options`

Specifically, the same type parameters used in the definition of `Context` class were given to them:

```ts
<E extends Env = any, P extends string = any, I extends Input = {}>
```

See: https://github.com/honojs/hono/blob/main/src/context.ts

## Diff

To confirm, change `bun_test/index.test.ts` as follows (not included in the commit)

```ts
describe('graphql-server', () => {
  // Construct a schema, using GraphQL schema language
  const schema = buildSchema(`
  type Query {
    hello: String
  }
`)

  // My motivation is to development a GraphQL server on Cloudflare Workers with D1.
  type Bindings = {
    DB: string
  }
  
  type GraphQLContext = Context<{ Bindings: Bindings }, '/graphql'>

  // The root provides a resolver function for each API endpoint
  const rootValue = (ctx?: GraphQLContext) => {
    return {
      hello: () => {
        return 'Hello world!'
      },
    }
  }

  const app = new Hono()

  app.use(
    '/graphql',
    graphqlServer({
      schema,
      rootResolver: rootValue,
    })
  )

  // ...


})
```

### Before

![スクリーンショット 2023-10-15 13 18 19](https://github.com/honojs/middleware/assets/33865215/7edee3ce-673f-47aa-9096-3d358f5d4c21)

![スクリーンショット 2023-10-15 13 18 46](https://github.com/honojs/middleware/assets/33865215/21032eba-4fea-4a8a-b378-f161c295fab2)

![スクリーンショット 2023-10-15 13 19 22](https://github.com/honojs/middleware/assets/33865215/40b0a3ce-4275-4a5a-a218-78078c5526ac)

### After

![スクリーンショット 2023-10-15 13 15 35](https://github.com/honojs/middleware/assets/33865215/44809296-654a-4eb9-a746-11e3f55191a0)

![スクリーンショット 2023-10-15 13 17 00](https://github.com/honojs/middleware/assets/33865215/f37609d1-2b4a-4420-8e84-6be47f470c2e)

![スクリーンショット 2023-10-15 16 52 08](https://github.com/honojs/middleware/assets/33865215/cf990e46-f95b-4c41-897e-b7a539a09412)

