### PR TITLE
feat(zod-openapi): allows the response to be `Response`

### DIFF
--- a/.changeset/tough-beds-speak.md
+++ b/.changeset/tough-beds-speak.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+feat: allows the response to be `Response` not just `TypedResponse`.

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -143,13 +143,17 @@ type Hook<T, E extends Env, P extends string, O> = (
         error: ZodError
       },
   c: Context<E, P>
-) => TypedResponse<O> | Promise<TypedResponse<T>> | void
+) => TypedResponse<O> | Promise<TypedResponse<T>> | Response | Promise<Response> | void
 
 type ConvertPathType<T extends string> = T extends `${infer Start}/{${infer Param}}${infer Rest}`
   ? `${Start}/:${Param}${ConvertPathType<Rest>}`
   : T
 
-type HandlerResponse<O> = TypedResponse<O> | Promise<TypedResponse<O>>
+type HandlerResponse<O> =
+  | TypedResponse<O>
+  | Promise<TypedResponse<O>>
+  | Response
+  | Promise<Response>
 
 export type OpenAPIHonoOptions<E extends Env> = {
   defaultHook?: Hook<any, E, any, any>

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -942,3 +942,28 @@ describe('With hc', () => {
     })
   })
 })
+
+describe('It allows the response type to be Response', () => {
+  const app = new OpenAPIHono()
+
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/no-content',
+      responses: {
+        204: {
+          description: 'No Content',
+        },
+      },
+    }),
+    (c) => {
+      return c.body(null, 204)
+    }
+  )
+
+  it('should return a 204 response without a type error', async () => {
+    const res = await app.request('/no-content')
+    expect(res.status).toBe(204)
+    expect(res.body).toBe(null)
+  })
+})


### PR DESCRIPTION
With this PR, I made it allows the response type to be `Response` and not just `TypedResponse`.

Resolves #205