### PR TITLE
fix(zod-validator): fix export for esm module

### DIFF
--- a/.changeset/quiet-bulldogs-deny.md
+++ b/.changeset/quiet-bulldogs-deny.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': patch
+---
+
+fix export esm module

--- a/packages/zod-validator/jest.config.js
+++ b/packages/zod-validator/jest.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../jest.config.js')

--- a/packages/zod-validator/package.cjs.json
+++ b/packages/zod-validator/package.cjs.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -2,6 +2,7 @@
   "name": "@hono/zod-validator",
   "version": "0.2.0",
   "description": "Validator middleware using Zod",
+  "type": "module",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -21,8 +21,7 @@
     "copy:package.cjs.json": "cp ./package.cjs.json ./dist/cjs/package.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
-    "build": "rimraf dist && yarn build:cjs && yarn build:esm",
-    "build2": "rimraf dist && yarn build:cjs && yarn build:esm && yarn copy:package.cjs.json",
+    "build": "rimraf dist && yarn build:cjs && yarn build:esm && yarn copy:package.cjs.json",
     "prerelease": "yarn build && yarn test",
     "release": "yarn publish"
   },

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "vitest --run",
     "copy:package.cjs.json": "cp ./package.cjs.json ./dist/cjs/package.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
@@ -44,6 +44,7 @@
     "jest": "^29.7.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3",
+    "vitest": "^1.4.0",
     "zod": "^3.22.4"
   }
 }

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -5,14 +5,23 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
     "test": "jest",
+    "copy:package.cjs.json": "cp ./package.cjs.json ./dist/cjs/package.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build": "rimraf dist && yarn build:cjs && yarn build:esm",
+    "build2": "rimraf dist && yarn build:cjs && yarn build:esm && yarn copy:package.cjs.json",
     "prerelease": "yarn build && yarn test",
     "release": "yarn publish"
   },

--- a/packages/zod-validator/vitest.config.ts
+++ b/packages/zod-validator/vitest.config.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,6 +2163,7 @@ __metadata:
     jest: "npm:^29.7.0"
     rimraf: "npm:^5.0.5"
     typescript: "npm:^5.3.3"
+    vitest: "npm:^1.4.0"
     zod: "npm:^3.22.4"
   peerDependencies:
     hono: ">=3.9.0"
@@ -4530,6 +4531,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@vitest/expect@npm:1.4.0"
+  dependencies:
+    "@vitest/spy": "npm:1.4.0"
+    "@vitest/utils": "npm:1.4.0"
+    chai: "npm:^4.3.10"
+  checksum: 2d6a657afc674adb78ad6609ecf61a94355b080cf90f922e05193b5b33b37d486c9b66a52270f1f367c16d626bcb8323368519dae096a992190898e03280b5e0
+  languageName: node
+  linkType: hard
+
 "@vitest/runner@npm:0.34.6":
   version: 0.34.6
   resolution: "@vitest/runner@npm:0.34.6"
@@ -4571,6 +4583,17 @@ __metadata:
     p-limit: "npm:^5.0.0"
     pathe: "npm:^1.1.1"
   checksum: d732de2368d2bc32cbc27f0bbc5477f6e36088ddfb873c036935a45b1b252ebc529b932cf5cd944eed9b692243acebef828f6d3218583cb8a6817a8270712050
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@vitest/runner@npm:1.4.0"
+  dependencies:
+    "@vitest/utils": "npm:1.4.0"
+    p-limit: "npm:^5.0.0"
+    pathe: "npm:^1.1.1"
+  checksum: 87a5bdde5c48e3258ecd2716994da20c8eec63acaf63a0db724513a42701bc644728009a7301d78b8775d8004c7ce1ddb8bde6495066d864c532bc117783aa91
   languageName: node
   linkType: hard
 
@@ -4618,6 +4641,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/snapshot@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@vitest/snapshot@npm:1.4.0"
+  dependencies:
+    magic-string: "npm:^0.30.5"
+    pathe: "npm:^1.1.1"
+    pretty-format: "npm:^29.7.0"
+  checksum: 6f089d1dbe43556779479bc309b0a8fc7e0229843c40efb4dabcf99ccf9a6fa859dd38c13674616a955801442730aca55151cbd52bb22d41d9a335060e03759b
+  languageName: node
+  linkType: hard
+
 "@vitest/spy@npm:0.34.6":
   version: 0.34.6
   resolution: "@vitest/spy@npm:0.34.6"
@@ -4651,6 +4685,15 @@ __metadata:
   dependencies:
     tinyspy: "npm:^2.2.0"
   checksum: efc42f679d2a51fc6583ca3136ccd47581cb27c923ed3cb0500f5dee9aac99b681bfdd400c16ef108f2e0761daa642bc190816a6411931a2aba99ebf8b213dd4
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@vitest/spy@npm:1.4.0"
+  dependencies:
+    tinyspy: "npm:^2.2.0"
+  checksum: 847bc3085d0aa2e039aa42d803cf2dc94596aab3a63de7d364933d24ed9e0781b7d3d4bd222df202f92bae83e9c37b2893b9f24a2de7d83b6930b7b1acf43516
   languageName: node
   linkType: hard
 
@@ -4697,6 +4740,18 @@ __metadata:
     loupe: "npm:^2.3.7"
     pretty-format: "npm:^29.7.0"
   checksum: d604c8ad3b1aee30d4dcd889098f591407bfe18547ff96485b1d1ed54eff58219c756a9544a7fbd4e37886863abacd7a89a76334cb3ea7f84c3d496bb757db23
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@vitest/utils@npm:1.4.0"
+  dependencies:
+    diff-sequences: "npm:^29.6.3"
+    estree-walker: "npm:^3.0.3"
+    loupe: "npm:^2.3.7"
+    pretty-format: "npm:^29.7.0"
+  checksum: cfa352484f0ea2614444a94fc35979bea94fac64e9756238c685ae74bcd027893a1798b9d6d92c1cdd454b1f7f08f453d0cca108274f0449b6f5efd345822a4c
   languageName: node
   linkType: hard
 
@@ -18269,6 +18324,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:1.4.0":
+  version: 1.4.0
+  resolution: "vite-node@npm:1.4.0"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.3.4"
+    pathe: "npm:^1.1.1"
+    picocolors: "npm:^1.0.0"
+    vite: "npm:^5.0.0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: bc8eb01dd03c2cc306be2bf35efe789d6a3e8ca1d89d635d3154a9af0213f7609c94ef849f30a01f04535b31e729aee49468275e267693a42c32845fbd2a6721
+  languageName: node
+  linkType: hard
+
 "vite@npm:^3.0.0 || ^4.0.0 || ^5.0.0-0, vite@npm:^3.1.0 || ^4.0.0 || ^5.0.0-0, vite@npm:^5.0.0":
   version: 5.0.10
   resolution: "vite@npm:5.0.10"
@@ -18557,6 +18627,56 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: 66d312a3dc12e67bba22d31332d939e89cd17d38531893c7b13b8826704564031c1dde795df2799b855660572c19a595301e920710c7775d072ee6332502efc5
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "vitest@npm:1.4.0"
+  dependencies:
+    "@vitest/expect": "npm:1.4.0"
+    "@vitest/runner": "npm:1.4.0"
+    "@vitest/snapshot": "npm:1.4.0"
+    "@vitest/spy": "npm:1.4.0"
+    "@vitest/utils": "npm:1.4.0"
+    acorn-walk: "npm:^8.3.2"
+    chai: "npm:^4.3.10"
+    debug: "npm:^4.3.4"
+    execa: "npm:^8.0.1"
+    local-pkg: "npm:^0.5.0"
+    magic-string: "npm:^0.30.5"
+    pathe: "npm:^1.1.1"
+    picocolors: "npm:^1.0.0"
+    std-env: "npm:^3.5.0"
+    strip-literal: "npm:^2.0.0"
+    tinybench: "npm:^2.5.1"
+    tinypool: "npm:^0.8.2"
+    vite: "npm:^5.0.0"
+    vite-node: "npm:1.4.0"
+    why-is-node-running: "npm:^2.2.2"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/node": ^18.0.0 || >=20.0.0
+    "@vitest/browser": 1.4.0
+    "@vitest/ui": 1.4.0
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 732ce229341f6777350d36020dc00ccf5dd2ac0da39424cf5c9f6f4116ed1b6f7bb56de5a11270c693214d817b6d121d3d326e8f5a73437ec3f4c65aa07e1f52
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem:

Deno loading cjs file instead of esm module.
 
<details><summary>Сode with incorrect behavior</summary>
<p>

```typescript
#!/usr/bin/env -S deno run -Ar --watch

import {zValidator} from 'npm:@hono/zod-validator'
import {Hono} from 'npm:hono'
import {z} from 'npm:zod'

const app = new Hono()
const schema = z.object({val: z.string()})

app.post('/post', zValidator('form', schema), (c) => {
  return c.json(c.req.valid('form'))
})

{
  const res = await app.request('/post', {
    method: 'POST',
    headers: {'content-type': 'application/json'},
    body: JSON.stringify({val: 'text'}), // incorrect data
  })
  console.log(res.status, res.status === 400) // expected 400
  console.log(await res.text())
}
{
  const res = await app.request('/post', {
    method: 'POST',
    headers: {'content-type': 'application/x-www-form-urlencoded'},
    body: new URLSearchParams({val: 'text'}), // valid data
  })
  console.log(res.status, res.status === 200) // expected 200
  console.log(await res.text())
}
```

</p>
</details> 

## Error:
```powershell
Error: Malformed FormData request. Body can not be decoded as form data
    at file:///C:/Users/MAKS11060/AppData/Local/deno/npm/registry.npmjs.org/hono/4.1.3/dist/cjs/validator/validator.js:89:17
    at async dispatch (file:///C:/Users/MAKS11060/AppData/Local/deno/npm/registry.npmjs.org/hono/4.1.3/dist/compose.js:29:17)
    at async file:///C:/Users/MAKS11060/AppData/Local/deno/npm/registry.npmjs.org/hono/4.1.3/dist/hono-base.js:188:25
    at async file:///C:/Users/MAKS11060/code/deno-playground/10-deno-load.ts:15:15 {
  res: undefined,
  status: 400
}
500 false
Internal Server Error
```