### PR TITLE
fix(zod-openapi): update RouteHandler type to support MaybePromise

### DIFF
--- a/.changeset/cuddly-pets-drum.md
+++ b/.changeset/cuddly-pets-drum.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix(zod-openapi): update RouteHandler type to support MaybePromise

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -197,8 +197,8 @@ export type RouteHandler<
       }
     }
   }
-    ? RouteConfigToTypedResponse<R>
-    : RouteConfigToTypedResponse<R> | Response | Promise<Response>
+    ? MaybePromise<RouteConfigToTypedResponse<R>>
+    : MaybePromise<RouteConfigToTypedResponse<R>> | MaybePromise<Response>
 >
 
 export type RouteHook<

--- a/packages/zod-openapi/test/handler.test-d.ts
+++ b/packages/zod-openapi/test/handler.test-d.ts
@@ -1,8 +1,7 @@
+import type { RouteHandler } from '../src'
 import { OpenAPIHono, createRoute, z } from '../src'
 
-test('supports async handler', () => {
-  const hono = new OpenAPIHono()
-
+describe('supports async handler', () => {
   const route = createRoute({
     method: 'get',
     path: '/users',
@@ -20,15 +19,37 @@ test('supports async handler', () => {
     },
   })
 
-  hono.openapi(route, (c) => {
-    return c.json({
-      id: '123',
+  test('argument of openapi method', () => {
+    const hono = new OpenAPIHono()
+
+    hono.openapi(route, (c) => {
+      return c.json({
+        id: '123',
+      })
+    })
+
+    hono.openapi(route, async (c) => {
+      return c.json({
+        id: '123',
+      })
     })
   })
 
-  hono.openapi(route, async (c) => {
-    return c.json({
-      id: '123',
-    })
+  test('RouteHandler type', () => {
+    const handler: RouteHandler<typeof route> = (c) => {
+      return c.json({
+        id: '123',
+      })
+    }
+
+    const asyncHandler: RouteHandler<typeof route> = async (c) => {
+      return c.json({
+        id: '123',
+      })
+    }
+
+    const hono = new OpenAPIHono()
+    hono.openapi(route, handler)
+    hono.openapi(route, asyncHandler)
   })
 })


### PR DESCRIPTION
I addressed the missing support for the RouteHandler type in this PR #522 .