### PR TITLE
ci: update actions/checkout and actions/setup-node to v4

### DIFF
--- a/.github/workflows/ci-arktype-validator.yml
+++ b/.github/workflows/ci-arktype-validator.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/arktype-validator
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-auth-js.yml
+++ b/.github/workflows/ci-auth-js.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/auth-js
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-clerk-auth.yml
+++ b/.github/workflows/ci-clerk-auth.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/clerk-auth
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-firebase-auth.yml
+++ b/.github/workflows/ci-firebase-auth.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/firebase-auth
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-graphql-server.yml
+++ b/.github/workflows/ci-graphql-server.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/graphql-server
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-hello.yml
+++ b/.github/workflows/ci-hello.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/hello
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-medley-router.yml
+++ b/.github/workflows/ci-medley-router.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/medley-router
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-prometheus.yml
+++ b/.github/workflows/ci-prometheus.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/prometheus
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-sentry.yml
+++ b/.github/workflows/ci-sentry.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/sentry
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-trpc-server.yml
+++ b/.github/workflows/ci-trpc-server.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/trpc-server
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-typebox-validator.yml
+++ b/.github/workflows/ci-typebox-validator.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/typebox-validator
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-typia-validator.yml
+++ b/.github/workflows/ci-typia-validator.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/typia-validator
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-valibot-validator.yml
+++ b/.github/workflows/ci-valibot-validator.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/valibot-validator
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-zod-openapi.yml
+++ b/.github/workflows/ci-zod-openapi.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/zod-openapi
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/ci-zod-validator.yml
+++ b/.github/workflows/ci-zod-validator.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: ./packages/zod-validator
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 18.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 


### PR DESCRIPTION
As the title suggests, update actions/checkout and actions/setup-node to v4.