### PR TITLE
fix(zod-openapi): Fix basePath method to transfer defaultHook of the parent app.

### DIFF
--- a/.changeset/quiet-shrimps-rescue.md
+++ b/.changeset/quiet-shrimps-rescue.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: Fix basePath method disregarding defaultHook

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -409,7 +409,7 @@ export class OpenAPIHono<
   }
 
   basePath<SubPath extends string>(path: SubPath): OpenAPIHono<E, S, MergePath<BasePath, SubPath>> {
-    return new OpenAPIHono(super.basePath(path) as any)
+    return new OpenAPIHono({...super.basePath(path) as any, defaultHook: this.defaultHook})
   }
 }
 

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -1279,9 +1279,7 @@ describe('Named params in nested routes', () => {
   it('Should return a correct path', async () => {
     const res = await root.request('/doc')
     expect(res.status).toBe(200)
-    const data: {
-      paths: { string: unknown }
-    } = await res.json()
+    const data = await res.json()
     expect(Object.keys(data['paths'])[0]).toBe('/root/{rootId}/sub/{subId}')
   })
 })

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -823,6 +823,15 @@ describe('basePath()', () => {
     const res = await app.request('/api/doc')
     expect(res.status).toBe(200)
   })
+
+  it('Should retain defaultHook of the parent app', async () => {
+    const defaultHook = () => {}
+    const app = new OpenAPIHono({
+      defaultHook
+    }).basePath('/api')
+    expect(app.defaultHook).toBeDefined()
+    expect(app.defaultHook).toBe(defaultHook)
+  })
 })
 
 describe('With hc', () => {
@@ -1270,7 +1279,9 @@ describe('Named params in nested routes', () => {
   it('Should return a correct path', async () => {
     const res = await root.request('/doc')
     expect(res.status).toBe(200)
-    const data = await res.json()
+    const data: {
+      paths: { string: unknown }
+    } = await res.json()
     expect(Object.keys(data['paths'])[0]).toBe('/root/{rootId}/sub/{subId}')
   })
 })


### PR DESCRIPTION
There is currently an issue with basePath method where it does not transfer defaultHook to the newly created instance.
This pull request fixes it.

In the following code (taken from the current docs) the defaultHook is never called because it does not exist on the new instance created when basePath method is called.

```
const app = new OpenAPIHono({
  defaultHook: (result, c) => {
    if (!result.success) {
      return c.json(
        {
          ok: false,
          errors: formatZodErrors(result),
          source: 'custom_error_handler',
        },
        422
      )
    }
  },
}).basePath('/api/v1')