### PR TITLE
[valibot-validator] Fix Type Inference for number Types in `valibot-validator` Query

### DIFF
--- a/.changeset/thin-fireants-work.md
+++ b/.changeset/thin-fireants-work.md
@@ -1,0 +1,5 @@
+---
+'@hono/valibot-validator': patch
+---
+
+improved vvalidator to infer route types with number queries

--- a/packages/valibot-validator/package.json
+++ b/packages/valibot-validator/package.json
@@ -31,7 +31,7 @@
     "valibot": ">=0.13.1 <1"
   },
   "devDependencies": {
-    "hono": "^3.11.7",
+    "hono": "^4.0.10",
     "jest": "^29.7.0",
     "rimraf": "^5.0.5",
     "valibot": "^0.24.1"

--- a/packages/valibot-validator/test/index.test.ts
+++ b/packages/valibot-validator/test/index.test.ts
@@ -17,6 +17,7 @@ describe('Basic', () => {
   const querySchema = optional(
     object({
       search: optional(string()),
+      page: optional(number()),
     })
   )
 
@@ -47,7 +48,8 @@ describe('Basic', () => {
         } & {
           query?:
             | {
-                search?: string | undefined
+                search?: string | string[] | undefined
+                page?: string | string[] | undefined
               }
             | undefined
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,7 +2114,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hono/valibot-validator@workspace:packages/valibot-validator"
   dependencies:
-    hono: "npm:^3.11.7"
+    hono: "npm:^4.0.10"
     jest: "npm:^29.7.0"
     rimraf: "npm:^5.0.5"
     valibot: "npm:^0.24.1"


### PR DESCRIPTION
This PR will solves #501.

This includes changes below:

- Update `hono` version: Updated `hono` to the same version as zod-validator.
- Fix type inference: Corrected the type inference in `vValidator` based on the reference implementation in `zod-validator`.
- Add test for `number` query: Added a test case to validate type inference for `number` types in queries.
