### PR TITLE
change: Export Hook in @hono/zod-openapi

### DIFF
--- a/.changeset/nervous-berries-invent.md
+++ b/.changeset/nervous-berries-invent.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+change: Export Hook in @hono/zod-openapi

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -134,7 +134,7 @@ type OutputType<R extends RouteConfig> = R['responses'] extends Record<infer _, 
     : {}
   : {}
 
-type Hook<T, E extends Env, P extends string, O> = (
+export type Hook<T, E extends Env, P extends string, O> = (
   result:
     | {
         success: true


### PR DESCRIPTION
This will let people create shareable defaultHooks, that way I can just use one snippet of code in all my sub routers.