### PR TITLE
Bugfix/603 hono node ws duplicate event listeners

### DIFF
--- a/.changeset/olive-ducks-end.md
+++ b/.changeset/olive-ducks-end.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': patch
+---
+
+Fixed bug with multiple connections in node-ws

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -5,22 +5,18 @@ import { WebSocket } from 'ws'
 import { createNodeWebSocket } from '.'
 
 describe('WebSocket helper', () => {
-  const app = new Hono()
-  const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app })
+  let app: Hono
+  let server: ServerType
+  let injectWebSocket: ReturnType<typeof createNodeWebSocket>['injectWebSocket']
+  let upgradeWebSocket: ReturnType<typeof createNodeWebSocket>['upgradeWebSocket']
 
-  const mainPromise = new Promise((resolve) =>
-    app.get(
-      '/',
-      upgradeWebSocket(() => ({
-        onOpen() {
-          resolve(true)
-        },
-      }))
-    )
-  )
+  beforeEach(async () => {
+    app = new Hono()
+    const websocketHelpers = createNodeWebSocket({ app })
+    injectWebSocket = websocketHelpers.injectWebSocket
+    upgradeWebSocket = websocketHelpers.upgradeWebSocket
 
-  it('Should be able to connect', async () => {
-    const server = await new Promise<ServerType>((resolve) => {
+    server = await new Promise<ServerType>((resolve) => {
       const server = serve(
         {
           fetch: app.fetch,
@@ -32,8 +28,91 @@ describe('WebSocket helper', () => {
       )
     })
     injectWebSocket(server)
+  })
+
+  afterEach(() => {
+    server.close()
+  })
+
+  it('Should be able to connect', async () => {
+    const mainPromise = new Promise<boolean>((resolve) =>
+      app.get(
+        '/',
+        upgradeWebSocket(() => ({
+          onOpen() {
+            resolve(true)
+          },
+        }))
+      )
+    )
+
     new WebSocket('ws://localhost:3030/')
 
     expect(await mainPromise).toBe(true)
+  })
+
+  it('Should be able to send and receive messages', async () => {
+    const mainPromise = new Promise((resolve) =>
+      app.get(
+        '/',
+        upgradeWebSocket(() => ({
+          onMessage(data) {
+            resolve(data.data)
+          },
+        }))
+      )
+    )
+
+    const ws = new WebSocket('ws://localhost:3030/')
+    await new Promise<void>((resolve) => ws.on('open', resolve))
+    ws.send('Hello')
+
+    expect(await mainPromise).toBe('Hello')
+  })
+
+  it('Should handle multiple concurrent connections', async () => {
+    const connectionCount = 5
+    let openConnections = 0
+    const messages: string[] = []
+
+    app.get(
+      '/',
+      upgradeWebSocket(() => ({
+        onOpen() {
+          openConnections++
+        },
+        onMessage(data) {
+          messages.push(data.data as string)
+        },
+      }))
+    )
+
+    const connections = await Promise.all(
+      Array(connectionCount)
+        .fill(null)
+        .map(async () => {
+          const ws = new WebSocket('ws://localhost:3030/')
+          await new Promise<void>((resolve) => ws.on('open', resolve))
+          return ws
+        })
+    )
+
+    expect(openConnections).toBe(connectionCount)
+
+    await Promise.all(
+      connections.map((ws, index) => {
+        return new Promise<void>((resolve) => {
+          ws.send(`Hello from connection ${index + 1}`)
+          ws.on('message', () => resolve())
+        })
+      })
+    )
+
+    expect(messages.length).toBe(connectionCount)
+    messages.forEach((msg, index) => {
+      expect(msg).toBe(`Hello from connection ${index + 1}`)
+    })
+
+    connections.forEach((ws) => ws.close())
   })
 })

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -12,20 +12,10 @@ describe('WebSocket helper', () => {
 
   beforeEach(async () => {
     app = new Hono()
-    const websocketHelpers = createNodeWebSocket({ app })
-    injectWebSocket = websocketHelpers.injectWebSocket
-    upgradeWebSocket = websocketHelpers.upgradeWebSocket
+    ;({ injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app }))
 
     server = await new Promise<ServerType>((resolve) => {
-      const server = serve(
-        {
-          fetch: app.fetch,
-          port: 3030,
-        },
-        () => {
-          resolve(server)
-        }
-      )
+      const server = serve({ fetch: app.fetch, port: 3030 }, () => resolve(server))
     })
     injectWebSocket(server)
   })
@@ -81,8 +71,9 @@ describe('WebSocket helper', () => {
         onOpen() {
           openConnections++
         },
-        onMessage(data) {
+        onMessage(data, ws) {
           messages.push(data.data as string)
+          ws.send(data.data as string)
         },
       }))
     )

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -52,7 +52,10 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
           return
         }
         const events = await createEvents(c)
-        wss.on('connection', (ws) => {
+        wss.on('connection', (ws, request) => {
+          if (request !== c.env.incoming) {
+            return
+          }
           const ctx: WSContext = {
             binaryType: 'arraybuffer',
             close(code, reason) {

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -20,7 +20,7 @@ export interface NodeWebSocketInit {
  * @returns NodeWebSocket
  */
 export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
-  const wss = new WebSocketServer({noServer: true})
+  const wss = new WebSocketServer({ noServer: true })
 
   return {
     injectWebSocket(server) {
@@ -34,9 +34,11 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
           }
           headers.append(key, Array.isArray(value) ? value[0] : value)
         }
-        await init.app.request(url, {
-          headers: headers,
-        })
+        await init.app.request(
+          url,
+          { headers: headers },
+          { incoming: request, outcoming: undefined }
+        )
         wss.handleUpgrade(request, socket, head, (ws) => {
           wss.emit('connection', ws, request)
         })

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -37,7 +37,7 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
         await init.app.request(
           url,
           { headers: headers },
-          { incoming: request, outcoming: undefined }
+          { incoming: request, outgoing: undefined }
         )
         wss.handleUpgrade(request, socket, head, (ws) => {
           wss.emit('connection', ws, request)


### PR DESCRIPTION
Fixed a bug when multiple connections are created in node-ws, as pointed out in #603 

Summary of changes:
- Fixed bug with multiple connections in node-ws
- Add relevant tests
- Fixed an issue that prevented access to node.js-specific APIs within upgradeWebocket handlers

