### PR TITLE
Use origin for zod-openapi example

### DIFF
--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -341,7 +341,7 @@ app.doc('/doc', c => ({
   },
   servers: [
     {
-      url: new URL(c.req.url).hostname,
+      url: new URL(c.req.url).origin,
       description: 'Current environment',
     },
   ],


### PR DESCRIPTION
`.hostname` doesn't include the protocol, which is important. =) 