### PR TITLE
fix: ensure state is passed through for both github app types

### DIFF
--- a/.changeset/hip-owls-give.md
+++ b/.changeset/hip-owls-give.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': patch
+---
+
+ensure CSRF state returned to GitHub apps

--- a/packages/oauth-providers/src/providers/github/authFlow.ts
+++ b/packages/oauth-providers/src/providers/github/authFlow.ts
@@ -43,15 +43,15 @@ export class AuthFlow {
   redirect() {
     const url = 'https://github.com/login/oauth/authorize?'
 
-    if (this.oauthApp) {
-      const parsedScope = toQueryParams({
-        scope: this.scope,
-        state: this.state,
-      })
-      return `${url}${parsedScope}&client_id=${this.client_id}`
-    }
+    const queryParams = toQueryParams({
+      client_id: this.client_id,
+      state: this.state,
+      // For GitHub apps, the scope is configured during the app setup / creation.
+      // For OAuth apps, we need to provide the scope.
+      ...(this.oauthApp && { scope: this.scope }),
+    })
 
-    return `${url}client_id=${this.client_id}`
+    return url.concat(queryParams);
   }
 
   private async getTokenFromCode() {


### PR DESCRIPTION
When using a GitHub App, instead of a GitHub OAuth App, no user can successfully authenticate because the state isn't added to the redirect URI.