### PR TITLE
fix(oauth-providers): oauth-middleware: load `env.SECRETS` with hono/adapter

### DIFF
--- a/.changeset/dull-frogs-glow.md
+++ b/.changeset/dull-frogs-glow.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': minor
+---
+
+load env.SECRET with hono/adapter, to support non-worker

--- a/.changeset/dull-frogs-glow.md
+++ b/.changeset/dull-frogs-glow.md
@@ -1,5 +1,5 @@
 ---
-'@hono/oauth-providers': minor
+'@hono/oauth-providers': patch
 ---
 
 load env.SECRET with hono/adapter, to support non-worker

--- a/packages/oauth-providers/src/providers/discord/discordAuth.ts
+++ b/packages/oauth-providers/src/providers/discord/discordAuth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
 import { setCookie, getCookie } from 'hono/cookie'
+import { env } from 'hono/adapter'
 import { HTTPException } from 'hono/http-exception'
 
 import { getRandomState } from '../../utils/getRandomState'
@@ -17,8 +18,8 @@ export function discordAuth(options: {
 
     // Create new Auth instance
     const auth = new AuthFlow({
-      client_id: options.client_id || (c.env?.DISCORD_ID as string),
-      client_secret: options.client_secret || (c.env?.DISCORD_SECRET as string),
+      client_id: options.client_id || (env(c).DISCORD_ID as string),
+      client_secret: options.client_secret || (env(c).DISCORD_SECRET as string),
       redirect_uri: c.req.url.split('?')[0],
       scope: options.scope,
       state: newState,

--- a/packages/oauth-providers/src/providers/facebook/facebookAuth.ts
+++ b/packages/oauth-providers/src/providers/facebook/facebookAuth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
 import { setCookie, getCookie } from 'hono/cookie'
+import { env } from 'hono/adapter'
 import { HTTPException } from 'hono/http-exception'
 
 import { getRandomState } from '../../utils/getRandomState'
@@ -16,8 +17,8 @@ export function facebookAuth(options: {
     const newState = getRandomState()
     // Create new Auth instance
     const auth = new AuthFlow({
-      client_id: options.client_id || (c.env?.FACEBOOK_ID as string),
-      client_secret: options.client_secret || (c.env?.FACEBOOK_SECRET as string),
+      client_id: options.client_id || (env(c).FACEBOOK_ID as string),
+      client_secret: options.client_secret || (env(c).FACEBOOK_SECRET as string),
       redirect_uri: c.req.url.split('?')[0],
       scope: options.scope,
       fields: options.fields,

--- a/packages/oauth-providers/src/providers/github/githubAuth.ts
+++ b/packages/oauth-providers/src/providers/github/githubAuth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
 import { getCookie, setCookie } from 'hono/cookie'
+import { env } from 'hono/adapter'
 import { HTTPException } from 'hono/http-exception'
 
 import { getRandomState } from '../../utils/getRandomState'
@@ -16,8 +17,8 @@ export function githubAuth(options: {
     const newState = getRandomState()
     // Create new Auth instance
     const auth = new AuthFlow({
-      client_id: options.client_id || (c.env?.GITHUB_ID as string),
-      client_secret: options.client_secret || (c.env?.GITHUB_SECRET as string),
+      client_id: options.client_id || (env(c).GITHUB_ID as string),
+      client_secret: options.client_secret || (env(c).GITHUB_SECRET as string),
       scope: options.scope,
       state: newState,
       oauthApp: options.oauthApp || false,

--- a/packages/oauth-providers/src/providers/google/googleAuth.ts
+++ b/packages/oauth-providers/src/providers/google/googleAuth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
 import { getCookie, setCookie } from 'hono/cookie'
+import { env } from 'hono/adapter'
 import { HTTPException } from 'hono/http-exception'
 
 import { getRandomState } from '../../utils/getRandomState'
@@ -17,8 +18,8 @@ export function googleAuth(options: {
     const newState = options.state || getRandomState()
     // Create new Auth instance
     const auth = new AuthFlow({
-      client_id: options.client_id || (c.env?.GOOGLE_ID as string),
-      client_secret: options.client_secret || (c.env?.GOOGLE_SECRET as string),
+      client_id: options.client_id || (env(c).GOOGLE_ID as string),
+      client_secret: options.client_secret || (env(c).GOOGLE_SECRET as string),
       redirect_uri: c.req.url.split('?')[0],
       login_hint: options.login_hint,
       prompt: options.prompt,

--- a/packages/oauth-providers/src/providers/linkedin/linkedinAuth.ts
+++ b/packages/oauth-providers/src/providers/linkedin/linkedinAuth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
 import { getCookie, setCookie } from 'hono/cookie'
+import { env } from 'hono/adapter'
 import { HTTPException } from 'hono/http-exception'
 
 import { getRandomState } from '../../utils/getRandomState'
@@ -16,8 +17,8 @@ export function linkedinAuth(options: {
     const newState = getRandomState()
     // Create new Auth instance
     const auth = new AuthFlow({
-      client_id: options.client_id || (c.env?.LINKEDIN_ID as string),
-      client_secret: options.client_secret || (c.env?.LINKEDIN_SECRET as string),
+      client_id: options.client_id || (env(c).LINKEDIN_ID as string),
+      client_secret: options.client_secret || (env(c).LINKEDIN_SECRET as string),
       redirect_uri: c.req.url.split('?')[0],
       scope: options.scope,
       state: newState,

--- a/packages/oauth-providers/src/providers/x/xAuth.ts
+++ b/packages/oauth-providers/src/providers/x/xAuth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
 import { getCookie, setCookie } from 'hono/cookie'
+import { env } from 'hono/adapter'
 import { HTTPException } from 'hono/http-exception'
 
 import { getCodeChallenge } from '../../utils/getCodeChallenge'
@@ -19,8 +20,8 @@ export function xAuth(options: {
     const challenge = await getCodeChallenge()
 
     const auth = new AuthFlow({
-      client_id: options.client_id || (c.env?.X_ID as string),
-      client_secret: options.client_secret || (c.env?.X_SECRET as string),
+      client_id: options.client_id || (env(c).X_ID as string),
+      client_secret: options.client_secret || (env(c).X_SECRET as string),
       redirect_uri: c.req.url.split('?')[0],
       scope: options.scope,
       fields: options.fields,


### PR DESCRIPTION
Hi, when using the middleware in node.js, I found it does not automatically read from process.env . Use of `hono/adapter` should fix this.

(correction welcome, I'm rather new to honojs)