### PR TITLE
feat(trpc-server): use c.body to create response to avoid header loss

### DIFF
--- a/.changeset/chatty-plants-dance.md
+++ b/.changeset/chatty-plants-dance.md
@@ -1,0 +1,5 @@
+---
+'@hono/trpc-server': patch
+---
+
+use `c.body` to create response to avoid header loss

--- a/packages/trpc-server/package.json
+++ b/packages/trpc-server/package.json
@@ -28,11 +28,11 @@
   "homepage": "https://honojs.dev",
   "peerDependencies": {
     "@trpc/server": "^10.10.0",
-    "hono": ">=3.*"
+    "hono": ">=4.*"
   },
   "devDependencies": {
     "@trpc/server": "^10.10.0",
-    "hono": "^3.11.7",
+    "hono": "^4.3.6",
     "jest": "^29.7.0",
     "rimraf": "^5.0.5",
     "zod": "^3.20.2"

--- a/packages/trpc-server/src/index.ts
+++ b/packages/trpc-server/src/index.ts
@@ -32,7 +32,7 @@ export const trpcServer = ({
       }),
       endpoint,
       req: c.req.raw,
-    })
+    }).then((res) => c.body(res.body, res))
     return res
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,13 +2094,13 @@ __metadata:
   resolution: "@hono/trpc-server@workspace:packages/trpc-server"
   dependencies:
     "@trpc/server": "npm:^10.10.0"
-    hono: "npm:^3.11.7"
+    hono: "npm:^4.3.6"
     jest: "npm:^29.7.0"
     rimraf: "npm:^5.0.5"
     zod: "npm:^3.20.2"
   peerDependencies:
     "@trpc/server": ^10.10.0
-    hono: ">=3.*"
+    hono: ">=4.*"
   languageName: unknown
   linkType: soft
 
@@ -9637,6 +9637,13 @@ __metadata:
   version: 4.3.3
   resolution: "hono@npm:4.3.3"
   checksum: 2e02a563ab8461a56a97b59b1c31fd002179999a0323b3a44cbf8b69b92ad35cc8f38ba26a88b64caa71e2c1c39a1454d84473ed0c69f4e9573e7b3b064e0f58
+  languageName: node
+  linkType: hard
+
+"hono@npm:^4.3.6":
+  version: 4.3.6
+  resolution: "hono@npm:4.3.6"
+  checksum: 2e27eb1e90b392a5884af573179d29e3f717f5e803c2b90f1383488f42bc986810e8e714d5bb1205935fda1d3e9944b3262aed88e852ea44d0e13d799474fa5b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
in `trpc-server` middleware, we currently return the response directly which causes the respose to loose information about context. So if we set a header/cookie inside a trpc route, we don't get that in the respose.

I have fixed it by creating a new response object with `c.body` and returning that.

A reproduction of the issue can be found at https://github.com/BlankParticle/hono-header-reproduction/tree/main
