### PR TITLE
feat: add support for authorization cookies in firebase-auth middleware

### DIFF
--- a/.changeset/quick-bikes-work.md
+++ b/.changeset/quick-bikes-work.md
@@ -1,0 +1,5 @@
+---
+'@hono/firebase-auth': minor
+---
+
+Allow cookies to be used instead of headers for providing firebase auth token

--- a/packages/firebase-auth/README.md
+++ b/packages/firebase-auth/README.md
@@ -74,9 +74,17 @@ app.fire()
 
 This field indicates your firebase project ID.
 
+### `useCookie: boolean` (**required**)
+
+This field, if set to true will pick the token to verify from a cookie instead of Authorization headers.  
+
 ### `authorizationHeaderKey?: string` (optional)
 
 Based on this configuration, the JWT created by firebase auth is looked for in the HTTP headers. The default is "Authorization".
+
+### `cookieName?: string` (optional)
+
+Based on this configuration, the JWT created by firebase auth is looked for in the HTTP cookie using this name. The default is "authorization".
 
 ### `keyStore?: KeyStorer` (optional)
 
@@ -99,6 +107,44 @@ Throws an exception if JWT validation fails. By default, this is output to the e
 You can specify a host for the Firebase Auth emulator. This config is mainly used when **Service Worker Syntax** is used.
 
 If not specified, check the [`FIREBASE_AUTH_EMULATOR_HOST` environment variable obtained from the request](https://github.com/Code-Hex/firebase-auth-cloudflare-workers#emulatorenv).
+
+## Security Considerations when using cookies for authentication
+
+When considering that a web framework uses tokens via cookies, security measures related to traditional browsers and cookies must be considered.
+
+    CSRF (Cross-Site Request Forgery)
+    XSS (Cross-Site Scripting)
+    MitM (Man-in-the-middle attack)
+
+Let's consider each:
+
+**CSRF**
+
+This is provided by hono as a standard middleware feature
+
+https://hono.dev/middleware/builtin/csrf
+
+**XSS**
+
+An attacker can inject a script and steal JWTs stored in cookies. Set the httpOnly flag on the cookie to prevent access from JavaScript. Additionally, configure "Content Security Policy" (CSP) to prevent unauthorized script execution. It is recommeded to force httpOnly and the functionality here: https://hono.dev/middleware/builtin/secure-headers
+
+**MitM**
+
+If your cookie security settings are inappropriate, there is a risk that your cookies will be stolen by a MitM. Use Samesite (or hono csrf middleware) and __Secure- prefix and __Host- prefix attributes.
+
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
+
+An example of good cookie settings:
+
+```
+let secureCookieSettings: CookieOptions = {
+  path: '/',
+  domain: <your_domain>,
+  secure: true,
+  httpOnly: true,
+  sameSite: 'Strict',
+}
+```
 
 ## Author
 


### PR DESCRIPTION
Hi,

This PR adds support for cookies to be used in firebase-auth middleware instead of headers. The use case for this is if you want access to a dashboard or component available only to users who have logged in and don't want to/can't add headers for HTTP requests made by said users.

