### PR TITLE
fix(react-renderer): dynamic import `renderToReadableStream`

### DIFF
--- a/.changeset/great-queens-vanish.md
+++ b/.changeset/great-queens-vanish.md
@@ -1,0 +1,5 @@
+---
+'@hono/react-renderer': patch
+---
+
+fix: dynamic import `renderToReadableStream`

--- a/packages/react-renderer/src/react-renderer.ts
+++ b/packages/react-renderer/src/react-renderer.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import type { Env, MiddlewareHandler } from 'hono/types'
 import React from 'react'
-import { renderToString, renderToReadableStream } from 'react-dom/server'
+import { renderToString } from 'react-dom/server'
 import type { Props } from '.'
 
 type RendererOptions = {
@@ -24,6 +24,7 @@ const createRenderer =
     const node = component ? component({ children, c, ...props }) : children
 
     if (options?.stream) {
+      const { renderToReadableStream } = await import('react-dom/server')
       const stream = await renderToReadableStream(
         React.createElement(RequestContext.Provider, { value: c }, node)
       )


### PR DESCRIPTION
To avoid throwing an error when `renderToReadableStream` is not available.