### PR TITLE
fix(auth-js): env AUTH_URL not working

### DIFF
--- a/.changeset/itchy-dolls-crash.md
+++ b/.changeset/itchy-dolls-crash.md
@@ -1,0 +1,5 @@
+---
+'@hono/auth-js': patch
+---
+
+fix env AUTH_URL not working

--- a/packages/auth-js/src/index.ts
+++ b/packages/auth-js/src/index.ts
@@ -30,7 +30,15 @@ export interface AuthConfig extends Omit<AuthConfigCore, 'raw'> {}
 export type ConfigHandler = (c: Context) => AuthConfig
 
 function reqWithEnvUrl(req: Request, authUrl?: string): Request {
-  return authUrl ? new Request(new URL(req.url, authUrl).href, req) : req
+  if (authUrl) {
+    const reqUrlObj = new URL(req.url)
+    const authUrlObj = new URL(authUrl)
+    const props = ['hostname', 'protocol', 'port', 'password', 'username'] as const
+    props.forEach(prop => reqUrlObj[prop] = authUrlObj[prop])
+    return new Request(reqUrlObj.href, req);
+  } else {
+    return req;
+  }
 }
 
 function setEnvDefaults(env: AuthEnv, config: AuthConfig) {

--- a/packages/auth-js/src/index.ts
+++ b/packages/auth-js/src/index.ts
@@ -29,7 +29,7 @@ export interface AuthConfig extends Omit<AuthConfigCore, 'raw'> {}
 
 export type ConfigHandler = (c: Context) => AuthConfig
 
-function reqWithEnvUrl(req: Request, authUrl?: string): Request {
+export function reqWithEnvUrl(req: Request, authUrl?: string): Request {
   if (authUrl) {
     const reqUrlObj = new URL(req.url)
     const authUrlObj = new URL(authUrl)

--- a/packages/auth-js/test/index.test.ts
+++ b/packages/auth-js/test/index.test.ts
@@ -1,7 +1,7 @@
 import { webcrypto } from 'node:crypto'
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
-import { authHandler, verifyAuth, initAuthConfig } from '../src'
+import { authHandler, verifyAuth, initAuthConfig, reqWithEnvUrl } from '../src'
 
 // @ts-expect-error - global crypto
 //needed for node 18 and below but should work in node 20 and above
@@ -80,5 +80,13 @@ describe('Auth.js Adapter Middleware', () => {
     const req = new Request('http://localhost/api/protected')
     const res = await app.request(req)
     expect(res.status).toBe(401)
+  })
+})
+
+describe('reqWithEnvUrl()', () => {
+  const req = new Request('http://request-base/request-path')
+  const newReq = reqWithEnvUrl(req, 'https://auth-url-base/auth-url-path')
+  it('Should rewrite the base path', () => {
+    expect(newReq.url.toString()).toBe('https://auth-url-base/request-path')
   })
 })


### PR DESCRIPTION
In the previous implementation, `AUTH_URL` was invalid because `c.req.raw` already includes the URL base. The provided URL base, `c.env.AUTH_URL`, will not be utilized. This issue will prevent the hono + auth.js project deployed behind a proxy from obtaining the correct `callback-url`.