### PR TITLE
Make it possible to define a different HTTP Status Code without using…

### DIFF
--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -26,7 +26,8 @@ export const zValidator = <
 >(
   target: Target,
   schema: T,
-  hook?: Hook<z.infer<T>, E, P>
+  hook?: Hook<z.infer<T>, E, P>,
+  statusCode?: Number
 ): MiddlewareHandler<E, P, V> =>
   validator(target, async (value, c) => {
     const result = await schema.safeParseAsync(value)
@@ -44,7 +45,7 @@ export const zValidator = <
     }
 
     if (!result.success) {
-      return c.json(result, 400)
+      return c.json(result, statusCode ?? 400);
     }
 
     const data = result.data as z.infer<T>


### PR DESCRIPTION
… a hook

Hope you open to the following..

I usually return 422 on invalid data, would be nice to set this without writing out a hook on every request.
