### PR TITLE
fix(firebase-auth): retrive header values for v4

### DIFF
--- a/.changeset/support-v4.md
+++ b/.changeset/support-v4.md
@@ -1,0 +1,5 @@
+---
+'@hono/firebase-auth': patch
+---
+
+- supported v4 to get header values

--- a/packages/firebase-auth/jest.config.js
+++ b/packages/firebase-auth/jest.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../jest.config.js')

--- a/packages/firebase-auth/src/index.ts
+++ b/packages/firebase-auth/src/index.ts
@@ -43,7 +43,7 @@ export const verifyFirebaseAuth = (userConfig: VerifyFirebaseAuthConfig): Middle
   }
 
   return async (c, next) => {
-    const authorization = c.req.headers.get(config.AuthorizationHeaderKey)
+    const authorization = c.req.raw.headers.get(config.AuthorizationHeaderKey)
     if (authorization === null) {
       const res = new Response('Bad Request', {
         status: 400,


### PR DESCRIPTION
fixed `TypeError: Cannot read properties of undefined (reading 'get')` error in hono v4