### PR TITLE
fix(node-ws): binary messages have wrong byteLength

### DIFF
--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -94,10 +94,9 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
           ws.on('message', (data, isBinary) => {
             const datas = Array.isArray(data) ? data : [data]
             for (const data of datas) {
-              const buff: Buffer = Buffer.from(data)
               events.onMessage?.(
                 new MessageEvent('message', {
-                  data: isBinary ? buff.buffer : buff.toString('utf-8'),
+                  data: isBinary ? data : data.toString('utf-8'),
                 }),
                 ctx
               )


### PR DESCRIPTION
Using the `Buffer.from` method, it creates an 8192-byte buffer (ref. https://nodejs.org/api/buffer.html#class-property-bufferpoolsize) so by using small 8-byte messages in Websocket communication, it creates extra stuff we don't need.

In addition, it eliminates the need to create an unnecessary buffer instance, as `ws` already creates one.

I also added a test for binary messages