### PR TITLE
fix(valibot-validator): make validation input optional when schema is optional

### DIFF
--- a/.changeset/old-suns-matter.md
+++ b/.changeset/old-suns-matter.md
@@ -1,0 +1,5 @@
+---
+'@hono/valibot-validator': patch
+---
+
+fix(valibot-validator): make validation input optional when schema is optional

--- a/packages/valibot-validator/src/index.ts
+++ b/packages/valibot-validator/src/index.ts
@@ -16,10 +16,14 @@ export const vValidator = <
   E extends Env,
   P extends string,
   V extends {
-    in: HasUndefined<Input<T>> extends true ? { [K in Target]?: Input<T> } : { [K in Target]: Input<T> }
+    in: HasUndefined<Input<T>> extends true
+      ? { [K in Target]?: Input<T> }
+      : { [K in Target]: Input<T> }
     out: { [K in Target]: Output<T> }
   } = {
-    in: HasUndefined<Input<T>> extends true ? { [K in Target]?: Input<T> } : { [K in Target]: Input<T> }
+    in: HasUndefined<Input<T>> extends true
+      ? { [K in Target]?: Input<T> }
+      : { [K in Target]: Input<T> }
     out: { [K in Target]: Output<T> }
   }
 >(

--- a/packages/valibot-validator/src/index.ts
+++ b/packages/valibot-validator/src/index.ts
@@ -8,16 +8,18 @@ type Hook<T extends BaseSchema, E extends Env, P extends string> = (
   c: Context<E, P>
 ) => Response | Promise<Response> | void | Promise<Response | void>
 
+type HasUndefined<T> = undefined extends T ? true : false
+
 export const vValidator = <
   T extends BaseSchema,
   Target extends keyof ValidationTargets,
   E extends Env,
   P extends string,
   V extends {
-    in: { [K in Target]: Input<T> }
+    in: HasUndefined<Input<T>> extends true ? { [K in Target]?: Input<T> } : { [K in Target]: Input<T> }
     out: { [K in Target]: Output<T> }
   } = {
-    in: { [K in Target]: Input<T> }
+    in: HasUndefined<Input<T>> extends true ? { [K in Target]?: Input<T> } : { [K in Target]: Input<T> }
     out: { [K in Target]: Output<T> }
   }
 >(

--- a/packages/valibot-validator/test/index.test.ts
+++ b/packages/valibot-validator/test/index.test.ts
@@ -16,7 +16,7 @@ describe('Basic', () => {
 
   const route = app.post('/author', vValidator('json', schema), (c) => {
     const data = c.req.valid('json')
-    return c.jsonT({
+    return c.json({
       success: true,
       message: `${data.name} is ${data.age}`,
     })

--- a/packages/valibot-validator/test/index.test.ts
+++ b/packages/valibot-validator/test/index.test.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import type { Equal, Expect } from 'hono/utils/types'
-import { number, object, string } from 'valibot'
+import { number, object, string, optional } from 'valibot'
 import { vValidator } from '../src'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -14,11 +14,17 @@ describe('Basic', () => {
     age: number(),
   })
 
-  const route = app.post('/author', vValidator('json', schema), (c) => {
+  const querySchema = optional(object({
+    search: optional(string())
+  }))
+
+  const route = app.post('/author', vValidator('json', schema), vValidator('query', querySchema), (c) => {
     const data = c.req.valid('json')
+    const query = c.req.valid('query')
+
     return c.json({
       success: true,
-      message: `${data.name} is ${data.age}`,
+      message: `${data.name} is ${data.age}, search is ${query?.search}`,
     })
   })
 
@@ -31,6 +37,10 @@ describe('Basic', () => {
             name: string
             age: number
           }
+        } & {
+          query?: {
+            search?: string | undefined
+          } | undefined
         }
         output: {
           success: boolean
@@ -44,7 +54,7 @@ describe('Basic', () => {
   type verify = Expect<Equal<Expected, Actual>>
 
   it('Should return 200 response', async () => {
-    const req = new Request('http://localhost/author', {
+    const req = new Request('http://localhost/author?search=hello', {
       body: JSON.stringify({
         name: 'Superman',
         age: 20,
@@ -59,7 +69,7 @@ describe('Basic', () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
       success: true,
-      message: 'Superman is 20',
+      message: 'Superman is 20, search is hello',
     })
   })
 

--- a/packages/valibot-validator/test/index.test.ts
+++ b/packages/valibot-validator/test/index.test.ts
@@ -14,19 +14,26 @@ describe('Basic', () => {
     age: number(),
   })
 
-  const querySchema = optional(object({
-    search: optional(string())
-  }))
-
-  const route = app.post('/author', vValidator('json', schema), vValidator('query', querySchema), (c) => {
-    const data = c.req.valid('json')
-    const query = c.req.valid('query')
-
-    return c.json({
-      success: true,
-      message: `${data.name} is ${data.age}, search is ${query?.search}`,
+  const querySchema = optional(
+    object({
+      search: optional(string()),
     })
-  })
+  )
+
+  const route = app.post(
+    '/author',
+    vValidator('json', schema),
+    vValidator('query', querySchema),
+    (c) => {
+      const data = c.req.valid('json')
+      const query = c.req.valid('query')
+
+      return c.json({
+        success: true,
+        message: `${data.name} is ${data.age}, search is ${query?.search}`,
+      })
+    }
+  )
 
   type Actual = ExtractSchema<typeof route>
   type Expected = {
@@ -38,9 +45,11 @@ describe('Basic', () => {
             age: number
           }
         } & {
-          query?: {
-            search?: string | undefined
-          } | undefined
+          query?:
+            | {
+                search?: string | undefined
+              }
+            | undefined
         }
         output: {
           success: boolean


### PR DESCRIPTION
Fixes types for optional schema by making input optional (`?`) when the schema is optional.

Exactly the same case as with `zod-validator` honojs/hono#1583