### PR TITLE
feat(typia-validator): upgrade typia dependency to ^6.1.0

### DIFF
--- a/.changeset/five-horses-know.md
+++ b/.changeset/five-horses-know.md
@@ -1,0 +1,5 @@
+---
+'@hono/typia-validator': patch
+---
+
+PeerDependency of Typia is updated from v5 to v6

--- a/packages/typia-validator/package.json
+++ b/packages/typia-validator/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=3.9.0",
-    "typia": "^5.0.4"
+    "typia": "^6.1.0"
   },
   "devDependencies": {
     "hono": "^3.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,7 +2155,7 @@ __metadata:
     typia: "npm:^5.0.4"
   peerDependencies:
     hono: ">=3.9.0"
-    typia: ^5.0.4
+    typia: ^6.1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This commit updates the peer dependency of typia from ^5.0.4 to ^6.1.0 in the typia-validator package. The yarn.lock file has also been updated to reflect this change.