### PR TITLE
Allow passing state in google oath middleware

### DIFF
--- a/.changeset/green-files-thank.md
+++ b/.changeset/green-files-thank.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': minor
+---
+
+Allow for an optional state arg to be passed to Google Auth middleware

--- a/packages/oauth-providers/src/providers/google/googleAuth.ts
+++ b/packages/oauth-providers/src/providers/google/googleAuth.ts
@@ -14,7 +14,7 @@ export function googleAuth(options: {
   state?: string
 }): MiddlewareHandler {
   return async (c, next) => {
-    const newState = getRandomState()
+    const newState = options.state || getRandomState()
     // Create new Auth instance
     const auth = new AuthFlow({
       client_id: options.client_id || (c.env?.GOOGLE_ID as string),
@@ -23,7 +23,7 @@ export function googleAuth(options: {
       login_hint: options.login_hint,
       prompt: options.prompt,
       scope: options.scope,
-      state: options.state || newState,
+      state: newState,
       code: c.req.query('code'),
       token: {
         token: c.req.query('access_token') as string,

--- a/packages/oauth-providers/src/providers/google/googleAuth.ts
+++ b/packages/oauth-providers/src/providers/google/googleAuth.ts
@@ -23,7 +23,7 @@ export function googleAuth(options: {
       login_hint: options.login_hint,
       prompt: options.prompt,
       scope: options.scope,
-      state: (options.state as string) || newState,
+      state: options.state || newState,
       code: c.req.query('code'),
       token: {
         token: c.req.query('access_token') as string,

--- a/packages/oauth-providers/src/providers/google/googleAuth.ts
+++ b/packages/oauth-providers/src/providers/google/googleAuth.ts
@@ -11,6 +11,7 @@ export function googleAuth(options: {
   prompt?: 'none' | 'consent' | 'select_account'
   client_id?: string
   client_secret?: string
+  state?: string
 }): MiddlewareHandler {
   return async (c, next) => {
     const newState = getRandomState()
@@ -22,7 +23,7 @@ export function googleAuth(options: {
       login_hint: options.login_hint,
       prompt: options.prompt,
       scope: options.scope,
-      state: newState,
+      state: (options.state as string) || newState,
       code: c.req.query('code'),
       token: {
         token: c.req.query('access_token') as string,


### PR DESCRIPTION
Minor adjustment to allow state to be a non required option while still falling back to the default random value if not provided