### PR TITLE
docs: add custom endpoint configuration example

### DIFF
--- a/packages/trpc-server/README.md
+++ b/packages/trpc-server/README.md
@@ -112,6 +112,28 @@ app.use(
   })
 )
 ```
+## Custom Endpoints
+
+To set up custom endpoints ensure the endpoint parameter matches the middleware's path. This alignment allows `@trpc/server` to accurately extract your procedure paths.
+
+```ts
+import { Hono } from 'hono'
+import { trpcServer } from '@hono/trpc-server'
+import { appRouter } from './router'
+
+const app = new Hono()
+
+// Custom endpoint configuration
+app.use(
+  '/api/trpc/*',
+  trpcServer({
+    endpoint: '/api/trpc',
+    router: appRouter,
+  })
+)
+
+export default app
+```
 
 ## Author
 


### PR DESCRIPTION
This PR adds documentation for configuring custom endpoints with the @hono/trpc-server middleware. Ensuring the endpoint parameter matches the middleware's path helps avoid issues like the one described in [honojs/middleware#166](https://github.com/honojs/middleware/issues/166).