### PR TITLE
feat(zod-openapi): Add `toDoc` function to generate OpenAPI specification files

### DIFF
--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -362,7 +362,8 @@ const app = new OpenAPIHono()
 
 // Define your routes and schemas...
 
-await toDoc(app, fs, {
+const paths: string[] = ['/doc']
+await toDoc(app, fs, paths, {
   outDir: './docs',
   format: 'yaml',    // default 'json'
   extension: '.yml',

--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -350,6 +350,25 @@ app.doc('/doc', c => ({
 }))
 ```
 
+### Exporting OpenAPI Specification
+
+You can export the OpenAPI specification of your Hono application using the `toDoc` function. 
+
+```ts
+import { OpenAPIHono, toDoc } from '@hono/zod-openapi'
+import fs from 'fs/promises'
+
+const app = new OpenAPIHono()
+
+// Define your routes and schemas...
+
+await toDoc(app, fs, {
+  outDir: './docs',
+  format: 'yaml',    // default 'json'
+  extension: '.yml',
+})
+```
+
 ## Limitations
 
 ### Combining with `Hono`

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -38,7 +38,8 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=3.11.3",
-    "zod": "3.*"
+    "zod": "3.*",
+    "yaml": "^2.4.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240117.0",
@@ -52,8 +53,7 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^5.5.0",
-    "@hono/zod-validator": "0.1.11",
-    "yaml": "^2.4.0"
+    "@hono/zod-validator": "0.1.11"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -52,7 +52,8 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^5.5.0",
-    "@hono/zod-validator": "0.1.11"
+    "@hono/zod-validator": "0.1.11",
+    "yaml": "^2.4.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/zod-openapi/src/export.ts
+++ b/packages/zod-openapi/src/export.ts
@@ -2,7 +2,6 @@ import { stringify as yamlStringify } from 'yaml'
 import type { OpenAPIHono } from './index'
 
 export interface ToFilesOptions {
-  paths?: string[]
   outDir?: string
   format?: 'json' | 'yaml'
   extension?: string
@@ -37,10 +36,11 @@ const fetchAndSaveOpenAPIDocument = async (app: OpenAPIHono, fs: FileSystem, doc
 export const toFiles = async (
   app: OpenAPIHono,
   fs: FileSystem,
+  paths: string[],
   options: ToFilesOptions = {}
 ): Promise<ToFilesResult> => {
-  const { paths, outDir = './dist', format = 'json', extension } = options
-  if (!paths || paths.length === 0) {
+  const { outDir = './dist', format = 'json', extension } = options
+  if (paths.length === 0) {
     return { success: false, outDir, files: [], error: new Error('OpenAPI document endpoints are not specified') }
   }
 

--- a/packages/zod-openapi/src/export.ts
+++ b/packages/zod-openapi/src/export.ts
@@ -1,7 +1,7 @@
 import { stringify as yamlStringify } from 'yaml'
 import type { OpenAPIHono } from './index'
 
-export interface ToDocOptions {
+export interface ToFilesOptions {
   outDir?: string
   format?: 'json' | 'yaml'
   extension?: string
@@ -12,18 +12,18 @@ export interface FileSystem {
   mkdir(path: string, options: { recursive: boolean }): Promise<void | string>
 }
 
-export interface ToDocResult {
+export interface ToFilesResult {
   success: boolean
   outDir: string
   files: string[]
   error?: Error
 }
 
-export const toDoc = async (
+export const ToFiles = async (
   app: OpenAPIHono,
   fs: FileSystem,
-  options: ToDocOptions = {}
-): Promise<ToDocResult> => {
+  options: ToFilesOptions = {}
+): Promise<ToFilesResult> => {
   const { outDir = './dist', format = 'json', extension } = options
 
   try {
@@ -43,7 +43,7 @@ export const toDoc = async (
 
     await fs.writeFile(filePath, content)
 
-    const result: ToDocResult = {
+    const result: ToFilesResult = {
       success: true,
       outDir,
       files: [filePath],

--- a/packages/zod-openapi/src/export.ts
+++ b/packages/zod-openapi/src/export.ts
@@ -1,0 +1,86 @@
+import type { OpenAPIHono } from './index'
+import { stringify as yamlStringify } from 'yaml'
+
+export interface ExportOptions {
+  outDir?: string
+  format?: 'json' | 'yaml'
+  extension?: string
+  beforeRequestHook?: BeforeRequestHook
+  afterResponseHook?: AfterResponseHook
+  afterExportHook?: AfterExportHook
+}
+
+export interface FileSystem {
+  writeFile(path: string, data: string | Uint8Array): Promise<void>
+  mkdir(path: string, options: { recursive: boolean }): Promise<void | string>
+}
+
+export type BeforeRequestHook = (req: Request) => Request | false
+export type AfterResponseHook = (res: Response) => Response | false
+export type AfterExportHook = (result: ExportResult) => void | Promise<void>
+
+export interface ExportResult {
+  success: boolean
+  outDir: string
+  files: string[]
+  error?: Error
+}
+
+export async function exportOpenAPI(
+  app: OpenAPIHono,
+  fs: FileSystem,
+  options: ExportOptions = {}
+): Promise<ExportResult> {
+  const { outDir = './dist', format = 'json', extension } = options
+
+  try {
+    await fs.mkdir(outDir, { recursive: true })
+
+    const files: string[] = []
+
+    const openApiJson = app.getOpenAPIDocument({
+      info: {
+        title: 'API Document',
+        version: '1.0.0',
+      },
+      openapi: '',
+    })
+
+    const ext = getExtension(format, extension)
+    const filePath = `${outDir}/openapi${ext}`
+
+    const content = getContent(openApiJson, format)
+
+    await fs.writeFile(filePath, content)
+    files.push(filePath)
+
+    const result: ExportResult = {
+      success: true,
+      outDir,
+      files,
+    }
+
+    return result
+  } catch (error) {
+    return {
+      success: false,
+      outDir,
+      files: [],
+      error: error as Error,
+    }
+  }
+}
+
+function getExtension(format?: string, extension?: string): string {
+  if (extension) return extension
+  if (format === 'yaml') return '.yaml'
+  return '.json'
+}
+
+function getContent(openApiJson: unknown, format: string): string {
+  if (format === 'yaml') {
+    return yamlStringify(openApiJson)
+  } else {
+    return JSON.stringify(openApiJson, null, 2)
+  }
+}

--- a/packages/zod-openapi/src/export.ts
+++ b/packages/zod-openapi/src/export.ts
@@ -2,7 +2,7 @@ import { stringify as yamlStringify } from 'yaml'
 import type { OpenAPIHono } from './index'
 
 export interface ToFilesOptions {
-  routes?: string[]
+  paths?: string[]
   outDir?: string
   format?: 'json' | 'yaml'
   extension?: string
@@ -39,17 +39,17 @@ export const toFiles = async (
   fs: FileSystem,
   options: ToFilesOptions = {}
 ): Promise<ToFilesResult> => {
-  const { routes, outDir = './dist', format = 'json', extension } = options
-  if (!routes || routes.length === 0) {
+  const { paths, outDir = './dist', format = 'json', extension } = options
+  if (!paths || paths.length === 0) {
     return { success: false, outDir, files: [], error: new Error('OpenAPI document endpoints are not specified') }
   }
 
   await fs.mkdir(outDir, { recursive: true })
 
-  const tasks = routes.map(docEndpointPath => {
-    const filePath = generateFilePath(outDir, docEndpointPath, format, extension)
-    return fetchAndSaveOpenAPIDocument(app, fs, docEndpointPath, filePath, format)
-      .catch(error => ({ error, docEndpointPath })) // エラーハンドリング
+  const tasks = paths.map(path => {
+    const filePath = generateFilePath(outDir, path, format, extension)
+    return fetchAndSaveOpenAPIDocument(app, fs, path, filePath, format)
+      .catch(error => ({ error, path }))
   })
 
   const results = await Promise.all(tasks)

--- a/packages/zod-openapi/src/export.ts
+++ b/packages/zod-openapi/src/export.ts
@@ -19,7 +19,7 @@ export interface ToDocResult {
   error?: Error
 }
 
-export const ToDoc = async (
+export const toDoc = async (
   app: OpenAPIHono,
   fs: FileSystem,
   options: ToDocOptions = {}

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -430,3 +430,4 @@ export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'
 
 extendZodWithOpenApi(z)
 export { z }
+export { exportDoc } from './export'

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -430,4 +430,4 @@ export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'
 
 extendZodWithOpenApi(z)
 export { z }
-export { toDoc } from './export'
+export { toFiles, ToFilesOptions, ToFilesResult } from './export'

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -430,4 +430,4 @@ export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'
 
 extendZodWithOpenApi(z)
 export { z }
-export { exportDoc } from './export'
+export { toDoc } from './export'

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -409,7 +409,7 @@ export class OpenAPIHono<
   }
 
   basePath<SubPath extends string>(path: SubPath): OpenAPIHono<E, S, MergePath<BasePath, SubPath>> {
-    return new OpenAPIHono({...super.basePath(path) as any, defaultHook: this.defaultHook})
+    return new OpenAPIHono({ ...(super.basePath(path) as any), defaultHook: this.defaultHook })
   }
 }
 

--- a/packages/zod-openapi/test/export.test.ts
+++ b/packages/zod-openapi/test/export.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { OpenAPIHono } from '../src/index'
+import { toDoc, FileSystem } from '../src/export'
+
+describe('toDoc', () => {
+  let app: OpenAPIHono
+  let fs: FileSystem
+
+  beforeEach(() => {
+    app = new OpenAPIHono()
+    fs = {
+      writeFile: vi.fn(),
+      mkdir: vi.fn(),
+    }
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should export OpenAPI document successfully', async () => {
+    app.doc('/api-docs', () => ({
+      openapi: '3.0.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+    }))
+
+    const result = await toDoc(app, fs)
+
+    expect(result.success).toBe(true)
+    expect(result.outDir).toBe('./dist')
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]).toBe('./dist/openapi.json')
+    expect(fs.mkdir).toHaveBeenCalledWith('./dist', { recursive: true })
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      './dist/openapi.json',
+      expect.any(String)
+    )
+  })
+
+  it('should export OpenAPI document in YAML format', async () => {
+    app.doc('/api-docs', () => ({
+      openapi: '3.0.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+    }))
+
+    const result = await toDoc(app, fs, { format: 'yaml' })
+
+    expect(result.success).toBe(true)
+    expect(result.outDir).toBe('./dist')
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]).toBe('./dist/openapi.yaml')
+    expect(fs.mkdir).toHaveBeenCalledWith('./dist', { recursive: true })
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      './dist/openapi.yaml',
+      expect.any(String)
+    )
+  })
+
+  it('should handle export error', async () => {
+    vi.spyOn(app, 'request').mockRejectedValue(new Error('Export error'))
+
+    app.doc('/api-docs', () => ({
+      openapi: '3.0.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+    }))
+
+    const result = await toDoc(app, fs)
+
+    expect(result.success).toBe(false)
+    expect(result.outDir).toBe('./dist')
+    expect(result.files).toHaveLength(0)
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error?.message).toBe('Export error')
+  })
+
+  it('should throw error if OpenAPI document endpoint not found', async () => {
+    const result = await toDoc(app, fs)
+
+    expect(result.success).toBe(false)
+    expect(result.outDir).toBe('./dist')
+    expect(result.files).toHaveLength(0)
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error?.message).toBe('OpenAPI document endpoint not found')
+ 
+  })
+})

--- a/packages/zod-openapi/test/export.test.ts
+++ b/packages/zod-openapi/test/export.test.ts
@@ -27,7 +27,8 @@ describe('toFiles', () => {
       },
     }))
 
-    const result = await toFiles(app, fs, { paths:['/api-docs'] })
+    const paths: string[] = ['/api-docs']
+    const result = await toFiles(app, fs, paths)
 
     expect(result.success).toBe(true)
     expect(result.outDir).toBe('./dist')
@@ -49,7 +50,8 @@ describe('toFiles', () => {
       },
     }))
 
-    const result = await toFiles(app, fs, { format: 'yaml', paths: ['/api-docs'] })
+    const paths: string[] = ['/api-docs']
+    const result = await toFiles(app, fs, paths, { format: 'yaml'})
     const expectedYAMLContent = `openapi: 3.0.0
 info:
   title: Test API
@@ -86,7 +88,8 @@ paths: {}
       },
     }))
 
-    const result = await toFiles(app, fs, { format: 'yaml', paths: ['/api-docs', '/api-docs31'] })
+    const paths: string[] = ['/api-docs', '/api-docs31'] 
+    const result = await toFiles(app, fs, paths, { format: 'yaml'})
     const expectedYAMLContent = `openapi: 3.0.0
 info:
   title: Test API
@@ -131,7 +134,7 @@ webhooks: {}
       },
     }))
 
-    const result = await toFiles(app, fs)
+    const result = await toFiles(app, fs, [])
 
     expect(result.success).toBe(false)
     expect(result.outDir).toBe('./dist')
@@ -141,7 +144,7 @@ webhooks: {}
   })
 
   it('should throw error if OpenAPI document endpoint not found', async () => {
-    const result = await toFiles(app, fs)
+    const result = await toFiles(app, fs, [])
 
     expect(result.success).toBe(false)
     expect(result.outDir).toBe('./dist')

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -827,7 +827,7 @@ describe('basePath()', () => {
   it('Should retain defaultHook of the parent app', async () => {
     const defaultHook = () => {}
     const app = new OpenAPIHono({
-      defaultHook
+      defaultHook,
     }).basePath('/api')
     expect(app.defaultHook).toBeDefined()
     expect(app.defaultHook).toBe(defaultHook)

--- a/packages/zod-openapi/yarn.lock
+++ b/packages/zod-openapi/yarn.lock
@@ -600,6 +600,7 @@ __metadata:
     tsup: "npm:^8.0.1"
     typescript: "npm:^5.3.3"
     vitest: "npm:^1.0.1"
+    yaml: "npm:^2.4.0"
     zod: "npm:^3.22.1"
   peerDependencies:
     hono: ">=3.11.3"
@@ -4826,6 +4827,15 @@ __metadata:
   version: 2.3.4
   resolution: "yaml@npm:2.3.4"
   checksum: cf03b68f8fef5e8516b0f0b54edaf2459f1648317fc6210391cf606d247e678b449382f4bd01f77392538429e306c7cba8ff46ff6b37cac4de9a76aff33bd9e1
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "yaml@npm:2.4.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 97ab0b5a0714c92e4dd75120a6a63e470b0adc282afae0a701bf38f8c42cbf6429fcd6aca883e3a63c68936ab841862e6c69e2d66d355c3e4fc7cfd346af2108
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Introduces a new function called `toDoc` that allows users to generate OpenAPI specification files.

### features:

Accepts a Hono application instance, a file system module, and optional configurations
Supports exporting in JSON or YAML format
Returns an export result object with success status, output directory, generated files, and error (if any)

### Usage:

```ts
import { OpenAPIHono, toDoc } from '@hono/zod-openapi'
import fs from 'fs/promises'

const app = new OpenAPIHono()

// Define routes and schemas...

await exportOpenAPI(app, fs, {
  outDir: './docs',
  format: 'yaml',
  extension: '.yml',
})
```

### Configuration options:

- outDir: Output directory for the generated files (default: './dist')
- format: File format, either 'json' or 'yaml' (default: 'json')
- extension: File extension (default: based on format)