### PR TITLE
chore(peer-deps): install newer peer depenencies

### DIFF
--- a/.changeset/eighty-doors-pull.md
+++ b/.changeset/eighty-doors-pull.md
@@ -1,0 +1,7 @@
+---
+'@hono/typebox-validator': patch
+'@hono/valibot-validator': patch
+'@hono/clerk-auth': patch
+---
+
+Update peer dependencies so that newer validators can be installed.

--- a/packages/clerk-auth/package.json
+++ b/packages/clerk-auth/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "@clerk/backend": "0.30.*",
+    "@clerk/backend": ">=0.30.0 <1",
     "hono": ">=3.*"
   },
   "devDependencies": {

--- a/packages/typebox-validator/package.json
+++ b/packages/typebox-validator/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "@sinclair/typebox": "^0.31.15",
+    "@sinclair/typebox": ">=0.31.15 <1",
     "hono": ">=3.9.0"
   },
   "devDependencies": {

--- a/packages/valibot-validator/package.json
+++ b/packages/valibot-validator/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=3.9.0",
-    "valibot": "^0.13.1"
+    "valibot": ">=0.13.1 <1"
   },
   "devDependencies": {
     "hono": "^3.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,7 +1826,7 @@ __metadata:
     react: "npm:^18.2.0"
     tsup: "npm:^8.0.1"
   peerDependencies:
-    "@clerk/backend": 0.30.*
+    "@clerk/backend": ">=0.30.0 <1"
     hono: ">=3.*"
   languageName: unknown
   linkType: soft
@@ -2092,7 +2092,7 @@ __metadata:
     jest: "npm:^29.7.0"
     rimraf: "npm:^5.0.5"
   peerDependencies:
-    "@sinclair/typebox": ^0.31.15
+    "@sinclair/typebox": ">=0.31.15 <1"
     hono: ">=3.9.0"
   languageName: unknown
   linkType: soft
@@ -2121,7 +2121,7 @@ __metadata:
     valibot: "npm:^0.24.1"
   peerDependencies:
     hono: ">=3.9.0"
-    valibot: ^0.13.1
+    valibot: ">=0.13.1 <1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Widen the peer deps version range so that newer validation libraries can be installed. Fixes #442.

I followed the README instruction but am not familiar with changeset. Feel free to give some feedback if I made a mistake.