### PR TITLE
docs(oauth-providers): use process.env instead of Bun.env as default

### DIFF
--- a/packages/oauth-providers/README.md
+++ b/packages/oauth-providers/README.md
@@ -28,8 +28,8 @@ Also, there is two ways to use this middleware:
 app.use(
   '/google',
   googleAuth({
-    client_id: Bun.env.GOOGLE_ID,
-    client_secret: Bun.env.GOOGLE_SECRET,
+    client_id: process.env.GOOGLE_ID,
+    client_secret: process.env.GOOGLE_SECRET,
     scope: ['openid', 'email', 'profile'],
   })
 )
@@ -55,8 +55,8 @@ Or
 app.get(
   '/google',
   googleAuth({
-    client_id: Bun.env.GOOGLE_ID,
-    client_secret: Bun.env.GOOGLE_SECRET,
+    client_id: process.env.GOOGLE_ID,
+    client_secret: process.env.GOOGLE_SECRET,
     scope: ['openid', 'email', 'profile'],
   }),
   (c) => {
@@ -75,6 +75,8 @@ app.get(
 export default app
 ```
 
+If you are using Bun, replace `process.env` to `Bun.env` to resolve Environments at runtime.
+
 ### Google
 
 ```ts
@@ -86,8 +88,8 @@ const app = new Hono()
 app.use(
   '/google',
   googleAuth({
-    client_id: Bun.env.GOOGLE_ID,
-    client_secret: Bun.env.GOOGLE_SECRET,
+    client_id: process.env.GOOGLE_ID,
+    client_secret: process.env.GOOGLE_SECRET,
     scope: ['openid', 'email', 'profile'],
   })
 )
@@ -198,8 +200,8 @@ const app = new Hono()
 app.use(
   '/facebook',
   facebookAuth({
-    client_id: Bun.env.FACEBOOK_ID,
-    client_secret: Bun.env.FACEBOOK_SECRET,
+    client_id: process.env.FACEBOOK_ID,
+    client_secret: process.env.FACEBOOK_SECRET,
     scope: ['email', 'public_profile'],
     fields: [
       'email',
@@ -410,8 +412,8 @@ const app = new Hono()
 app.use(
   '/github',
   githubAuth({
-    client_id: Bun.env.GITHUB_ID,
-    client_secret: Bun.env.GITHUB_SECRET,
+    client_id: process.env.GITHUB_ID,
+    client_secret: process.env.GITHUB_SECRET,
   })
 )
 
@@ -439,8 +441,8 @@ const app = new Hono()
 app.use(
   '/github',
   githubAuth({
-    client_id: Bun.env.GITHUB_ID,
-    client_secret: Bun.env.GITHUB_SECRET,
+    client_id: process.env.GITHUB_ID,
+    client_secret: process.env.GITHUB_SECRET,
     scope: ['public_repo', 'read:user', 'user', 'user:email', 'user:follow'],
     oauthApp: true,
   })
@@ -543,8 +545,8 @@ const app = new Hono()
 app.use(
   '/linkedin',
   linkedinAuth({
-    client_id: Bun.env.LINKEDIN_ID,
-    client_secret: Bun.env.LINKEDIN_SECRET,
+    client_id: process.env.LINKEDIN_ID,
+    client_secret: process.env.LINKEDIN_SECRET,
     scope: ['email', 'openid', 'profile'],
   })
 )
@@ -573,8 +575,8 @@ const app = new Hono()
 app.use(
   '/linkedin',
   linkedinAuth({
-    client_id: Bun.env.LINKEDIN_ID,
-    client_secret: Bun.env.LINKEDIN_SECRET,
+    client_id: process.env.LINKEDIN_ID,
+    client_secret: process.env.LINKEDIN_SECRET,
     appAuth: true,
   })
 )
@@ -627,8 +629,8 @@ const app = new Hono()
 app.use(
   '/x',
   xAuth({
-    client_id: Bun.env.X_ID,
-    client_secret: Bun.env.X_SECRET,
+    client_id: process.env.X_ID,
+    client_secret: process.env.X_SECRET,
     scope: ['tweet.read', 'users.read', 'offline.access'],
     fields: ['profile_image_url', 'url'],
   })
@@ -784,8 +786,8 @@ const app = new Hono()
 app.use(
   '/discord',
   discordAuth({
-    client_id: Bun.env.DISCORD_ID,
-    client_secret: Bun.env.DISCORD_SECRET,
+    client_id: process.env.DISCORD_ID,
+    client_secret: process.env.DISCORD_SECRET,
     scope: ['identify', 'email'],
   })
 )


### PR DESCRIPTION
Now Bun is not standard, so I think README should use `process.env` instead of `Bun.env`, so I replaced `Bun.env` to `process.env` in this PR.
But there is a difference between `Bun.env` and `process.env`, I also added note about Bun.