### PR TITLE
fix(oidc-auth): Fix "yarn release" for Yarn v4 / Build ESM only

### DIFF
--- a/.changeset/curvy-lemons-give.md
+++ b/.changeset/curvy-lemons-give.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': patch
+---
+
+Fix "yarn release" and fix npm package

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:auth-js": "yarn workspace @hono/auth-js build",
     "build:bun-transpiler": "yarn workspace @hono/bun-transpiler build",
     "build:prometheus": "yarn workspace @hono/prometheus build",
+    "build:oidc-auth": "yarn workspace @hono/oidc-auth build",
     "build": "run-p 'build:*'",
     "lint": "eslint 'packages/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'packages/**/*.{ts,tsx}'",

--- a/packages/oidc-auth/package.json
+++ b/packages/oidc-auth/package.json
@@ -4,22 +4,22 @@
   "description": "OpenID Connect Authentication middleware for Hono",
   "type": "module",
   "main": "dist/index.js",
-  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --verbose --coverage",
-    "build": "tsup ./src/index.ts --format esm,cjs --dts",
+    "build": "tsup ./src/index.ts --format esm --dts",
     "prerelease": "yarn build && yarn test",
-    "release": "yarn publish"
+    "release": "yarn prerelease && yarn npm publish"
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "license": "MIT",


### PR DESCRIPTION
Hi @yusukebe !
Thanks for releasing `@hono/oidc-auth`!

However, I noticed that there are no `dist/*` files in the npm package for `@hono/oidc-auth@1.0.0`.
This is due to the `yarn release` not executing the `build` script in the `package.json`.
I have fixed the `release` script to address this issue.

Additionally, `yarn publish` was a Yarn v1 command, so I have updated it to be compatible with v4.

Lastly, I noticed that the dependent library, `oauth4webapi`, does not support CommonJS.
As a result, I have updated the `package.json` to only build ESM.