### PR TITLE
Get email with github token

### DIFF
--- a/.changeset/lazy-files-appear.md
+++ b/.changeset/lazy-files-appear.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': minor
+---
+
+Requesting github for user email with token


### PR DESCRIPTION
GitHub OAuth apps now only send the public email. The middleware has been updated to request the user's email using the received token for both OAuth apps and GitHub Apps
