### PR TITLE
docs(zod-openapi): add components registoration and auth configutation tips

### DIFF
--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -284,6 +284,48 @@ const appRoutes = app.openapi(route, (c) => {
 const client = hc<typeof appRoutes>('http://localhost:8787/')
 ```
 
+## Tips
+
+### How to register components
+
+You can register components to the registry as follows:
+
+```ts
+app.openAPIRegistry.registerComponent('schemas', {
+  User: UserSchema,
+})
+```
+
+### How to setup authorization
+
+You can setup authorization as follows:
+
+eg. Bearer Auth
+
+Register the security scheme:
+
+```ts
+app.openAPIRegistry.registerComponent('securitySchema', {
+  Bearer: {
+    type: 'http',
+    scheme: 'bearer',
+  },
+}
+```
+
+And setup the security scheme for specific routes:
+
+```ts
+const route = createRoute({
+  // ...
+  security: [
+    {
+      Bearer: [],
+    },
+  ],
+})
+```
+
 ## Limitations
 
 Be careful when combining `OpenAPIHono` instances with plain `Hono` instances. `OpenAPIHono` will merge the definitions of direct subapps, but plain `Hono` knows nothing about the OpenAPI spec additions. Similarly `OpenAPIHono` will not "dig" for instances deep inside a branch of plain `Hono` instances.

--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -296,6 +296,8 @@ app.openAPIRegistry.registerComponent('schemas', {
 })
 ```
 
+About this feature, please refer to [the "Zod to OpenAPI" resource / Defining Custom Components](https://github.com/asteasolutions/zod-to-openapi#defining-custom-components)
+
 ### How to setup authorization
 
 You can setup authorization as follows:


### PR DESCRIPTION
related: #261 

Since the guide was missing, we added a guide on authentication to the document to prevent the same question from occurring.