### PR TITLE
fix(node-ws): Create only one WebSocketServer instead of per websocket request

### DIFF
--- a/.changeset/yellow-lions-breathe.md
+++ b/.changeset/yellow-lions-breathe.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': patch
+---
+
+create only one WebSocketServer instead of per websocket request

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -32,7 +32,7 @@ describe('WebSocket helper', () => {
       )
     })
     injectWebSocket(server)
-    const ws = new WebSocket('ws://localhost:3030/')
+    new WebSocket('ws://localhost:3030/')
 
     expect(await mainPromise).toBe(true)
   })


### PR DESCRIPTION
Currently, a new WebSocketServer is opened per websocket request. This PR reuses a single server for all requests.