### PR TITLE
feat(zod-openapi): expose `extendZodWithOpenApi` from `zod-to-openapi`

### DIFF
--- a/.changeset/tricky-bugs-switch.md
+++ b/.changeset/tricky-bugs-switch.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+expose `extendZodWithOpenApi` from `zod-to-openapi`

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -548,7 +548,7 @@ export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'
 }
 
 extendZodWithOpenApi(z)
-export { z }
+export { extendZodWithOpenApi, z }
 
 function addBasePathToDocument(document: Record<string, any>, basePath: string) {
   const updatedPaths: Record<string, any> = {}


### PR DESCRIPTION
Fixes #631.

Just to add some context why I think it's valuable - I have plenty of zod schemas already and some of them aren't used by Hono at all, but I don't want to be limited and decide whether to use import from the middleware or directly from `zod`, I just want to use the `zod` export everywhere.

It's your call, but I'd even encourage using this method (i.e. using `extendZodWithOpenApi` instead of importing `z`) in the documentation as it gives much more flexibility.