### PR TITLE
fix: redirect url for github apps

### DIFF
--- a/.changeset/two-crabs-speak.md
+++ b/.changeset/two-crabs-speak.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': patch
+---
+
+ensure redirect to original URL for GitHub apps

--- a/packages/oauth-providers/src/providers/github/githubAuth.ts
+++ b/packages/oauth-providers/src/providers/github/githubAuth.ts
@@ -40,7 +40,11 @@ export function githubAuth(options: {
         path: '/',
         // secure: true,
       })
-      return c.redirect(auth.redirect())
+
+      // OAuth apps can't have multiple callback URLs, but GitHub Apps can.
+      // As such, we want to make sure we call back to the same location
+      // for GitHub apps and not the first configured callbackURL in the app config.
+      return c.redirect(auth.redirect().concat(options.oauthApp ? '' : `&redirect_uri=${c.req.url}`))
     }
 
     // Retrieve user data from github


### PR DESCRIPTION
OAuth apps can't have multiple callback URLs, but GitHub Apps can.

As such, we want to make sure we call back to the same location for GitHub apps and not the first configured callbackURL in the app config.

cc @yusukebe @monoald 