### PR TITLE
    fix(ctx): fix the context not propagated down to resolvers.

### DIFF
--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -133,6 +133,7 @@ export const graphqlServer = <E extends Env = any, P extends string = any, I ext
         schema,
         document: documentAST,
         rootValue: rootResolver ? await rootResolver(c) : null,
+        contextValue: c,
         variableValues: variables,
         operationName: operationName,
       })


### PR DESCRIPTION
This MR is to fix one of the issues raised in https://github.com/honojs/middleware/issues/198 , the context should be included in the execution options.