### PR TITLE
zod-openapi: make getRoutingPath non-enumerable

### DIFF
--- a/.changeset/long-crabs-drum.md
+++ b/.changeset/long-crabs-drum.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Make getRoutingPath property of a RouteConfig non-enumerable

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -431,12 +431,13 @@ type RoutingPath<P extends string> = P extends `${infer Head}/{${infer Param}}${
 export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'> & { path: P }>(
   routeConfig: R
 ) => {
-  return {
+  const route = {
     ...routeConfig,
     getRoutingPath(): RoutingPath<R['path']> {
       return routeConfig.path.replaceAll(/\/{(.+?)}/g, '/:$1') as RoutingPath<P>
     },
   }
+  return Object.defineProperty(route, 'getRoutingPath', { enumerable: false })
 }
 
 extendZodWithOpenApi(z)

--- a/packages/zod-openapi/test/createRoute.test.ts
+++ b/packages/zod-openapi/test/createRoute.test.ts
@@ -50,11 +50,7 @@ describe('createRoute', () => {
       },
     } as const
     const route = createRoute(config)
-
-    expect(route).toEqual({
-      ...config,
-      getRoutingPath: expect.any(Function),
-    })
+    expect(route).toEqual(config)
     expect(route.getRoutingPath()).toBe(expected)
     expectTypeOf(route.getRoutingPath()).toEqualTypeOf<typeof expected>()
   })


### PR DESCRIPTION
This prevents potential serialisation errors (e.g. yaml's `stringify`) of the return value of getOpenAPIDocument.