### PR TITLE
Adding Appwrite auth middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build:bun-transpiler": "yarn workspace @hono/bun-transpiler build",
     "build:prometheus": "yarn workspace @hono/prometheus build",
     "build:oidc-auth": "yarn workspace @hono/oidc-auth build",
+    "build:appwrite-auth": "yarn workspace @hono/appwrite-auth build",
     "build": "run-p 'build:*'",
     "lint": "eslint 'packages/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'packages/**/*.{ts,tsx}'",

--- a/packages/appwrite-auth/CHANGELOG.md
+++ b/packages/appwrite-auth/CHANGELOG.md
@@ -1,0 +1,2 @@
+# @hono/appwrite-auth
+

--- a/packages/appwrite-auth/README.md
+++ b/packages/appwrite-auth/README.md
@@ -1,0 +1,108 @@
+# Hono Appwrite auth middleware
+
+This is an Appwrite Auth middleware library for [Hono](https://github.com/honojs/hono) that uses Appwrite's [SSR](https://appwrite.io/docs/products/auth/server-side-rendering) login.
+
+This package also provides some [helpers](#helpers) that will make the login process much easier.
+
+## Installation
+
+```plain
+npm i hono @hono/appwrite-auth node-appwrite
+```
+
+## Usage
+
+1. Set Appwrite config using the `initAppwrite` function.
+2. Protect routes using the `appwriteMiddleware` function.
+3. Get the user object anywhere using the `getAuth` function.
+
+```ts
+import { hello } from '@hono/hello'
+import { Hono } from 'hono'
+import { getAuth, appwriteMiddleware, initAppwrite } from '@hono/appwrite-auth'
+
+const app = new Hono()
+
+const appwriteConfig = {
+  endpoint  : 'https://cloud.appwrite.io/v1',
+  projectId : '<YOUR_PROJECT_ID>',
+  apiKey    : '<API_KEY>',
+  cookieName: 'appwrite_secure_ssr',
+}
+
+app.use('*', initAppwrite(appwriteConfig))
+
+app.get('/', (c) => c.text('No auth required'))
+
+app.use('/api/', appwriteMiddleware())
+
+app.get('/api/user/prefs', (c) => {
+  const user = getAuth(c)
+
+  return c.json({ preferences: user.prefs })
+})
+
+export default app
+```
+
+## Helpers
+
+### Email login
+
+This helper is expecting to get the email and password name `email` & `password` in a post `application/json` body.
+
+```ts
+import { appwriteEmailLogin, initAppwrite } from '@hono/appwrite-auth'
+
+app.use('*', initAppwrite(appwriteConfig))
+
+app.post('/login/', appwriteEmailLogin())
+
+export default app
+```
+
+### OAuth2 login
+
+Appwrite has support for a wide variety of OAuth2 providers,
+you can see the full list [here](https://appwrite.io/docs/references/cloud/client-web/account#createOAuth2Session). a hint? it's big.
+
+```ts
+import { appwriteEmailLogin, initAppwrite } from '@hono/appwrite-auth'
+import { OAuthProvider } from 'node-appwrite'
+
+
+app.use('*', initAppwrite(appwriteConfig))
+
+const successUrl = 'https://your.website.com//auth2/google/success'
+const failureUrl = 'https://your.website.com//auth2/google/success'
+
+/*
+ * Create the OAuth2, this helper will redirect the user
+ * to the OAuth2 provider login URL.
+ */
+app.post('/auth2/google', appwriteAuth2(OAuthProvider.Google))
+
+// Success and failure URLs
+app.get('/auth2/google/success', appwriteAuth2Save()) // user is logged in and added to the context, optional redirect URL can be sent to the function
+app.get('/auth2/google/failure', (c) => c.json({ messsage: '😢  sorry mate' }, 400)) // handle failure
+
+
+export default app
+```
+
+## Available config settings
+
+| Value       | Description                                                  | 
+|-------------|--------------------------------------------------------------|
+| endpoint    | Appwrite API endpoint e.g. `https://cloud.appwrite.io/v1`    |
+| projectId   | Appwrite project ID                                          |
+| apiKey      | Appwrite project API key with `sessions.write` scope enabled |
+| cookie_name | The cookie that will be set in the user browser              |
+
+## Author
+
+Binyamin Yawitz <https://github.com/byawitz>
+
+## License
+
+MIT

--- a/packages/appwrite-auth/README.md
+++ b/packages/appwrite-auth/README.md
@@ -33,7 +33,7 @@ app.use('*', initAppwrite(appwriteConfig))
 
 app.get('/', (c) => c.text('No auth required'))
 
-app.use('/api/', appwriteMiddleware())
+app.use('/api/*', appwriteMiddleware())
 
 app.get('/api/user/prefs', (c) => {
   const user = getAuth(c)

--- a/packages/appwrite-auth/README.md
+++ b/packages/appwrite-auth/README.md
@@ -66,7 +66,7 @@ Appwrite has support for a wide variety of OAuth2 providers,
 you can see the full list [here](https://appwrite.io/docs/references/cloud/client-web/account#createOAuth2Session). a hint? it's big.
 
 ```ts
-import { appwriteEmailLogin, initAppwrite } from '@hono/appwrite-auth'
+import { appwriteAuth2Save, appwriteAuth2, initAppwrite } from '@hono/appwrite-auth'
 import { OAuthProvider } from 'node-appwrite'
 
 
@@ -79,7 +79,7 @@ const failureUrl = 'https://your.website.com//auth2/google/success'
  * Create the OAuth2, this helper will redirect the user
  * to the OAuth2 provider login URL.
  */
-app.post('/auth2/google', appwriteAuth2(OAuthProvider.Google))
+app.post('/auth2/google', appwriteAuth2(OAuthProvider.Google,successUrl,failureUrl))
 
 // Success and failure URLs
 app.get('/auth2/google/success', appwriteAuth2Save()) // user is logged in and added to the context, optional redirect URL can be sent to the function

--- a/packages/appwrite-auth/README.md
+++ b/packages/appwrite-auth/README.md
@@ -17,7 +17,6 @@ npm i hono @hono/appwrite-auth node-appwrite
 3. Get the user object anywhere using the `getAuth` function.
 
 ```ts
-import { hello } from '@hono/hello'
 import { Hono } from 'hono'
 import { getAuth, appwriteMiddleware, initAppwrite } from '@hono/appwrite-auth'
 

--- a/packages/appwrite-auth/package.json
+++ b/packages/appwrite-auth/package.json
@@ -39,7 +39,7 @@
     "@hono/node-server": "^1.8.2",
     "@types/node": "^20.11.17",
     "hono": "^3.11.7",
-    "node-appwrite": "../../../sdk-for-node",
+    "node-appwrite": "^12.0.0",
     "tsup": "^8.0.1",
     "tsx": "^3.12.2",
     "vitest": "^1.0.4"

--- a/packages/appwrite-auth/package.json
+++ b/packages/appwrite-auth/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@hono/appwrite-auth",
+  "version": "0.0.1",
+  "description": "A third-party Appwrite auth middleware for Hono",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepare-test": "tsx src/test.server.ts",
+    "test": "vitest --run",
+    "build": "tsup ./src/index.ts --format esm,cjs --dts",
+    "publint": "publint",
+    "release": "yarn build && yarn test && yarn publint && yarn publish"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/honojs/middleware.git"
+  },
+  "homepage": "https://github.com/honojs/middleware",
+  "peerDependencies": {
+    "hono": "*"
+  },
+  "devDependencies": {
+    "@hono/node-server": "^1.8.2",
+    "@types/node": "^20.11.17",
+    "hono": "^3.11.7",
+    "node-appwrite": "../../../sdk-for-node",
+    "tsup": "^8.0.1",
+    "tsx": "^3.12.2",
+    "vitest": "^1.0.4"
+  }
+}

--- a/packages/appwrite-auth/src/index.test.ts
+++ b/packages/appwrite-auth/src/index.test.ts
@@ -1,29 +1,42 @@
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
-
-/******
- The tests will be added by creating
- mocking server inside the `test.server` file
- after Appwrite will release version 1.5 officially
-
- *****/
+import type { AppwriteAuthConfig } from './index'
+import { appwriteMiddleware, initAppwrite } from './index'
 
 describe('Appwrite middleware', () => {
   const app = new Hono()
 
-  it('should be 1', () => {
-    expect(1).toBe(1)
+  const appwriteConfig: AppwriteAuthConfig = {
+    endpoint  : 'https://cloud.appwrite.io/v1',
+    projectId : 'PROJECT_ID',
+    apiKey    : 'API_KEY',
+    cookieName: 'appwrite-secure-cookie',
+  }
+
+  app.get('/', (c) => c.json({ success: true }))
+
+  app.use('/api/*', initAppwrite(appwriteConfig))
+  app.use('/api/*', appwriteMiddleware())
+
+  app.get('/api/whoami', (c) => c.json({ success: true }))
+
+
+  it('it Should return 200', async () => {
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true })
   })
-})
 
-describe.skip('Appwrite email Helper', () => {
-  const app = new Hono()
+  it('it Should return 401', async () => {
+    const res = await app.request('/api/whoami')
+    expect(res.status).toBe(401)
+    expect(await res.text()).toEqual('Unauthorized')
+  })
 
-
-})
-
-describe.skip('Appwrite oauth2 helper', () => {
-  const app = new Hono()
-
+  it('it Should return 403', async () => {
+    const res = await app.request('/api/whoami', { credentials: 'include', headers: { 'cookie': 'appwrite-secure-cookie=cookieID' } })
+    expect(res.status).toBe(403)
+    expect(await res.text()).toEqual('Forbidden')
+  })
 
 })

--- a/packages/appwrite-auth/src/index.test.ts
+++ b/packages/appwrite-auth/src/index.test.ts
@@ -1,0 +1,29 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+
+/******
+ The tests will be added by creating
+ mocking server inside the `test.server` file
+ after Appwrite will release version 1.5 officially
+
+ *****/
+
+describe('Appwrite middleware', () => {
+  const app = new Hono()
+
+  it('should be 1', () => {
+    expect(1).toBe(1)
+  })
+})
+
+describe.skip('Appwrite email Helper', () => {
+  const app = new Hono()
+
+
+})
+
+describe.skip('Appwrite oauth2 helper', () => {
+  const app = new Hono()
+
+
+})

--- a/packages/appwrite-auth/src/index.ts
+++ b/packages/appwrite-auth/src/index.ts
@@ -1,0 +1,139 @@
+import { type Context } from 'hono'
+import { getCookie, setCookie } from 'hono/cookie'
+import { createMiddleware } from 'hono/factory'
+import { HTTPException } from 'hono/http-exception'
+import { Account, Client, type Models } from 'node-appwrite'
+
+
+export interface AppwriteAuthConfig {
+  endpoint: string,
+  projectId: string,
+  apiKey: string,
+  cookieName: string,
+
+}
+
+const badResponse = new Response('Unauthorized', {
+  status: 401,
+})
+
+export const initAppwrite = (config: AppwriteAuthConfig) => {
+  return createMiddleware(async (c, next) => {
+    const sessionClient = new Client()
+      .setEndpoint(config.endpoint)
+      .setProject(config.projectId)
+
+    const adminClient = new Client()
+      .setEndpoint(config.endpoint)
+      .setProject(config.projectId)
+      .setKey(config.apiKey)
+
+    c.set('appwriteConfig', config)
+    c.set('sessionClient', sessionClient)
+    c.set('adminClient', adminClient)
+
+    await next()
+  })
+}
+
+export const getAuth = (c: Context) => {
+  return c.get('appwriteUser')
+}
+
+export const appwriteMiddleware = () => {
+
+  return createMiddleware(async (c, next) => {
+    const config  = c.get('appwriteConfig')
+    const session = getCookie(c, config.cookieName)
+
+    if (!session) {
+      throw new HTTPException(401, { res: badResponse })
+    }
+
+    const sessionClient = c.get('sessionClient')
+    sessionClient.setSession(session)
+
+    const account = new Account(sessionClient)
+    try {
+      const user = await account.get()
+
+      c.set('appwriteUser', user)
+
+      await next()
+
+    } catch (e) {
+      throw new HTTPException(401, { res: badResponse })
+    }
+  })
+}
+
+
+/************* Helpers *************/
+
+export const appwriteEmailLogin = () => {
+  return async (c: Context) => {
+    const body                = await c.req.json()
+    const { email, password } = body
+    const adminClient         = c.get('adminClient')
+    const config              = c.get('appwriteConfig')
+    const account             = new Account(adminClient)
+
+    try {
+      const session = await account.createEmailPasswordSession(email, password)
+
+      setAppwriteCookie(c, config, session)
+
+      return c.json({ success: true })
+    } catch (e) {
+      throw new HTTPException(401, { res: badResponse })
+    }
+  }
+}
+
+export const appwriteAuth2 = (provider: string, success: string, failure: string) => {
+  return async (c: Context) => {
+    const adminClient = c.get('adminClient')
+
+    try {
+      const account = new Account(adminClient)
+
+      const redirectUrl = await account.createOAuth2Token(provider, success, failure)
+
+      return c.redirect(redirectUrl)
+    } catch (e) {
+      throw new HTTPException(401, { res: badResponse })
+    }
+  }
+}
+
+export const appwriteAuth2Save = (redirect?: string) => {
+  return async (c: Context) => {
+    const adminClient = c.get('adminClient')
+    const config      = c.get('appwriteConfig')
+
+    const { userId, secret } = c.req.query()
+    try {
+      const account = new Account(adminClient)
+      const session = await account.createSession(userId, secret)
+      setAppwriteCookie(c, config, session)
+
+      if (redirect) {
+        return c.redirect(redirect)
+      }
+
+      return c.json({ success: true })
+    } catch (e) {
+      throw new HTTPException(401, { res: badResponse })
+    }
+  }
+}
+
+function setAppwriteCookie(c: Context, config: AppwriteAuthConfig, session: Models.Session) {
+  setCookie(c, config.cookieName, session.secret, {
+    httpOnly: true,
+    secure  : true,
+    sameSite: 'Strict',
+    expires : new Date(session.expire),
+    path    : '/',
+  })
+}

--- a/packages/appwrite-auth/src/index.ts
+++ b/packages/appwrite-auth/src/index.ts
@@ -13,9 +13,6 @@ export interface AppwriteAuthConfig {
 
 }
 
-const badResponse = new Response('Unauthorized', {
-  status: 401,
-})
 
 export const initAppwrite = (config: AppwriteAuthConfig) => {
   return createMiddleware(async (c, next) => {
@@ -36,7 +33,7 @@ export const initAppwrite = (config: AppwriteAuthConfig) => {
   })
 }
 
-export const getAuth = (c: Context) => {
+export const getAuth = (c: Context): Models.User<Models.Preferences> => {
   return c.get('appwriteUser')
 }
 
@@ -47,7 +44,11 @@ export const appwriteMiddleware = () => {
     const session = getCookie(c, config.cookieName)
 
     if (!session) {
-      throw new HTTPException(401, { res: badResponse })
+      throw new HTTPException(401, {
+        res: new Response('Unauthorized', {
+          status: 401,
+        }),
+      })
     }
 
     const sessionClient = c.get('sessionClient')
@@ -62,7 +63,11 @@ export const appwriteMiddleware = () => {
       await next()
 
     } catch (e) {
-      throw new HTTPException(401, { res: badResponse })
+      throw new HTTPException(403, {
+        res: new Response('Forbidden', {
+          status: 403,
+        }),
+      })
     }
   })
 }
@@ -85,12 +90,16 @@ export const appwriteEmailLogin = () => {
 
       return c.json({ success: true })
     } catch (e) {
-      throw new HTTPException(401, { res: badResponse })
+      throw new HTTPException(401, {
+        res: new Response('Unauthorized', {
+          status: 401,
+        }),
+      })
     }
   }
 }
 
-export const appwriteAuth2 = (provider: string, success: string, failure: string) => {
+export const appwriteOAuth2 = (provider: string, success: string, failure: string) => {
   return async (c: Context) => {
     const adminClient = c.get('adminClient')
 
@@ -101,12 +110,16 @@ export const appwriteAuth2 = (provider: string, success: string, failure: string
 
       return c.redirect(redirectUrl)
     } catch (e) {
-      throw new HTTPException(401, { res: badResponse })
+      throw new HTTPException(401, {
+        res: new Response('Unauthorized', {
+          status: 401,
+        }),
+      })
     }
   }
 }
 
-export const appwriteAuth2Save = (redirect?: string) => {
+export const appwriteOAuth2Save = (redirect?: string) => {
   return async (c: Context) => {
     const adminClient = c.get('adminClient')
     const config      = c.get('appwriteConfig')
@@ -123,7 +136,11 @@ export const appwriteAuth2Save = (redirect?: string) => {
 
       return c.json({ success: true })
     } catch (e) {
-      throw new HTTPException(401, { res: badResponse })
+      throw new HTTPException(401, {
+        res: new Response('Unauthorized', {
+          status: 401,
+        }),
+      })
     }
   }
 }

--- a/packages/appwrite-auth/src/test.server.ts
+++ b/packages/appwrite-auth/src/test.server.ts
@@ -1,0 +1,7 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+
+const app = new Hono()
+app.get('/', (c) => c.text('Hello Node.js!'))
+
+serve(app)

--- a/packages/appwrite-auth/src/test.server.ts
+++ b/packages/appwrite-auth/src/test.server.ts
@@ -1,7 +1,0 @@
-import { serve } from '@hono/node-server'
-import { Hono } from 'hono'
-
-const app = new Hono()
-app.get('/', (c) => c.text('Hello Node.js!'))
-
-serve(app)

--- a/packages/appwrite-auth/tsconfig.json
+++ b/packages/appwrite-auth/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "types": [
+      "node"
+    ],
+    "rootDir": "./src",
+    "outDir": "./dist",
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+}

--- a/packages/appwrite-auth/vitest.config.ts
+++ b/packages/appwrite-auth/vitest.config.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,7 +1376,7 @@ __metadata:
     "@hono/node-server": "npm:^1.8.2"
     "@types/node": "npm:^20.11.17"
     hono: "npm:^3.11.7"
-    node-appwrite: ../../../sdk-for-node
+    node-appwrite: "npm:^12.0.0"
     tsup: "npm:^8.0.1"
     tsx: "npm:^3.12.2"
     vitest: "npm:^1.0.4"
@@ -13033,12 +13033,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-appwrite@file:../../../sdk-for-node::locator=%40hono%2Fappwrite-auth%40workspace%3Apackages%2Fappwrite-auth":
-  version: 12.0.0-rc.6
-  resolution: "node-appwrite@file:../../../sdk-for-node#../../../sdk-for-node::hash=1789d2&locator=%40hono%2Fappwrite-auth%40workspace%3Apackages%2Fappwrite-auth"
+"node-appwrite@npm:^12.0.0":
+  version: 12.0.0
+  resolution: "node-appwrite@npm:12.0.0"
   dependencies:
     undici: "npm:^5.28.2"
-  checksum: 658b70a62ae2aebc833cd9bfbd2b8d3ff1b837543c129e4827ba55557386c174d30f248fde8f23e2acb334d55841d072ccd696a71d6758a51bb2a13c1a2ce9d5
+  checksum: f3d76528d2d3839f5f25dc40bfa26c689dbfecffea8cb23cc3a9782ca6fcbec676917cfdec1f46dbb4e382666e89626af8a3f81e8ff5ce19488b56c8b168999b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,6 +1369,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hono/appwrite-auth@workspace:packages/appwrite-auth":
+  version: 0.0.0-use.local
+  resolution: "@hono/appwrite-auth@workspace:packages/appwrite-auth"
+  dependencies:
+    "@hono/node-server": "npm:^1.8.2"
+    "@types/node": "npm:^20.11.17"
+    hono: "npm:^3.11.7"
+    node-appwrite: ../../../sdk-for-node
+    tsup: "npm:^8.0.1"
+    tsx: "npm:^3.12.2"
+    vitest: "npm:^1.0.4"
+  peerDependencies:
+    hono: "*"
+  languageName: unknown
+  linkType: soft
+
 "@hono/arktype-validator@workspace:packages/arktype-validator":
   version: 0.0.0-use.local
   resolution: "@hono/arktype-validator@workspace:packages/arktype-validator"
@@ -1538,6 +1554,13 @@ __metadata:
     hono: ">=3.8.0"
   languageName: unknown
   linkType: soft
+
+"@hono/node-server@npm:^1.8.2":
+  version: 1.8.2
+  resolution: "@hono/node-server@npm:1.8.2"
+  checksum: 17028ba797d8f735ba5dbf745e577bbee208a5ffb739e15645bf3cfb1ceb9bfa9800668e03b14472fa43271d8549141d0621cdcc4d0e3665cb4e0c58826d533d
+  languageName: node
+  linkType: hard
 
 "@hono/oauth-providers@workspace:packages/oauth-providers":
   version: 0.0.0-use.local
@@ -3674,6 +3697,15 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^20.11.17":
+  version: 20.11.21
+  resolution: "@types/node@npm:20.11.21"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 52b1cdfe8b14a67ab98c01b2e9621994b34a2537368e108fb925121a9d5958eb7344a2fb81ff36964932d5e5a093de8897f021bded10cad3536fd31e932b3000
   languageName: node
   linkType: hard
 
@@ -6889,7 +6921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.18.10, esbuild@npm:^0.18.2":
+"esbuild@npm:^0.18.10, esbuild@npm:^0.18.2, esbuild@npm:~0.18.20":
   version: 0.18.20
   resolution: "esbuild@npm:0.18.20"
   dependencies:
@@ -8356,7 +8388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.5.0":
+"get-tsconfig@npm:^4.5.0, get-tsconfig@npm:^4.7.2":
   version: 4.7.2
   resolution: "get-tsconfig@npm:4.7.2"
   dependencies:
@@ -12984,6 +13016,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-appwrite@file:../../../sdk-for-node::locator=%40hono%2Fappwrite-auth%40workspace%3Apackages%2Fappwrite-auth":
+  version: 12.0.0-rc.6
+  resolution: "node-appwrite@file:../../../sdk-for-node#../../../sdk-for-node::hash=1789d2&locator=%40hono%2Fappwrite-auth%40workspace%3Apackages%2Fappwrite-auth"
+  dependencies:
+    undici: "npm:^5.28.2"
+  checksum: 658b70a62ae2aebc833cd9bfbd2b8d3ff1b837543c129e4827ba55557386c174d30f248fde8f23e2acb334d55841d072ccd696a71d6758a51bb2a13c1a2ce9d5
+  languageName: node
+  linkType: hard
+
 "node-emoji@npm:^1.11.0":
   version: 1.11.0
   resolution: "node-emoji@npm:1.11.0"
@@ -15578,6 +15619,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:^0.5.21":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: "npm:^1.0.0"
+    source-map: "npm:^0.6.0"
+  checksum: 9ee09942f415e0f721d6daad3917ec1516af746a8120bba7bb56278707a37f1eb8642bde456e98454b8a885023af81a16e646869975f06afc1a711fb90484e7d
+  languageName: node
+  linkType: hard
+
 "source-map@npm:0.7.4, source-map@npm:^0.7.0":
   version: 0.7.4
   resolution: "source-map@npm:0.7.4"
@@ -16710,6 +16761,23 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 02f19e458ec78ead8fffbf711f834ad8ecd2cc6ade4ec0320790713dccc0a412b99e7fd907c4cda2a1dc602c75db6f12e0108e87a5afad4b2f9e90a24cabd5a2
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^3.12.2":
+  version: 3.14.0
+  resolution: "tsx@npm:3.14.0"
+  dependencies:
+    esbuild: "npm:~0.18.20"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.2"
+    source-map-support: "npm:^0.5.21"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: b6c938bdae9c656aef2aa0130ee6aa8f3487b5d411d5f7934b705c28ff44ab268db3dde123cf5237b4e5e2ab4441a0bad4b1a39e3ff2170d138538e44082f05d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

Appwrite has added Server-Side login as you can see [here](https://www.youtube.com/watch?v=jeL4cSovOBA) and [here](https://appwrite.io/docs/products/auth/server-side-rendering)

This is the first step toward creating an auth middleware to be used with Appwrite.

This middleware also provides 2 helpers for making the process of email and OAuth2 login much easier.