### PR TITLE
feat(zod-openapi): export RouteConfig type

### DIFF
--- a/.changeset/itchy-glasses-smell.md
+++ b/.changeset/itchy-glasses-smell.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+feat(zod-openapi): export RouteConfig type

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -35,7 +35,7 @@ import { z, ZodType } from 'zod'
 
 type MaybePromise<T> = Promise<T> | T
 
-type RouteConfig = RouteConfigBase & {
+export type RouteConfig = RouteConfigBase & {
   middleware?: MiddlewareHandler | MiddlewareHandler[]
 }
 


### PR DESCRIPTION
#373
#432

I want to create a wrapper function for createRoute.
But, the current RouteConfig differs from the RouteConfig in @asteasolutions/zod-to-openapi.
It would be easy to define it myself, but it would be helpful if it is exported as there may be more differences in the future.