### PR TITLE
Add @hono/react-compat package

### DIFF
--- a/packages/react-compat/CHANGELOG.md
+++ b/packages/react-compat/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @hono/react-compat

--- a/packages/react-compat/README.md
+++ b/packages/react-compat/README.md
@@ -1,0 +1,19 @@
+# Alias of hono/jsx for replacement of React
+
+This package is used to install the React compatibility API provided by [Hono](https://github.com/honojs/hono). This package allows you to replace the "react" and "react-dom" entities with "@hono/react-compat".
+
+## Usage
+
+```bash
+npm install react@npm:@hono/react-compat react-dom@npm:@hono/react-compat
+```
+
+After installing in this way, "@hono/react-compat" will be loaded when "react" is specified in the `jsxImportSource` setting or in the `import` statement. See the [npm docs](https://docs.npmjs.com/cli/v7/commands/npm-install) for more information about aliased installs.
+
+## Author
+
+Taku Amano <https://github.com/usualoma>
+
+## License
+
+MIT

--- a/packages/react-compat/package.json
+++ b/packages/react-compat/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@hono/react-compat",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Alias of hono/jsx for replacement of React",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsup ./src --format esm,cjs --dts",
+    "publint": "publint",
+    "release": "yarn build && yarn test && yarn publint && yarn publish"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.mts",
+      "import": "./dist/*.mjs",
+      "require": "./dist/*.js"
+    }
+  },
+  "peerDependencies": {
+    "hono": ">=4.5.*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.1"
+  }
+}

--- a/packages/react-compat/src/client.ts
+++ b/packages/react-compat/src/client.ts
@@ -1,0 +1,1 @@
+export * from 'hono/jsx/dom/client'

--- a/packages/react-compat/src/index.ts
+++ b/packages/react-compat/src/index.ts
@@ -1,0 +1,1 @@
+export * from 'hono/jsx'

--- a/packages/react-compat/src/jsx-dev-runtime.ts
+++ b/packages/react-compat/src/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export * from 'hono/jsx/jsx-dev-runtime'

--- a/packages/react-compat/src/jsx-runtime.ts
+++ b/packages/react-compat/src/jsx-runtime.ts
@@ -1,0 +1,1 @@
+export * from 'hono/jsx/jsx-runtime'

--- a/packages/react-compat/src/server.ts
+++ b/packages/react-compat/src/server.ts
@@ -1,0 +1,1 @@
+export * from 'hono/jsx/dom/server'

--- a/packages/react-compat/tsconfig.json
+++ b/packages/react-compat/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+}


### PR DESCRIPTION
The dependency on Hono version is weak and can be used for "4.x", but currently ">= 4.5.*" is specified for `peerDependencies`, as a merged release of https://github.com/honojs/hono/pull/2929 and https://github.com/honojs/hono/pull/2930 would work more fully.

https://github.com/honojs/middleware/compare/main...usualoma:middleware:feat/react-compat?expand=1#diff-290f95d23c372b783139084b0b97bef9100b22c677ab0497121b834c8ca38f86R28