### PR TITLE
fix(graphql-server): update example code to Typescript and parameter name

### DIFF
--- a/packages/graphql-server/README.md
+++ b/packages/graphql-server/README.md
@@ -16,11 +16,11 @@ yarn add @hono/graphql-server
 
 ## Usage
 
-index.js:
+index.ts:
 
-```js
+```ts
 import { Hono } from 'hono'
-import { graphqlServer } from '@hono/graphql-server'
+import { type RootResolver, graphqlServer } from '@hono/graphql-server'
 import { buildSchema } from 'graphql'
 
 export const app = new Hono()
@@ -31,7 +31,7 @@ type Query {
 }
 `)
 
-const rootResolver = (ctx) => {
+const rootResolver: RootResolver = (c) => {
   return {
     hello: () => 'Hello Hono!',
   }

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -23,7 +23,7 @@ import { parseBody } from './parse-body'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RootResolver<E extends Env = any, P extends string = any, I extends Input = {}> = (
   // eslint-enable-next-line @typescript-eslint/no-explicit-any
-  ctx?: Context<E, P, I>
+  c?: Context<E, P, I>
 ) => Promise<unknown> | unknown
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This Pull Request makes the following changes for consistency with other middleware:

- Changed the README example code to TypeScript.
- Renamed the variable representing `Context` from `ctx` to `c`.