### PR TITLE
fix(zod-openapi): Fix a bug that slashes were duplicated when mountin…

### DIFF
--- a/.changeset/four-rice-listen.md
+++ b/.changeset/four-rice-listen.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Fix a bug that slashes were duplicated when mounting a path using the route method

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -30,6 +30,10 @@ import type { RemoveBlankRecord } from 'hono/utils/types'
 import type { AnyZodObject, ZodSchema, ZodError } from 'zod'
 import { z, ZodType } from 'zod'
 
+const normalizePath = (path: string) => {
+  return `/${path.replaceAll(/^\/+|\/+$|(\/)+/g, '$1')}`
+}
+
 type RequestTypes = {
   body?: ZodRequestBody
   params?: AnyZodObject
@@ -323,13 +327,13 @@ export class OpenAPIHono<
         case 'route':
           return this.openAPIRegistry.registerPath({
             ...def.route,
-            path: `${path}${def.route.path}`,
+            path: normalizePath(`${path}${def.route.path}`),
           })
 
         case 'webhook':
           return this.openAPIRegistry.registerWebhook({
             ...def.webhook,
-            path: `${path}${def.webhook.path}`,
+            path: normalizePath(`${path}${def.webhook.path}`),
           })
 
         case 'schema':

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -27,12 +27,9 @@ import type {
 } from 'hono'
 import type { MergePath, MergeSchemaPath } from 'hono/types'
 import type { RemoveBlankRecord } from 'hono/utils/types'
+import { mergePath } from 'hono/utils/url'
 import type { AnyZodObject, ZodSchema, ZodError } from 'zod'
 import { z, ZodType } from 'zod'
-
-const normalizePath = (path: string) => {
-  return `/${path.replaceAll(/^\/+|\/+$|(\/)+/g, '$1')}`
-}
 
 type RequestTypes = {
   body?: ZodRequestBody
@@ -327,13 +324,13 @@ export class OpenAPIHono<
         case 'route':
           return this.openAPIRegistry.registerPath({
             ...def.route,
-            path: normalizePath(`${path}${def.route.path}`),
+            path: mergePath(path, def.route.path),
           })
 
         case 'webhook':
           return this.openAPIRegistry.registerWebhook({
             ...def.webhook,
-            path: normalizePath(`${path}${def.webhook.path}`),
+            path: mergePath(path, def.webhook.path),
           })
 
         case 'schema':


### PR DESCRIPTION
…g a path using the route method

Before:
<img width="358" alt="スクリーンショット 2023-11-16 14 14 45" src="https://github.com/honojs/middleware/assets/40270352/69fe723b-b626-463c-91b0-198cb7cfc894">

After:
<img width="369" alt="スクリーンショット 2023-11-16 14 15 02" src="https://github.com/honojs/middleware/assets/40270352/f4e797c8-c089-4939-bf0f-b255d7a10cd1">

