### PR TITLE
feat(oauth-providers): allow custom redirect_uri

### DIFF
--- a/.changeset/cold-tigers-lie.md
+++ b/.changeset/cold-tigers-lie.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': minor
+---
+
+allow override of redirect_uri

--- a/packages/oauth-providers/README.md
+++ b/packages/oauth-providers/README.md
@@ -928,6 +928,7 @@ This parameters can be useful if
 
 1. `hono` process cannot infer correct redirect_uri from the request. For example, when the server runs behind a reverse proxy and have no access to its internet hostname.
 2. Or, in need to start oauth flow from a different route.
+3. Or, in need to encode more info into `redirect_uri`.
 
 ```ts
 const app = new Hono();

--- a/packages/oauth-providers/src/providers/discord/discordAuth.ts
+++ b/packages/oauth-providers/src/providers/discord/discordAuth.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareHandler } from 'hono'
-import { setCookie, getCookie } from 'hono/cookie'
+import { getCookie, setCookie } from 'hono/cookie'
 import { env } from 'hono/adapter'
 import { HTTPException } from 'hono/http-exception'
 
@@ -31,14 +31,6 @@ export function discordAuth(options: {
       },
     })
 
-    // Avoid CSRF attack by checking state
-    if (c.req.url.includes('?')) {
-      const storedState = getCookie(c, 'state')
-      if (c.req.query('state') !== storedState) {
-        throw new HTTPException(401)
-      }
-    }
-
     // Redirect to login dialog
     if (!auth.code) {
       setCookie(c, 'state', newState, {
@@ -48,6 +40,14 @@ export function discordAuth(options: {
         // secure: true,
       })
       return c.redirect(auth.redirect())
+    }
+
+    // Avoid CSRF attack by checking state
+    if (c.req.url.includes('?')) {
+      const storedState = getCookie(c, 'state')
+      if (c.req.query('state') !== storedState) {
+        throw new HTTPException(401)
+      }
     }
 
     // Retrieve user data from discord

--- a/packages/oauth-providers/src/providers/discord/discordAuth.ts
+++ b/packages/oauth-providers/src/providers/discord/discordAuth.ts
@@ -11,6 +11,7 @@ export function discordAuth(options: {
   scope: Scopes[]
   client_id?: string
   client_secret?: string
+  redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
     // Generate encoded "keys"
@@ -20,7 +21,7 @@ export function discordAuth(options: {
     const auth = new AuthFlow({
       client_id: options.client_id || (env(c).DISCORD_ID as string),
       client_secret: options.client_secret || (env(c).DISCORD_SECRET as string),
-      redirect_uri: c.req.url.split('?')[0],
+      redirect_uri: options.redirect_uri || c.req.url.split('?')[0],
       scope: options.scope,
       state: newState,
       code: c.req.query('code'),

--- a/packages/oauth-providers/src/providers/facebook/facebookAuth.ts
+++ b/packages/oauth-providers/src/providers/facebook/facebookAuth.ts
@@ -12,6 +12,7 @@ export function facebookAuth(options: {
   fields: Fields[]
   client_id?: string
   client_secret?: string
+  redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
     const newState = getRandomState()
@@ -19,7 +20,7 @@ export function facebookAuth(options: {
     const auth = new AuthFlow({
       client_id: options.client_id || (env(c).FACEBOOK_ID as string),
       client_secret: options.client_secret || (env(c).FACEBOOK_SECRET as string),
-      redirect_uri: c.req.url.split('?')[0],
+      redirect_uri: options.redirect_uri || c.req.url.split('?')[0],
       scope: options.scope,
       fields: options.fields,
       state: newState,

--- a/packages/oauth-providers/src/providers/facebook/facebookAuth.ts
+++ b/packages/oauth-providers/src/providers/facebook/facebookAuth.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareHandler } from 'hono'
-import { setCookie, getCookie } from 'hono/cookie'
+import { getCookie, setCookie } from 'hono/cookie'
 import { env } from 'hono/adapter'
 import { HTTPException } from 'hono/http-exception'
 
@@ -31,14 +31,6 @@ export function facebookAuth(options: {
       },
     })
 
-    // Avoid CSRF attack by checking state
-    if (c.req.url.includes('?')) {
-      const storedState = getCookie(c, 'state')
-      if (c.req.query('state') !== storedState) {
-        throw new HTTPException(401)
-      }
-    }
-
     // Redirect to login dialog
     if (!auth.code) {
       setCookie(c, 'state', newState, {
@@ -48,6 +40,14 @@ export function facebookAuth(options: {
         // secure: true,
       })
       return c.redirect(auth.redirect())
+    }
+
+    // Avoid CSRF attack by checking state
+    if (c.req.url.includes('?')) {
+      const storedState = getCookie(c, 'state')
+      if (c.req.query('state') !== storedState) {
+        throw new HTTPException(401)
+      }
     }
 
     // Retrieve user data from facebook

--- a/packages/oauth-providers/src/providers/github/authFlow.ts
+++ b/packages/oauth-providers/src/providers/github/authFlow.ts
@@ -2,11 +2,11 @@ import { HTTPException } from 'hono/http-exception'
 
 import { toQueryParams } from '../../utils/objectToQuery'
 import type {
+  GitHubEmailResponse,
   GitHubErrorResponse,
+  GitHubScope,
   GitHubTokenResponse,
   GitHubUser,
-  GitHubScope,
-  GitHubEmailResponse,
 } from './types'
 
 type GithubAuthFlow = {

--- a/packages/oauth-providers/src/providers/github/githubAuth.ts
+++ b/packages/oauth-providers/src/providers/github/githubAuth.ts
@@ -12,6 +12,7 @@ export function githubAuth(options: {
   client_secret?: string
   scope?: GitHubScope[]
   oauthApp?: boolean
+  // TODO: support redirect_uri . see https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
 }): MiddlewareHandler {
   return async (c, next) => {
     const newState = getRandomState()

--- a/packages/oauth-providers/src/providers/github/githubAuth.ts
+++ b/packages/oauth-providers/src/providers/github/githubAuth.ts
@@ -12,7 +12,7 @@ export function githubAuth(options: {
   client_secret?: string
   scope?: GitHubScope[]
   oauthApp?: boolean
-  redirect_uri?: string,
+  redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
     const newState = getRandomState()
@@ -47,7 +47,9 @@ export function githubAuth(options: {
       // As such, we want to make sure we call back to the same location
       // for GitHub apps and not the first configured callbackURL in the app config.
       return c.redirect(
-        auth.redirect().concat(options.oauthApp ? '' : `&redirect_uri=${options.redirect_uri || c.req.url}`)
+        auth
+          .redirect()
+          .concat(options.oauthApp ? '' : `&redirect_uri=${options.redirect_uri || c.req.url}`)
       )
     }
 

--- a/packages/oauth-providers/src/providers/github/githubAuth.ts
+++ b/packages/oauth-providers/src/providers/github/githubAuth.ts
@@ -12,7 +12,7 @@ export function githubAuth(options: {
   client_secret?: string
   scope?: GitHubScope[]
   oauthApp?: boolean
-  // TODO: support redirect_uri . see https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+  redirect_uri?: string,
 }): MiddlewareHandler {
   return async (c, next) => {
     const newState = getRandomState()
@@ -47,7 +47,7 @@ export function githubAuth(options: {
       // As such, we want to make sure we call back to the same location
       // for GitHub apps and not the first configured callbackURL in the app config.
       return c.redirect(
-        auth.redirect().concat(options.oauthApp ? '' : `&redirect_uri=${c.req.url}`)
+        auth.redirect().concat(options.oauthApp ? '' : `&redirect_uri=${options.redirect_uri || c.req.url}`)
       )
     }
 

--- a/packages/oauth-providers/src/providers/google/googleAuth.ts
+++ b/packages/oauth-providers/src/providers/google/googleAuth.ts
@@ -13,6 +13,7 @@ export function googleAuth(options: {
   client_id?: string
   client_secret?: string
   state?: string
+  redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
     const newState = options.state || getRandomState()
@@ -20,7 +21,7 @@ export function googleAuth(options: {
     const auth = new AuthFlow({
       client_id: options.client_id || (env(c).GOOGLE_ID as string),
       client_secret: options.client_secret || (env(c).GOOGLE_SECRET as string),
-      redirect_uri: c.req.url.split('?')[0],
+      redirect_uri: options.redirect_uri || c.req.url.split('?')[0],
       login_hint: options.login_hint,
       prompt: options.prompt,
       scope: options.scope,

--- a/packages/oauth-providers/src/providers/google/googleAuth.ts
+++ b/packages/oauth-providers/src/providers/google/googleAuth.ts
@@ -33,14 +33,6 @@ export function googleAuth(options: {
       },
     })
 
-    // Avoid CSRF attack by checking state
-    if (c.req.url.includes('?')) {
-      const storedState = getCookie(c, 'state')
-      if (c.req.query('state') !== storedState) {
-        throw new HTTPException(401)
-      }
-    }
-
     // Redirect to login dialog
     if (!auth.code) {
       setCookie(c, 'state', newState, {
@@ -50,6 +42,14 @@ export function googleAuth(options: {
         // secure: true,
       })
       return c.redirect(auth.redirect())
+    }
+
+    // Avoid CSRF attack by checking state
+    if (c.req.url.includes('?')) {
+      const storedState = getCookie(c, 'state')
+      if (c.req.query('state') !== storedState) {
+        throw new HTTPException(401)
+      }
     }
 
     // Retrieve user data from google

--- a/packages/oauth-providers/src/providers/linkedin/authFlow.ts
+++ b/packages/oauth-providers/src/providers/linkedin/authFlow.ts
@@ -4,9 +4,9 @@ import type { Token } from '../../types'
 import { toQueryParams } from '../../utils/objectToQuery'
 import type {
   LinkedInErrorResponse,
+  LinkedInScope,
   LinkedInTokenResponse,
   LinkedInUser,
-  LinkedInScope,
 } from './types'
 
 export type LinkedInAuthFlow = {

--- a/packages/oauth-providers/src/providers/linkedin/linkedinAuth.ts
+++ b/packages/oauth-providers/src/providers/linkedin/linkedinAuth.ts
@@ -27,14 +27,6 @@ export function linkedinAuth(options: {
       code: c.req.query('code'),
     })
 
-    // Avoid CSRF attack by checking state
-    if (c.req.url.includes('?')) {
-      const storedState = getCookie(c, 'state')
-      if (c.req.query('state') !== storedState) {
-        throw new HTTPException(401)
-      }
-    }
-
     // Redirect to login dialog
     if (!auth.code && !options.appAuth) {
       setCookie(c, 'state', newState, {
@@ -44,6 +36,14 @@ export function linkedinAuth(options: {
         // secure: true,
       })
       return c.redirect(auth.redirect())
+    }
+
+    // Avoid CSRF attack by checking state
+    if (c.req.url.includes('?')) {
+      const storedState = getCookie(c, 'state')
+      if (c.req.query('state') !== storedState) {
+        throw new HTTPException(401)
+      }
     }
 
     if (options.appAuth) {

--- a/packages/oauth-providers/src/providers/linkedin/linkedinAuth.ts
+++ b/packages/oauth-providers/src/providers/linkedin/linkedinAuth.ts
@@ -12,6 +12,7 @@ export function linkedinAuth(options: {
   client_secret?: string
   scope?: LinkedInScope[]
   appAuth?: boolean
+  redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
     const newState = getRandomState()
@@ -19,7 +20,7 @@ export function linkedinAuth(options: {
     const auth = new AuthFlow({
       client_id: options.client_id || (env(c).LINKEDIN_ID as string),
       client_secret: options.client_secret || (env(c).LINKEDIN_SECRET as string),
-      redirect_uri: c.req.url.split('?')[0],
+      redirect_uri: options.redirect_uri || c.req.url.split('?')[0],
       scope: options.scope,
       state: newState,
       appAuth: options.appAuth || false,

--- a/packages/oauth-providers/src/providers/x/xAuth.ts
+++ b/packages/oauth-providers/src/providers/x/xAuth.ts
@@ -13,6 +13,7 @@ export function xAuth(options: {
   fields?: XFields[]
   client_id?: string
   client_secret?: string
+  redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
     // Generate encoded "keys"
@@ -22,7 +23,7 @@ export function xAuth(options: {
     const auth = new AuthFlow({
       client_id: options.client_id || (env(c).X_ID as string),
       client_secret: options.client_secret || (env(c).X_SECRET as string),
-      redirect_uri: c.req.url.split('?')[0],
+      redirect_uri: options.redirect_uri || c.req.url.split('?')[0],
       scope: options.scope,
       fields: options.fields,
       state: newState,

--- a/packages/oauth-providers/test/handlers.ts
+++ b/packages/oauth-providers/test/handlers.ts
@@ -12,7 +12,7 @@ import type {
   GoogleErrorResponse,
   GoogleTokenResponse,
   GoogleUser,
-} from '../src/providers/google/types'
+} from '../src/providers/google'
 import type { LinkedInErrorResponse, LinkedInTokenResponse } from '../src/providers/linkedin'
 import type { XErrorResponse, XRevokeResponse, XTokenResponse } from '../src/providers/x'
 

--- a/packages/oauth-providers/test/handlers.ts
+++ b/packages/oauth-providers/test/handlers.ts
@@ -8,11 +8,7 @@ import type {
   FacebookUser,
 } from '../src/providers/facebook'
 import type { GitHubErrorResponse, GitHubTokenResponse } from '../src/providers/github'
-import type {
-  GoogleErrorResponse,
-  GoogleTokenResponse,
-  GoogleUser,
-} from '../src/providers/google'
+import type { GoogleErrorResponse, GoogleTokenResponse, GoogleUser } from '../src/providers/google'
 import type { LinkedInErrorResponse, LinkedInTokenResponse } from '../src/providers/linkedin'
 import type { XErrorResponse, XRevokeResponse, XTokenResponse } from '../src/providers/x'
 

--- a/packages/oauth-providers/test/index.test.ts
+++ b/packages/oauth-providers/test/index.test.ts
@@ -62,17 +62,14 @@ describe('OAuth Middleware', () => {
       scope: ['openid', 'email', 'profile'],
     })
   )
-  app.use(
-    '/google-custom-redirect',
-    (c, next) => {
-      return googleAuth({
-        client_id,
-        client_secret,
-        scope: ['openid', 'email', 'profile'],
-        redirect_uri: 'http://localhost:3000/google',
-      })(c, next)
-    },
-  )
+  app.use('/google-custom-redirect', (c, next) => {
+    return googleAuth({
+      client_id,
+      client_secret,
+      scope: ['openid', 'email', 'profile'],
+      redirect_uri: 'http://localhost:3000/google',
+    })(c, next)
+  })
   app.get('/google', (c) => {
     const user = c.get('user-google')
     const token = c.get('token')
@@ -104,6 +101,15 @@ describe('OAuth Middleware', () => {
       ],
     })
   )
+  app.use('/facebook-custom-redirect', (c, next) =>
+    facebookAuth({
+      client_id,
+      client_secret,
+      scope: [],
+      fields: [],
+      redirect_uri: 'http://localhost:3000/facebook',
+    })(c, next)
+  )
   app.get('/facebook', (c) => {
     const user = c.get('user-facebook')
     const token = c.get('token')
@@ -123,6 +129,13 @@ describe('OAuth Middleware', () => {
       client_id,
       client_secret,
     })
+  )
+  app.use('/github/app-custom-redirect', (c, next) =>
+    githubAuth({
+      client_id,
+      client_secret,
+      redirect_uri: 'http://localhost:3000/github/app',
+    })(c, next)
   )
   app.get('/github/app', (c) => {
     const token = c.get('token')
@@ -167,6 +180,14 @@ describe('OAuth Middleware', () => {
       scope: ['email', 'openid', 'profile'],
     })
   )
+  app.use('/linkedin-custom-redirect', (c, next) =>
+    linkedinAuth({
+      client_id,
+      client_secret,
+      scope: ['email', 'openid', 'profile'],
+      redirect_uri: 'http://localhost:3000/linkedin',
+    })(c, next)
+  )
   app.get('/linkedin', (c) => {
     const token = c.get('token')
     const refreshToken = c.get('refresh-token')
@@ -204,6 +225,15 @@ describe('OAuth Middleware', () => {
         'withheld',
       ],
     })
+  )
+  app.use('/x-custom-redirect', (c, next) =>
+    xAuth({
+      client_id,
+      client_secret,
+      scope: [],
+      fields: [],
+      redirect_uri: 'http://localhost:3000/x',
+    })(c, next)
   )
   app.get('/x', (c) => {
     const token = c.get('token')
@@ -251,6 +281,14 @@ describe('OAuth Middleware', () => {
       client_secret,
       scope: ['identify', 'email'],
     })
+  )
+  app.use('/discord-custom-redirect', (c, next) =>
+    discordAuth({
+      client_id,
+      client_secret,
+      scope: ['identify', 'email'],
+      redirect_uri: 'http://localhost:3000/discord',
+    })(c, next)
   )
   app.get('/discord', (c) => {
     const token = c.get('token')
@@ -341,8 +379,7 @@ describe('OAuth Middleware', () => {
         grantedScopes: string[]
       }
 
-      expect(res).not.toBeNull()
-      expect(res.status).toBe(200)
+      expect(res?.status).toBe(200)
       expect(response.user).toEqual(googleUser)
       expect(response.grantedScopes).toEqual(dummyToken.scope.split(' '))
       expect(response.token).toEqual({
@@ -358,6 +395,14 @@ describe('OAuth Middleware', () => {
 
       expect(res).not.toBeNull()
       expect(res.status).toBe(302)
+    })
+
+    it('Should redirect to custom redirect_uri', async () => {
+      const res = await app.request('/facebook-custom-redirect')
+      expect(res?.status).toBe(302)
+      const redirectLocation = res.headers.get('location')!
+      const redirectUrl = new URL(redirectLocation)
+      expect(redirectUrl.searchParams.get('redirect_uri')).toBe('http://localhost:3000/facebook')
     })
 
     it('Prevent CSRF attack', async () => {
@@ -402,6 +447,16 @@ describe('OAuth Middleware', () => {
 
         expect(res).not.toBeNull()
         expect(res.status).toBe(302)
+      })
+
+      it('Should redirect to custom redirect_uri', async () => {
+        const res = await app.request('/github/app-custom-redirect')
+        expect(res?.status).toBe(302)
+        const redirectLocation = res.headers.get('location')!
+        const redirectUrl = new URL(redirectLocation)
+        expect(redirectUrl.searchParams.get('redirect_uri')).toBe(
+          'http://localhost:3000/github/app'
+        )
       })
 
       it('Should throw error for invalide code', async () => {
@@ -480,6 +535,14 @@ describe('OAuth Middleware', () => {
       expect(res.status).toBe(302)
     })
 
+    it('Should redirect to custom redirect_uri', async () => {
+      const res = await app.request('/linkedin-custom-redirect')
+      expect(res?.status).toBe(302)
+      const redirectLocation = res.headers.get('location')!
+      const redirectUrl = new URL(redirectLocation)
+      expect(redirectUrl.searchParams.get('redirect_uri')).toBe('http://localhost:3000/linkedin')
+    })
+
     it('Should throw error for invalide code', async () => {
       const res = await app.request('/linkedin?code=9348ffdsd-sdsdbad-code')
 
@@ -519,6 +582,14 @@ describe('OAuth Middleware', () => {
 
         expect(res).not.toBeNull()
         expect(res.status).toBe(302)
+      })
+
+      it('Should redirect to custom redirect_uri', async () => {
+        const res = await app.request('/x-custom-redirect')
+        expect(res?.status).toBe(302)
+        const redirectLocation = res.headers.get('location')!
+        const redirectUrl = new URL(redirectLocation)
+        expect(redirectUrl.searchParams.get('redirect_uri')).toBe('http://localhost:3000/x')
       })
 
       it('Prevent CSRF attack', async () => {
@@ -607,6 +678,14 @@ describe('OAuth Middleware', () => {
 
         expect(res).not.toBeNull()
         expect(res.status).toBe(302)
+      })
+
+      it('Should redirect to custom redirect_uri', async () => {
+        const res = await app.request('/discord-custom-redirect')
+        expect(res?.status).toBe(302)
+        const redirectLocation = res.headers.get('location')!
+        const redirectUrl = new URL(redirectLocation)
+        expect(redirectUrl.searchParams.get('redirect_uri')).toBe('http://localhost:3000/discord')
       })
 
       it('Prevent CSRF attack', async () => {

--- a/packages/oauth-providers/test/index.test.ts
+++ b/packages/oauth-providers/test/index.test.ts
@@ -379,7 +379,8 @@ describe('OAuth Middleware', () => {
         grantedScopes: string[]
       }
 
-      expect(res?.status).toBe(200)
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(200)
       expect(response.user).toEqual(googleUser)
       expect(response.grantedScopes).toEqual(dummyToken.scope.split(' '))
       expect(response.token).toEqual({

--- a/packages/oauth-providers/test/index.test.ts
+++ b/packages/oauth-providers/test/index.test.ts
@@ -62,6 +62,17 @@ describe('OAuth Middleware', () => {
       scope: ['openid', 'email', 'profile'],
     })
   )
+  app.use(
+    '/google-custom-redirect',
+    (c, next) => {
+      return googleAuth({
+        client_id,
+        client_secret,
+        scope: ['openid', 'email', 'profile'],
+        redirect_uri: 'http://localhost:3000/google',
+      })(c, next)
+    },
+  )
   app.get('/google', (c) => {
     const user = c.get('user-google')
     const token = c.get('token')
@@ -295,6 +306,16 @@ describe('OAuth Middleware', () => {
 
       expect(res).not.toBeNull()
       expect(res.status).toBe(302)
+      expect(res.headers)
+    })
+
+    it('Should redirect to custom redirect_uri', async () => {
+      const res = await app.request('/google-custom-redirect')
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(302)
+      const redirectLocation = res.headers.get('location')!
+      const redirectUrl = new URL(redirectLocation)
+      expect(redirectUrl.searchParams.get('redirect_uri')).toBe('http://localhost:3000/google')
     })
 
     it('Prevent CSRF attack', async () => {

--- a/packages/oauth-providers/test/index.test.ts
+++ b/packages/oauth-providers/test/index.test.ts
@@ -2,9 +2,9 @@ import { Hono } from 'hono'
 import { setupServer } from 'msw/node'
 import type { DiscordUser } from '../src/providers/discord'
 import {
+  discordAuth,
   refreshToken as discordRefresh,
   revokeToken as discordRevoke,
-  discordAuth,
 } from '../src/providers/discord'
 import { facebookAuth } from '../src/providers/facebook'
 import type { FacebookUser } from '../src/providers/facebook'
@@ -18,30 +18,30 @@ import type { XUser } from '../src/providers/x'
 import { refreshToken, revokeToken, xAuth } from '../src/providers/x'
 import type { Token } from '../src/types'
 import {
+  discordCodeError,
+  discordRefreshToken,
+  discordRefreshTokenError,
+  discordToken,
+  discordUser,
+  dummyCode,
   dummyToken,
+  facebookCodeError,
+  facebookUser,
+  githubCodeError,
+  githubToken,
+  githubUser,
+  googleCodeError,
   googleUser,
   handlers,
-  facebookUser,
-  githubUser,
-  dummyCode,
-  googleCodeError,
-  facebookCodeError,
-  githubToken,
-  githubCodeError,
   linkedInCodeError,
-  linkedInUser,
   linkedInToken,
+  linkedInUser,
   xCodeError,
-  xUser,
-  xToken,
   xRefreshToken,
   xRefreshTokenError,
   xRevokeTokenError,
-  discordCodeError,
-  discordUser,
-  discordToken,
-  discordRefreshToken,
-  discordRefreshTokenError,
+  xToken,
+  xUser,
 } from './handlers'
 
 const server = setupServer(...handlers)


### PR DESCRIPTION
Previously oauth middlewares only set redirect_uri from `c.req.url` which I felt restrictive:

1. hono (and the server process) may not be able to infer the redirect uri correctly. e.g. when it doesn't know its internet hostname.
2. developer may want to start oauth flow from routes other than the callback path.
3. developer may want to encode something into `redirect_uri`, like another redirect dest after authorization succeeds.

Allowing a custom `redirect_uri` would support these usages. Please see updated middleware readme for an example.