### PR TITLE
graphql-server: hono peer dependency to support v4.0.0

### DIFF
--- a/.changeset/ninety-cups-grin.md
+++ b/.changeset/ninety-cups-grin.md
@@ -1,0 +1,5 @@
+---
+'@hono/graphql-server': patch
+---
+
+fix: change peer dependency to support v4.0.0

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -23,7 +23,7 @@
     "release": "np"
   },
   "peerDependencies": {
-    "hono": "^3.0.0"
+    "hono": ">=3.0.0"
   },
   "dependencies": {
     "graphql": "^16.5.0"
@@ -41,7 +41,7 @@
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
-    "hono": "^3.11.7",
+    "hono": "^4.0.2",
     "jest": "^28.1.2",
     "jest-environment-miniflare": "^2.6.0",
     "np": "^7.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,7 +1485,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.26.0"
     eslint-plugin-node: "npm:^11.1.0"
     graphql: "npm:^16.5.0"
-    hono: "npm:^3.11.7"
+    hono: "npm:^4.0.2"
     jest: "npm:^28.1.2"
     jest-environment-miniflare: "npm:^2.6.0"
     np: "npm:^7.6.2"
@@ -1494,7 +1494,7 @@ __metadata:
     ts-jest: "npm:^28.0.5"
     typescript: "npm:^4.7.4"
   peerDependencies:
-    hono: ^3.0.0
+    hono: ">=3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -8919,6 +8919,13 @@ __metadata:
   version: 4.0.1
   resolution: "hono@npm:4.0.1"
   checksum: 0f4fe93d376ce4063d42ccc35eee445756f17ca4044ef1f59e276b4737dacc5e76334e230a59101a4092aa88a066f7585303da7631ca4a46325384d55db48df3
+  languageName: node
+  linkType: hard
+
+"hono@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "hono@npm:4.0.2"
+  checksum: c0806a912c1be094aa7e34050e8391c41f2623fae683239d9d1f1680f8646602ebf91a8e1c58bf75de510a6d0fe70189e57f629c0e48f8abb5ab873ba844a481
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update hono peer dependency
```
# npm resolution error report

While resolving: x.askua.dev@undefined
Found: hono@4.0.2
node_modules/hono
  hono@"^4.0.1" from the root project

Could not resolve dependency:
peer hono@"^3.0.0" from @hono/graphql-server@0.4.2
node_modules/@hono/graphql-server
  @hono/graphql-server@"*" from the root project

Fix the upstream dependency conflict, or retry
this command with --force or --legacy-peer-deps
to accept an incorrect (and potentially broken) dependency resolution.
```