### PR TITLE
 chore: update `@hono/trpc-server` to allow using Trpc 11

### DIFF
--- a/.changeset/happy-onions-carry.md
+++ b/.changeset/happy-onions-carry.md
@@ -1,0 +1,5 @@
+---
+'@hono/trpc-server': patch
+---
+
+chore: update `@hono/trpc-server` to allow using Trpc 11

--- a/packages/trpc-server/package.json
+++ b/packages/trpc-server/package.json
@@ -27,11 +27,11 @@
   },
   "homepage": "https://honojs.dev",
   "peerDependencies": {
-    "@trpc/server": "^10.10.0",
+    "@trpc/server": "^10.10.0 || >11.0.0-rc",
     "hono": ">=4.*"
   },
   "devDependencies": {
-    "@trpc/server": "^10.10.0",
+    "@trpc/server": "^10.10.0 || >11.0.0-rc",
     "hono": "^4.3.6",
     "jest": "^29.7.0",
     "rimraf": "^5.0.5",

--- a/packages/trpc-server/test/context.test.ts
+++ b/packages/trpc-server/test/context.test.ts
@@ -115,7 +115,7 @@ describe('tRPC Adapter Middleware passing asynchronous Context', () => {
   it.only('Should return 200 response', async () => {
     const searchParams = new URLSearchParams({
       input: JSON.stringify({ '0': 'Hono' }),
-      batch: '2',
+      batch: '1',
     })
     const req = new Request(`http://localhost/trpc/hello?${searchParams.toString()}`)
     const res = await app.request(req)
@@ -123,7 +123,7 @@ describe('tRPC Adapter Middleware passing asynchronous Context', () => {
     expect(await res.json()).toEqual([
       {
         result: {
-          data: 'Hello World, batch is 2',
+          data: 'Hello World, batch is 1',
         },
       },
     ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,13 +2120,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hono/trpc-server@workspace:packages/trpc-server"
   dependencies:
-    "@trpc/server": "npm:^10.10.0"
+    "@trpc/server": "npm:^10.10.0 || >11.0.0-rc"
     hono: "npm:^4.3.6"
     jest: "npm:^29.7.0"
     rimraf: "npm:^5.0.5"
     zod: "npm:^3.20.2"
   peerDependencies:
-    "@trpc/server": ^10.10.0
+    "@trpc/server": ^10.10.0 || >11.0.0-rc
     hono: ">=4.*"
   languageName: unknown
   linkType: soft
@@ -3716,10 +3716,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trpc/server@npm:^10.10.0":
-  version: 10.44.1
-  resolution: "@trpc/server@npm:10.44.1"
-  checksum: 838fb12286b91c4f1fe22479b426d6c1100700d253980c54b3417358008abc5e7c3f7a78f8ac0526d7693fcf70276bf42ce5fd6d25b6db2b6e3fdbe16c087dca
+"@trpc/server@npm:^10.10.0 || >11.0.0-rc":
+  version: 11.0.0-rc.433
+  resolution: "@trpc/server@npm:11.0.0-rc.433"
+  checksum: feb96e58b049566ab4b10ab563130db360ddd80f211a0048e92f5cbbefa0bf174befe776a7fbd8dd799eece61578b3a8d7ce4eca122e1257e49b99f2bd467cd3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates `@trpc/server` dependency to allow `11.0.0-rc.*` versions too.
~There has not been any changes to the fetch adapter, so no code change is required~

~There has been changes in the serialisation format of Trpc data, the tests were written with trpc 10.~

~The tests needs to be updated for Trpc 11, but that would break testing for trpc 10 (the package works fine with both 10/11, only the tests are the issue)~

According to Trpc's author batch is a boolean which is `1` for true and anything else is false, so the test is faulty. I have updated the tests.