### PR TITLE
fix(react-renderer): fix overwriting headers when stream is enabled

### DIFF
--- a/.changeset/twenty-windows-raise.md
+++ b/.changeset/twenty-windows-raise.md
@@ -1,0 +1,5 @@
+---
+'@hono/react-renderer': patch
+---
+
+fix: overwriting headers when stream is enabled

--- a/packages/react-renderer/src/react-renderer.ts
+++ b/packages/react-renderer/src/react-renderer.ts
@@ -30,15 +30,15 @@ const createRenderer =
         React.createElement(RequestContext.Provider, { value: c }, node),
         options.readableStreamOptions
       )
-      return c.body(stream, {
-        headers:
-          options.stream === true
-            ? {
-                'Transfer-Encoding': 'chunked',
-                'Content-Type': 'text/html; charset=UTF-8',
-              }
-            : options.stream,
-      })
+      if (options.stream === true) {
+        c.header('Transfer-Encoding', 'chunked')
+        c.header('Content-Type', 'text/html; charset=UTF-8')
+      } else {
+        for (const [key, value] of Object.entries(options.stream)) {
+          c.header(key, value)
+        }
+      }
+      return c.body(stream)
     } else {
       const docType =
         typeof options?.docType === 'string'


### PR DESCRIPTION
Correct the following issue

- https://github.com/honojs/middleware/issues/418