### PR TITLE
fix(swagger-ui): Add support for several more configuration options

### DIFF
--- a/.changeset/hungry-cameras-return.md
+++ b/.changeset/hungry-cameras-return.md
@@ -1,0 +1,5 @@
+---
+'@hono/swagger-ui': minor
+---
+
+Added support for `defaultModelsExpandDepth`, `defaultModelExpandDepth`, `defaultModelRendering`, `displayRequestDuration`, `filter`, `showExtensions`, and `showCommonExtensions` configuration options

--- a/packages/swagger-ui/src/swagger/renderer.ts
+++ b/packages/swagger-ui/src/swagger/renderer.ts
@@ -18,6 +18,13 @@ export type DistSwaggerUIOptions = {
   requestInterceptor?: string
   responseInterceptor?: string
   persistAuthorization?: boolean
+  defaultModelsExpandDepth?: number
+  defaultModelExpandDepth?: number
+  defaultModelRendering?: "example" | "model" | undefined
+  displayRequestDuration?: boolean
+  filter?: boolean | string
+  showExtensions?: boolean
+  showCommonExtensions?: boolean
 } & RequireOne<{
   url?: SwaggerConfigs['url']
   urls?: SwaggerConfigs['urls']
@@ -45,6 +52,13 @@ const RENDER_TYPE_MAP = {
   requestInterceptor: RENDER_TYPE.RAW,
   responseInterceptor: RENDER_TYPE.RAW,
   persistAuthorization: RENDER_TYPE.RAW,
+  defaultModelsExpandDepth: RENDER_TYPE.RAW,
+  defaultModelExpandDepth: RENDER_TYPE.RAW,
+  defaultModelRendering: RENDER_TYPE.STRING,
+  displayRequestDuration: RENDER_TYPE.RAW,
+  filter: RENDER_TYPE.RAW,
+  showExtensions: RENDER_TYPE.RAW,
+  showCommonExtensions: RENDER_TYPE.RAW,
 } as const satisfies Record<
   keyof DistSwaggerUIOptions,
   (typeof RENDER_TYPE)[keyof typeof RENDER_TYPE]

--- a/packages/swagger-ui/test/option-renderer.test.ts
+++ b/packages/swagger-ui/test/option-renderer.test.ts
@@ -122,4 +122,53 @@ describe('SwaggerUIOption Rendering', () => {
         persistAuthorization: true,
       })
     ).toEqual('persistAuthorization: true'))
+
+  it('renders correctly with defaultModelsExpandDepth', () =>
+    expect(
+      renderSwaggerUIOptions({
+        defaultModelsExpandDepth: 1,
+      })
+    ).toEqual('defaultModelsExpandDepth: 1'))
+
+  it('renders correctly with defaultModelExpandDepth', () =>
+    expect(
+      renderSwaggerUIOptions({
+        defaultModelExpandDepth: 2,
+      })
+    ).toEqual('defaultModelExpandDepth: 2'))
+
+  it('renders correctly with defaultModelRendering', () =>
+    expect(
+      renderSwaggerUIOptions({
+        defaultModelRendering: 'model',
+      })
+    ).toEqual("defaultModelRendering: 'model'"))
+
+  it('renders correctly with displayRequestDuration', () =>
+    expect(
+      renderSwaggerUIOptions({
+        displayRequestDuration: true,
+      })
+    ).toEqual('displayRequestDuration: true'))
+  
+  it('renders correctly with filter', () =>
+    expect(
+      renderSwaggerUIOptions({
+        filter: true,
+      })
+    ).toEqual('filter: true'))
+
+  it('renders correctly with showExtensions', () =>
+    expect(
+      renderSwaggerUIOptions({
+        showExtensions: true,
+      })
+    ).toEqual('showExtensions: true'))
+
+  it('renders correctly with showCommonExtensions', () =>
+    expect(
+      renderSwaggerUIOptions({
+        showCommonExtensions: true,
+      })
+    ).toEqual('showCommonExtensions: true'))
 })


### PR DESCRIPTION
fixes #267

Adds support for the following Swagger-UI config options:

- `defaultModelsExpandDepth`
- `defaultModelExpandDepth`
- `defaultModelRendering`
- `displayRequestDuration`
- `filter`
- `showExtensions`
- `showCommonExtensions`