### PR TITLE
fix(eslint): set `curly` rule as `all`

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -21,6 +21,7 @@ module.exports = defineConfig({
     addEventListener: false,
   },
   rules: {
+    curly: ['error', 'all'],
     quotes: ['error', 'single'],
     semi: ['error', 'never'],
     'no-debugger': ['error'],


### PR DESCRIPTION
Related https://github.com/orgs/honojs/discussions/2108

As mentioned above, the style of brace should be specified in the linter. In this case, we use `all`.