### PR TITLE
fix(auth-js): bun req cloning

### DIFF
--- a/.changeset/good-lizards-smile.md
+++ b/.changeset/good-lizards-smile.md
@@ -1,0 +1,5 @@
+---
+'@hono/auth-js': patch
+---
+
+fix bun req cloning

--- a/packages/auth-js/test/index.test.ts
+++ b/packages/auth-js/test/index.test.ts
@@ -3,7 +3,7 @@ import { skipCSRFCheck } from '@auth/core'
 import type { Adapter } from '@auth/core/adapters'
 import Credentials from '@auth/core/providers/credentials'
 import { Hono } from 'hono'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from "vitest"
 import type { AuthConfig } from '../src'
 import { authHandler, verifyAuth, initAuthConfig, reqWithEnvUrl } from '../src'
 
@@ -78,9 +78,9 @@ describe('Config', () => {
   })
 })
 
-describe('reqWithEnvUrl()', () => {
+describe('reqWithEnvUrl()', async() => {
   const req = new Request('http://request-base/request-path')
-  const newReq = reqWithEnvUrl(req, 'https://auth-url-base/auth-url-path')
+  const newReq = await reqWithEnvUrl(req, 'https://auth-url-base/auth-url-path')
   it('Should rewrite the base path', () => {
     expect(newReq.url.toString()).toBe('https://auth-url-base/request-path')
   })
@@ -126,6 +126,7 @@ describe('Credentials Provider', () => {
       password: {},
     },
     authorize: (credentials) => {
+
       if (credentials.password === 'password') {
         return user
       }


### PR DESCRIPTION
@yusukebe This pr fixes issues on bun. As cloning  request like   `new Request(url,old)` doesn't work on bun yet which causes CRSF issues this pr uses getRuntimeKey from hono adapter to handle cloning for bun separetely.