### PR TITLE
fix(firebase-auth): export esm

### DIFF
--- a/.changeset/poor-cars-film.md
+++ b/.changeset/poor-cars-film.md
@@ -1,0 +1,5 @@
+---
+'@hono/firebase-auth': patch
+---
+
+fix: export esm

--- a/packages/firebase-auth/package.json
+++ b/packages/firebase-auth/package.json
@@ -2,7 +2,9 @@
   "name": "@hono/firebase-auth",
   "version": "1.3.3",
   "description": "A third-party firebase auth middleware for Hono",
-  "main": "dist/index.js",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -11,9 +13,22 @@
     "start-firebase-emulator": "firebase emulators:start --project example-project12345",
     "test-with-emulator": "firebase emulators:exec --project example-project12345 'vitest run'",
     "test": "vitest run",
-    "build": "tsc",
-    "prerelease": "yarn build",
+    "build": "tsup ./src/index.ts --format esm,cjs --dts",
+    "publint": "publint",
+    "prerelease": "yarn build && arn publint",
     "release": "yarn publish"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
   },
   "license": "MIT",
   "repository": {
@@ -38,6 +53,7 @@
     "hono": "^3.11.7",
     "miniflare": "^3.20231025.1",
     "prettier": "^2.7.1",
+    "tsup": "^8.0.1",
     "typescript": "^4.7.4",
     "vitest": "^0.34.6"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,6 +1426,7 @@ __metadata:
     hono: "npm:^3.11.7"
     miniflare: "npm:^3.20231025.1"
     prettier: "npm:^2.7.1"
+    tsup: "npm:^8.0.1"
     typescript: "npm:^4.7.4"
     vitest: "npm:^0.34.6"
   peerDependencies:


### PR DESCRIPTION
In this PR, make Firebase Auth Middleware exports `esm` formatted package.

In Issue #335, `hono` was using `esm` and `@hono/firebase-auth` was using `cjs` so they did not reference the same `HTTPException` and the `res instanceof HTTPException` was not working properly. By using `@hono/firebase-auth` with this PR, both will use `esm` and the error will be gone.

Fixes #335