### PR TITLE
fix(zod-validator): make validation input optional when schema is optional

### DIFF
--- a/.changeset/chilly-tomatoes-suffer.md
+++ b/.changeset/chilly-tomatoes-suffer.md
@@ -1,0 +1,5 @@
+---
+"@hono/zod-validator": patch
+---
+
+fix(zod-validator): make validation input optional when schema is optional

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -7,17 +7,25 @@ export type Hook<T, E extends Env, P extends string, O = {}> = (
   c: Context<E, P>
 ) => Response | Promise<Response> | void | Promise<Response | void> | TypedResponse<O>
 
+type HasUndefined<T> = undefined extends T ? true : false
+
 export const zValidator = <
   T extends ZodSchema,
   Target extends keyof ValidationTargets,
   E extends Env,
   P extends string,
+  I = z.input<T>,
+  O = z.output<T>,
   V extends {
-    in: { [K in Target]: z.input<T> }
-    out: { [K in Target]: z.output<T> }
+    in: HasUndefined<I> extends true
+      ? { [K in Target]?: I }
+      : { [K in Target]: I };
+    out: { [K in Target]: O };
   } = {
-    in: { [K in Target]: z.input<T> }
-    out: { [K in Target]: z.output<T> }
+    in: HasUndefined<I> extends true
+      ? { [K in Target]?: I }
+      : { [K in Target]: I };
+    out: { [K in Target]: O };
   }
 >(
   target: Target,

--- a/packages/zod-validator/test/index.test.ts
+++ b/packages/zod-validator/test/index.test.ts
@@ -9,12 +9,16 @@ type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
 describe('Basic', () => {
   const app = new Hono()
 
-  const schema = z.object({
+  const jsonSchema = z.object({
     name: z.string(),
     age: z.number(),
   })
 
-  const route = app.post('/author', zValidator('json', schema), (c) => {
+  const querySchema = z.object({
+    name: z.string().optional()
+  }).optional()
+
+  const route = app.post('/author', zValidator('json', jsonSchema), zValidator('query', querySchema), (c) => {
     const data = c.req.valid('json')
     return c.jsonT({
       success: true,
@@ -31,6 +35,10 @@ describe('Basic', () => {
             name: string
             age: number
           }
+        } & {
+          query?: {
+            name?: string | undefined
+          } | undefined
         }
         output: {
           success: boolean

--- a/packages/zod-validator/test/index.test.ts
+++ b/packages/zod-validator/test/index.test.ts
@@ -20,9 +20,12 @@ describe('Basic', () => {
 
   const route = app.post('/author', zValidator('json', jsonSchema), zValidator('query', querySchema), (c) => {
     const data = c.req.valid('json')
+    const query = c.req.valid('query')
+
     return c.jsonT({
       success: true,
       message: `${data.name} is ${data.age}`,
+      queryName: query?.name,
     })
   })
 
@@ -43,6 +46,7 @@ describe('Basic', () => {
         output: {
           success: boolean
           message: string
+          queryName: string | undefined
         }
       }
     }
@@ -52,7 +56,7 @@ describe('Basic', () => {
   type verify = Expect<Equal<Expected, Actual>>
 
   it('Should return 200 response', async () => {
-    const req = new Request('http://localhost/author', {
+    const req = new Request('http://localhost/author?name=Metallo', {
       body: JSON.stringify({
         name: 'Superman',
         age: 20,
@@ -65,6 +69,7 @@ describe('Basic', () => {
     expect(await res.json()).toEqual({
       success: true,
       message: 'Superman is 20',
+      queryName: 'Metallo'
     })
   })
 


### PR DESCRIPTION
Fixes types for optional schema by making input optional (`?`) when the schema is optional.

See honojs/hono#1583