### PR TITLE
Adding hono/prometheus middleware

### DIFF
--- a/.changeset/friendly-carrots-help.md
+++ b/.changeset/friendly-carrots-help.md
@@ -1,0 +1,5 @@
+---
+'@hono/prometheus': major
+---
+
+Releasing first version

--- a/.github/workflows/ci-prometheus.yml
+++ b/.github/workflows/ci-prometheus.yml
@@ -1,0 +1,25 @@
+name: ci-prometheus
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/prometheus/**'
+  pull_request:
+    branches: ['*']
+    paths:
+      - 'packages/prometheus/**'
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/prometheus
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn test

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:oauth-providers": "yarn workspace @hono/oauth-providers build",
     "build:react-renderer": "yarn workspace @hono/react-renderer build",
     "build:auth-js": "yarn workspace @hono/auth-js build",
+    "build:prometheus": "yarn workspace @hono/prometheus build",
     "build": "run-p 'build:*'",
     "lint": "eslint 'packages/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'packages/**/*.{ts,tsx}'",

--- a/packages/prometheus/README.md
+++ b/packages/prometheus/README.md
@@ -2,6 +2,16 @@
 
 This middleware adds basic [RED metrics](https://www.weave.works/blog/the-red-method-key-metrics-for-microservices-architecture/) to your Hono application, and exposes them on the `/metrics` endpoint for Prometheus to scrape.
 
+## Installation
+
+This package depends on `prom-client`, so you need to install that as well:
+
+```bash
+npm install -S @hono/prometheus prom-client
+# or
+yarn add @hono/prometheus prom-client
+```
+
 ## Usage
 
 ```ts

--- a/packages/prometheus/README.md
+++ b/packages/prometheus/README.md
@@ -1,0 +1,84 @@
+# Prometheus middleware for Hono
+
+This middleware adds basic [RED metrics](https://www.weave.works/blog/the-red-method-key-metrics-for-microservices-architecture/) to your Hono application, and exposes them on the `/metrics` endpoint for Prometheus to scrape.
+
+## Usage
+
+```ts
+import { prometheus } from '@hono/prometheus'
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.use('*', prometheus())
+app.get('/', (c) => c.text('foo'))
+
+export default app
+```
+
+## Options
+
+An options object can be passed in the `prometheus()` middleware to configure the metrics:
+
+### `metricsPath`
+
+Type: *string*
+
+The path where the metrics will be exposed for Prometheus to scrape. Defaults to `/metrics`.
+
+### `prefix`
+
+Type: *string*
+
+Prefix all metrics with this string.
+
+### `registry`
+
+Type: *[Registry](https://www.npmjs.com/package/prom-client)*
+
+A prom-client Registry instance to store the metrics. If not provided, a new one will be created.
+
+Useful when you want to register some custom metrics while exposing them on the same `/metrics` endpoint that this middleware creates. In this case, you can create a Registry instance, register your custom metrics on that, and pass that into this option.
+
+### `collectDefaultMetrics`
+
+Type: *boolean | [CollectDefaultMetricsOptions](https://www.npmjs.com/package/prom-client#default-metrics)*
+
+There are some default metrics recommended by prom-client, like event loop delay, garbage collection statistics etc.
+
+To enable these metrics, set this option to `true`. To configure the default metrics, pass an object with the [configuration options](https://www.npmjs.com/package/prom-client#default-metrics).
+
+
+### `metricOptions`
+
+Type: *object (see below)*
+
+Modify the standard metrics (*requestDuration* and *requestsTotal*) with any of the [Counter](https://www.npmjs.com/package/prom-client#counter) / [Histogram](https://www.npmjs.com/package/prom-client#histogram) metric options, including:
+
+#### `customLabels`
+
+Type: *Record<string, (context) => string>*
+
+A record where the keys are the labels to add to the metrics, and the values are functions that receive the Hono context and return the value for that label. This is useful when adding labels to the metrics that are specific to your application or your needs. These functions are executed after all the other middlewares finished.
+
+The following example adds a label to the *requestsTotal* metric with the `contentType` name where the value is the content type of the response:
+
+```ts
+app.use('*', prometheus({
+  metricOptions: {
+    requestsTotal: {
+      customLabels: {
+        contentType: (c) => c.res.headers.get('content-type'),
+      }
+    },
+  }
+}))
+```
+
+## Author
+
+David Dios <https://github.com/dios-david>
+
+## License
+
+MIT

--- a/packages/prometheus/README.md
+++ b/packages/prometheus/README.md
@@ -10,7 +10,10 @@ import { Hono } from 'hono'
 
 const app = new Hono()
 
-app.use('*', prometheus())
+const { printMetrics, registerMetrics } = prometheus()
+
+app.use('*', registerMetrics)
+app.get('/metrics', printMetrics)
 app.get('/', (c) => c.text('foo'))
 
 export default app
@@ -18,13 +21,7 @@ export default app
 
 ## Options
 
-An options object can be passed in the `prometheus()` middleware to configure the metrics:
-
-### `metricsPath`
-
-Type: *string*
-
-The path where the metrics will be exposed for Prometheus to scrape. Defaults to `/metrics`.
+An options object can be passed in the `prometheus()` middleware factory to configure the metrics:
 
 ### `prefix`
 

--- a/packages/prometheus/package.json
+++ b/packages/prometheus/package.json
@@ -36,7 +36,7 @@
     "prom-client": "^15.0.0"
   },
   "devDependencies": {
-    "hono": "^3.9.2",
+    "hono": "^3.12.0",
     "prom-client": "^15.0.0",
     "tsup": "^8.0.1",
     "vitest": "^1.0.4"

--- a/packages/prometheus/package.json
+++ b/packages/prometheus/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "^3.9.2",
+    "hono": "^3.12.0",
     "prom-client": "^15.0.0"
   },
   "devDependencies": {

--- a/packages/prometheus/package.json
+++ b/packages/prometheus/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@hono/prometheus",
+  "version": "0.1.0",
+  "description": "Prometheus metrics middleware for Hono",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "test": "vitest --run",
+    "build": "tsup ./src/index.ts --format esm,cjs --dts",
+    "publint": "publint",
+    "release": "yarn build && yarn test && yarn publint && yarn publish"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/honojs/middleware.git"
+  },
+  "homepage": "https://github.com/honojs/middleware",
+  "peerDependencies": {
+    "hono": "^3.9.2",
+    "prom-client": "^15.0.0"
+  },
+  "devDependencies": {
+    "hono": "^3.9.2",
+    "prom-client": "^15.0.0",
+    "tsup": "^8.0.1",
+    "vitest": "^1.0.4"
+  }
+}

--- a/packages/prometheus/src/index.test.ts
+++ b/packages/prometheus/src/index.test.ts
@@ -9,7 +9,7 @@ describe('Prometheus middleware', () => {
 
   app.use('*', prometheus({
     registry,
-  }))
+  }).registerMetrics)
 
   app.get('/', (c) => c.text('hello'))
   app.get('/user/:id', (c) => c.text(c.req.param('id')))
@@ -24,7 +24,7 @@ describe('Prometheus middleware', () => {
       app.use('*', prometheus({
         registry,
         prefix: 'myprefix_',
-      }))
+      }).registerMetrics)
 
       expect(await registry.metrics()).toMatchInlineSnapshot(`
         "# HELP myprefix_http_request_duration_seconds Duration of HTTP requests in seconds
@@ -50,7 +50,7 @@ describe('Prometheus middleware', () => {
             }
           },
         }
-      }))
+      }).registerMetrics)
 
       app.get('/', (c) => c.text('hello'))
 
@@ -141,16 +141,18 @@ describe('Prometheus middleware', () => {
       const app = new Hono()
       const registry = new Registry()
 
-      app.use('*', prometheus({
+      const { printMetrics, registerMetrics } = prometheus({
         registry,
         metricOptions: {
           requestDuration: {
             disabled: true, // Disable duration metrics to make the test result more predictable
           }
         }
-      }))
+      })
 
+      app.use('*', registerMetrics)
       app.get('/', (c) => c.text('hello'))
+      app.get('/metrics', printMetrics)
 
       await app.request('http://localhost/')
 

--- a/packages/prometheus/src/index.test.ts
+++ b/packages/prometheus/src/index.test.ts
@@ -1,0 +1,138 @@
+import { Hono } from 'hono'
+import type { Histogram} from 'prom-client'
+import { Registry } from 'prom-client'
+import { prometheus } from './index'
+
+describe('Prometheus middleware', () => {
+  const app = new Hono()
+  const registry = new Registry()
+
+  app.use('*', prometheus({
+    registry,
+  }))
+
+  app.get('/', (c) => c.text('hello'))
+  app.get('/user/:id', (c) => c.text(c.req.param('id')))
+
+  beforeEach(() => registry.resetMetrics())
+
+  describe('configuration', () => {
+    it('prefix - adds the provided prefix to the metric names', async () => {
+      const app = new Hono()
+      const registry = new Registry()
+
+      app.use('*', prometheus({
+        registry,
+        prefix: 'myprefix_',
+      }))
+
+      expect(await registry.metrics()).toMatchInlineSnapshot(`
+        "# HELP myprefix_http_request_duration_seconds Duration of HTTP requests in seconds
+        # TYPE myprefix_http_request_duration_seconds histogram
+
+        # HELP myprefix_http_requests_total Total number of HTTP requests
+        # TYPE myprefix_http_requests_total counter
+        "
+      `)
+    })
+
+    it('customLabels - adds custom labels to metrics', async () => {
+      const app = new Hono()
+      const registry = new Registry()
+
+      app.use('*', prometheus({
+        registry,
+        metricOptions: {
+          requestsTotal: {
+            customLabels: {
+              id: (c) => c.req.query('id') ?? 'unknown',
+              contentType: (c) => c.res.headers.get('content-type') ?? 'unknown',
+            }
+          },
+        }
+      }))
+
+      app.get('/', (c) => c.text('hello'))
+
+      await app.request('http://localhost/?id=123')
+
+      expect(await registry.getSingleMetricAsString('http_requests_total')).toMatchInlineSnapshot(`
+        "# HELP http_requests_total Total number of HTTP requests
+        # TYPE http_requests_total counter
+        http_requests_total{method="GET",route="/",status="200",ok="true",id="123",contentType="text/plain;charset=UTF-8"} 1"
+      `)
+    })
+  })
+
+  describe('metrics', () => {
+    describe('http_requests_total', () => {
+      it('increments the http_requests_total metric with the correct labels on successful responses', async () => {
+        await app.request('http://localhost/')
+    
+        const { values } = await registry.getSingleMetric('http_requests_total')!.get()!
+    
+        expect(values).toEqual([
+          {
+            labels: {
+              method: 'GET',
+              route: '/',
+              status: '200',
+              ok: 'true',
+            },
+            value: 1,
+          }
+        ])
+      })
+  
+      it('increments the http_requests_total metric with the correct labels on errors', async () => {
+        await app.request('http://localhost/notfound')
+  
+        const { values } = await registry.getSingleMetric('http_requests_total')!.get()!
+    
+        expect(values).toEqual([
+          {
+            labels: {
+              method: 'GET',
+              route: '/*',
+              status: '404',
+              ok: 'false',
+            },
+            value: 1,
+          }
+        ])
+      })
+    })
+  
+    describe('http_requests_duration', () => {
+      it('updates the http_requests_duration metric with the correct labels on successful responses', async () => {
+        await app.request('http://localhost/')
+    
+        const { values } = await (registry.getSingleMetric('http_request_duration_seconds') as Histogram)!.get()!
+  
+        const countMetric = values.find(
+          (v) => v.metricName === 'http_request_duration_seconds_count' &&
+            v.labels.method === 'GET' &&
+            v.labels.route === '/' &&
+            v.labels.status === '200'
+        )
+
+        expect(countMetric?.value).toBe(1)
+      })
+  
+      it('updates the http_requests_duration metric with the correct labels on errors', async () => {
+        await app.request('http://localhost/notfound')
+    
+        const { values } = await (registry.getSingleMetric('http_request_duration_seconds') as Histogram)!.get()!
+  
+        const countMetric = values.find(
+          (v) => v.metricName === 'http_request_duration_seconds_count' &&
+            v.labels.method === 'GET' &&
+            v.labels.route === '/*' &&
+            v.labels.status === '404'
+        )
+  
+        expect(countMetric?.value).toBe(1)
+      })
+    })
+  })
+})

--- a/packages/prometheus/src/index.ts
+++ b/packages/prometheus/src/index.ts
@@ -47,23 +47,17 @@ export const prometheus = (options?: PrometheusOptions) => {
     registry,
     customOptions: metricOptions,
   })
-  
-
-  const metricsEndpointMiddleware = createMiddleware(async (c, next) => {
-    c.body(await registry.metrics())
-
-    await next()
-  })
 
   return createMiddleware(async (c, next) => {
     const timer = metrics.requestDuration?.startTimer()
 
     if (c.req.path === metricsPath) {
-      await metricsEndpointMiddleware(c, next)
+      return c.text(await registry.metrics())
     }
   
     try {
       await next()
+
     } finally {
       const commonLabels = {
         method: c.req.method,

--- a/packages/prometheus/src/index.ts
+++ b/packages/prometheus/src/index.ts
@@ -1,0 +1,86 @@
+import type { Context } from 'hono'
+import { createMiddleware } from 'hono/factory'
+import type { DefaultMetricsCollectorConfiguration, RegistryContentType } from 'prom-client'
+import { Registry, collectDefaultMetrics as promCollectDefaultMetrics } from 'prom-client'
+import { type MetricOptions, type CustomMetricsOptions, createStandardMetrics } from './standardMetrics'
+
+interface PrometheusOptions {
+  registry?: Registry;
+  metricsPath?: string;
+  collectDefaultMetrics?: boolean | DefaultMetricsCollectorConfiguration<RegistryContentType>;
+  prefix?: string;
+  metricOptions?: Omit<CustomMetricsOptions, 'prefix' | 'register'>;
+}
+
+const evaluateCustomLabels = (
+  customLabels: MetricOptions['customLabels'],
+  context: Context,
+) => {
+  const labels: Record<string, string> = {}
+
+  for (const [key, fn] of Object.entries(customLabels ?? {})) {
+    labels[key] = fn(context)
+  }
+
+  return labels
+}
+
+export const prometheus = (options?: PrometheusOptions) => {
+  const {
+    registry = new Registry(),
+    metricsPath = '/metrics',
+    collectDefaultMetrics = false,
+    prefix = '',
+    metricOptions,
+  } = options ?? {}
+
+  if (collectDefaultMetrics) {
+    promCollectDefaultMetrics({
+      prefix,
+      register: registry,
+      ...(typeof collectDefaultMetrics === 'object' && collectDefaultMetrics)
+    })
+  }
+
+  const metrics = createStandardMetrics({
+    prefix,
+    registry,
+    customOptions: metricOptions,
+  })
+  
+
+  const metricsEndpointMiddleware = createMiddleware(async (c, next) => {
+    c.body(await registry.metrics())
+
+    await next()
+  })
+
+  return createMiddleware(async (c, next) => {
+    const timer = metrics.requestDuration?.startTimer()
+
+    if (c.req.path === metricsPath) {
+      await metricsEndpointMiddleware(c, next)
+    }
+  
+    try {
+      await next()
+    } finally {
+      const commonLabels = {
+        method: c.req.method,
+        route: c.req.routePath,
+        status: c.res.status.toString(),
+        ok: String(c.res.ok),
+      }
+
+      timer?.({
+        ...commonLabels,
+        ...evaluateCustomLabels(metricOptions?.requestDuration?.customLabels, c)
+      })
+  
+      metrics.requestsTotal?.inc({
+        ...commonLabels,
+        ...evaluateCustomLabels(metricOptions?.requestsTotal?.customLabels, c)
+      })
+    }
+  })
+}

--- a/packages/prometheus/src/standardMetrics.ts
+++ b/packages/prometheus/src/standardMetrics.ts
@@ -1,0 +1,82 @@
+import type { Context } from 'hono'
+import type { CounterConfiguration, HistogramConfiguration, Metric } from 'prom-client'
+import { Counter, Histogram, type Registry } from 'prom-client'
+
+export type MetricOptions = {
+  disabled?: boolean;
+  customLabels?: Record<string, (c: Context) => string>;
+} & (
+  ({ type: 'counter' } & CounterConfiguration<string>) |
+  ({ type: 'histogram' } & HistogramConfiguration<string>) 
+)
+
+const standardMetrics = {
+  requestDuration: {
+    type: 'histogram',
+    name: 'http_request_duration_seconds',
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'status', 'ok', 'route'],
+    // OpenTelemetry recommendation for histogram buckets of http request duration:
+    // https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
+    buckets: [ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ],
+  },
+  requestsTotal: {
+    type: 'counter',
+    name: 'http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['method', 'status', 'ok', 'route'],
+  },
+} satisfies Record<string, MetricOptions>
+
+export type MetricName = keyof typeof standardMetrics
+
+export type CustomMetricsOptions = {
+  [Name in MetricName]?: Partial<Omit<MetricOptions, 'type' | 'collect' | 'labelNames'>>
+}
+
+type CreatedMetrics = {
+  [Name in MetricName]: (typeof standardMetrics)[Name]['type'] extends 'counter' ? Counter<string> : Histogram<string>
+}
+
+const getMetricConstructor = (type: MetricOptions['type']) => ({
+  counter: Counter,
+  histogram: Histogram,
+})[type]
+
+export const createStandardMetrics = ({
+  registry,
+  prefix = '',
+  customOptions,
+} : {
+  registry: Registry;
+  prefix?: string;
+  customOptions?: CustomMetricsOptions;
+}) => {
+  const createdMetrics: Record<string, Metric> = {}
+
+  for (const [metric, options] of Object.entries(standardMetrics)) {
+    const opts: MetricOptions = {
+      ...options,
+      ...customOptions?.[metric as MetricName],
+    }
+
+    if (opts.disabled) {
+      continue
+    }
+
+    const MetricConstructor = getMetricConstructor(opts.type)
+
+    createdMetrics[metric] = new MetricConstructor({
+      ...(opts as object),
+      name: `${prefix}${opts.name}`,
+      help: opts.help,
+      registers: [...opts.registers ?? [], registry],
+      labelNames: [...opts.labelNames ?? [], ...Object.keys(opts.customLabels ?? {})],
+      ...(opts.type === 'histogram' && opts.buckets && {
+        buckets: opts.buckets,
+      }),
+    })
+  }
+
+  return createdMetrics as CreatedMetrics
+}

--- a/packages/prometheus/tsconfig.json
+++ b/packages/prometheus/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+}

--- a/packages/prometheus/vitest.config.ts
+++ b/packages/prometheus/vitest.config.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,7 +1545,7 @@ __metadata:
     tsup: "npm:^8.0.1"
     vitest: "npm:^1.0.4"
   peerDependencies:
-    hono: ^3.9.2
+    hono: ^3.12.0
     prom-client: ^15.0.0
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,7 +1540,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hono/prometheus@workspace:packages/prometheus"
   dependencies:
-    hono: "npm:^3.9.2"
+    hono: "npm:^3.12.0"
     prom-client: "npm:^15.0.0"
     tsup: "npm:^8.0.1"
     vitest: "npm:^1.0.4"
@@ -8871,10 +8871,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^3.9.2":
-  version: 3.12.0
-  resolution: "hono@npm:3.12.0"
-  checksum: e10dd70e5eda44c76e8e5dae807963841475449fbb4100421ec2e5e680734644006f6133e8a8edf66ac8d47aad114a704db52b53cab2f292a8d17f02342fcff1
+"hono@npm:^3.12.0":
+  version: 3.12.6
+  resolution: "hono@npm:3.12.6"
+  checksum: 74475dc0519f064a6c25b4d588a65ad06b9e3217c914e1d60aad9f3fc7516786dbda44e5bab527a6e6b8a10fdf30c37d25c2d20bab03681325d65edd6909a913
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,6 +1523,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@hono/prometheus@workspace:packages/prometheus":
+  version: 0.0.0-use.local
+  resolution: "@hono/prometheus@workspace:packages/prometheus"
+  dependencies:
+    hono: "npm:^3.9.2"
+    prom-client: "npm:^15.0.0"
+    tsup: "npm:^8.0.1"
+    vitest: "npm:^1.0.4"
+  peerDependencies:
+    hono: ^3.9.2
+    prom-client: ^15.0.0
+  languageName: unknown
+  linkType: soft
+
 "@hono/qwik-city@workspace:packages/qwik-city":
   version: 0.0.0-use.local
   resolution: "@hono/qwik-city@workspace:packages/qwik-city"
@@ -2788,7 +2802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.6.0":
+"@opentelemetry/api@npm:^1.4.0, @opentelemetry/api@npm:^1.6.0":
   version: 1.7.0
   resolution: "@opentelemetry/api@npm:1.7.0"
   checksum: b5468115d1cec45dd2b86b39210fdc03620a93b9f07c3d20b14081f75e2f7c9b37ceceeb60d5f35c6d4f9819ae07eee0b4874e53e7362376db21db1e00f483f8
@@ -4855,6 +4869,13 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: d73d8b897238a2d3ffa5f59c0241870043aa7471335e89ea5e1ff48edb7c2d0bb471517a3e4c5c3f4c043615caa2717b5f80a5e61e07503d51dc85cb848e665d
+  languageName: node
+  linkType: hard
+
+"bintrees@npm:1.0.2":
+  version: 1.0.2
+  resolution: "bintrees@npm:1.0.2"
+  checksum: 132944b20c93c1a8f97bf8aa25980a76c6eb4291b7f2df2dbcd01cb5b417c287d3ee0847c7260c9f05f3d5a4233aaa03dec95114e97f308abe9cc3f72bed4a44
   languageName: node
   linkType: hard
 
@@ -8818,6 +8839,13 @@ __metadata:
   version: 3.11.7
   resolution: "hono@npm:3.11.7"
   checksum: 6665e26801cb4c4334e09dbb42453bf40e1daae9a44bf9a1ed22815f6cb701c0d9ac1a4452624234f36093996c8afff0a41d2d5b52a77f4f460178be48e022bf
+  languageName: node
+  linkType: hard
+
+"hono@npm:^3.9.2":
+  version: 3.12.0
+  resolution: "hono@npm:3.12.0"
+  checksum: e10dd70e5eda44c76e8e5dae807963841475449fbb4100421ec2e5e680734644006f6133e8a8edf66ac8d47aad114a704db52b53cab2f292a8d17f02342fcff1
   languageName: node
   linkType: hard
 
@@ -14150,6 +14178,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prom-client@npm:^15.0.0":
+  version: 15.1.0
+  resolution: "prom-client@npm:15.1.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.4.0"
+    tdigest: "npm:^0.1.1"
+  checksum: c10781adbf49225298e44da5396a51a0bd4d0cddc3c7e237ba50e888e12ead26a8f98261f362a442f1bbcdaddd6e7302d5675b37beac67ea9b6f82e4d39fb3cc
+  languageName: node
+  linkType: hard
+
 "promise-breaker@npm:^6.0.0":
   version: 6.0.0
   resolution: "promise-breaker@npm:6.0.0"
@@ -16213,6 +16251,15 @@ __metadata:
     debug: "npm:4.3.1"
     is2: "npm:^2.0.6"
   checksum: a5fb29e35f1e452f1064e3671d02b6d65e7d9bffad98d8da688270b6ffdaa9a8351fe8321aedf131f3904af70b569d9c5f6d9fe75d57dda19c466abac2bc025a
+  languageName: node
+  linkType: hard
+
+"tdigest@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "tdigest@npm:0.1.2"
+  dependencies:
+    bintrees: "npm:1.0.2"
+  checksum: 10187b8144b112fcdfd3a5e4e9068efa42c990b1e30cd0d4f35ee8f58f16d1b41bc587e668fa7a6f6ca31308961cbd06cd5d4a4ae1dc388335902ae04f7d57df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/honojs/hono/issues/263

As suggested in [this comment](https://github.com/honojs/hono/issues/263#issuecomment-1193129541), I'm adding this to the `honojs/middleware` repository instead of the main one as a third-party middleware.

I've tried to come up with sensible configuration options and default values based on my previous experiences with [express-prom-bundle](https://www.npmjs.com/package/express-prom-bundle) and [koa-prometheus](https://www.npmjs.com/package/@uswitch/koa-prometheus).