### PR TITLE
feat(arktype-validator): migrate to 2.0

### DIFF
--- a/.changeset/itchy-eyes-warn.md
+++ b/.changeset/itchy-eyes-warn.md
@@ -1,0 +1,9 @@
+---
+'@hono/arktype-validator': major
+---
+
+Migrate to ArkType 2.0
+
+If you're still using `arktype-1.x`, you should remain on `@hono/arktype-validator@1.0.0`.
+
+If you're using `arktype-2.x` (latest), you'll need to upgrade to `@hono/arktype-validator@2.0.0`.

--- a/packages/arktype-validator/package.json
+++ b/packages/arktype-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono/arktype-validator",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "ArkType validator middleware",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -31,11 +31,11 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "arktype": "^1.0.28-alpha",
+    "arktype": "^2.0.0-dev.14",
     "hono": "*"
   },
   "devDependencies": {
-    "arktype": "^1.0.28-alpha",
+    "arktype": "^2.0.0-dev.14",
     "hono": "^3.11.7",
     "tsup": "^8.0.1",
     "vitest": "^1.0.4"

--- a/packages/arktype-validator/package.json
+++ b/packages/arktype-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono/arktype-validator",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "ArkType validator middleware",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/arktype-validator/src/index.ts
+++ b/packages/arktype-validator/src/index.ts
@@ -1,17 +1,16 @@
-import type { Type, Problems } from 'arktype'
+import { type, type Type, type ArkErrors } from 'arktype'
 import type { Context, MiddlewareHandler, Env, ValidationTargets, TypedResponse } from 'hono'
 import { validator } from 'hono/validator'
 
 export type Hook<T, E extends Env, P extends string, O = {}> = (
-  result: { success: false; data: unknown; problems: Problems } | { success: true; data: T },
+  result: { success: false; data: unknown; errors: ArkErrors } | { success: true; data: T },
   c: Context<E, P>
 ) => Response | Promise<Response> | void | Promise<Response | void> | TypedResponse<O>
 
 type HasUndefined<T> = undefined extends T ? true : false
 
 export const arktypeValidator = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends Type<any>,
+  T extends Type,
   Target extends keyof ValidationTargets,
   E extends Env,
   P extends string,
@@ -30,11 +29,13 @@ export const arktypeValidator = <
   hook?: Hook<T['infer'], E, P>
 ): MiddlewareHandler<E, P, V> =>
   validator(target, (value, c) => {
-    const { data, problems } = schema(value)
+    const out = schema(value)
+
+    const hasErrors = out instanceof type.errors
 
     if (hook) {
       const hookResult = hook(
-        problems ? { success: false, data: value, problems } : { success: true, data },
+        hasErrors ? { success: false, data: value, errors: out } : { success: true, data: out },
         c
       )
       if (hookResult) {
@@ -47,15 +48,15 @@ export const arktypeValidator = <
       }
     }
 
-    if (problems) {
+    if (hasErrors) {
       return c.json(
         {
           success: false,
-          problems: problems.map((problem) => ({ ...problem, message: problem.toString() })),
+          errors: out,
         },
         400
       )
     }
 
-    return data
+    return out
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@arktype/schema@npm:0.1.4-cjs":
+  version: 0.1.4-cjs
+  resolution: "@arktype/schema@npm:0.1.4-cjs"
+  dependencies:
+    "@arktype/util": "npm:0.0.41-cjs"
+  checksum: dd83edcbd29ab8b1faf4c8aee3d03b7d75a4cc7848c44cffd0580b89cfa0cabd280916fcd94317b89fc9d730a0fb6c9e7f53db9088788f54dd9077d5479c1b2f
+  languageName: node
+  linkType: hard
+
+"@arktype/util@npm:0.0.41-cjs":
+  version: 0.0.41-cjs
+  resolution: "@arktype/util@npm:0.0.41-cjs"
+  checksum: 77013353924d4f1d81eacc782b7bf07ac21fd5e96368505e05f75dfc822933cb3fc65ba055cc60105f5a86f89c9f4d60aa8be8f0942ebee93f0165cbe4e4b2b9
+  languageName: node
+  linkType: hard
+
 "@asteasolutions/zod-to-openapi@npm:^7.0.0":
   version: 7.0.0
   resolution: "@asteasolutions/zod-to-openapi@npm:7.0.0"
@@ -1771,12 +1787,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hono/arktype-validator@workspace:packages/arktype-validator"
   dependencies:
-    arktype: "npm:^1.0.28-alpha"
+    arktype: "npm:^2.0.0-dev.14"
     hono: "npm:^3.11.7"
     tsup: "npm:^8.0.1"
     vitest: "npm:^1.0.4"
   peerDependencies:
-    arktype: ^1.0.28-alpha
+    arktype: ^2.0.0-dev.14
     hono: "*"
   languageName: unknown
   linkType: soft
@@ -5091,10 +5107,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arktype@npm:^1.0.28-alpha":
-  version: 1.0.28-alpha
-  resolution: "arktype@npm:1.0.28-alpha"
-  checksum: cf5a7a6303dcd42d54f10f83119c90ac382a0b75074716c4b6fcca6e6326ea070b6a8b1ae7a4da576e93e80b312d0d01368937e695074ddd3a53a0dc30fb98b2
+"arktype@npm:^2.0.0-dev.14":
+  version: 2.0.0-dev.12-cjs
+  resolution: "arktype@npm:2.0.0-dev.12-cjs"
+  dependencies:
+    "@arktype/schema": "npm:0.1.4-cjs"
+    "@arktype/util": "npm:0.0.41-cjs"
+  checksum: b0e7fc182bb6d4d0d4e125744a5b8233295d2ca30715f1bafdd158d37ed8abffafe0f5ef28ff8f99f82ffb1b8d1f36fcc282035c4ef4b909a748c1d520044afc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This migrates `arktype-validator` to `arktype` 2.0, which is the current `latest` install.