### PR TITLE
fix: deprecated json response method

### DIFF
--- a/.changeset/ninety-rules-give.md
+++ b/.changeset/ninety-rules-give.md
@@ -1,0 +1,7 @@
+---
+'@hono/swagger-ui': patch
+'@hono/typebox-validator': patch
+'@hono/typia-validator': patch
+---
+
+Fixed a part of deprecated response json method in hono since v4.

--- a/packages/swagger-ui/README.md
+++ b/packages/swagger-ui/README.md
@@ -91,7 +91,7 @@ app.openapi(
     }
   }),
   (c) => {
-    return c.jsonT({
+    return c.json({
       message: 'hello'
     })
   }

--- a/packages/typebox-validator/test/index.test.ts
+++ b/packages/typebox-validator/test/index.test.ts
@@ -16,7 +16,7 @@ describe('Basic', () => {
 
   const route = app.post('/author', tbValidator('json', schema), (c) => {
     const data = c.req.valid('json')
-    return c.jsonT({
+    return c.json({
       success: true,
       message: `${data.name} is ${data.age}`,
     })

--- a/packages/typia-validator/README.md
+++ b/packages/typia-validator/README.md
@@ -17,7 +17,7 @@ interface Author {
 
   const route = app.post('/author', typiaValidator('json', validate), (c) => {
     const data = c.req.valid('json')
-    return c.jsonT({
+    return c.json({
       success: true,
       message: `${data.name} is ${data.age}`,
     })

--- a/packages/typia-validator/test/index.test.ts
+++ b/packages/typia-validator/test/index.test.ts
@@ -19,7 +19,7 @@ describe('Basic', () => {
 
   const route = app.post('/author', typiaValidator('json', validate), (c) => {
     const data = c.req.valid('json')
-    return c.jsonT({
+    return c.json({
       success: true,
       message: `${data.name} is ${data.age}`,
     })


### PR DESCRIPTION
Fixed a part of deprecated response json method in hono since v4.

`c.jsonT -> c.json`

source: [Migration Guide v3.12.x to v4.0.0](https://github.com/honojs/hono/blob/f2985492a30f14f9b2fbeffd5cc6b3aaeb34a2d1/docs/MIGRATION.md?plain=1#L11)