### PR TITLE
fix(node-ws): `CloseEvent` is not defined

### DIFF
--- a/.changeset/light-goats-teach.md
+++ b/.changeset/light-goats-teach.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': patch
+---
+
+Add a `CloseEvent` class to avoid exception "CloseEvent is not defined"

--- a/packages/node-ws/src/events.ts
+++ b/packages/node-ws/src/events.ts
@@ -1,0 +1,32 @@
+interface CloseEventInit extends EventInit {
+    code?: number;
+    reason?: string;
+    wasClean?: boolean;
+}
+
+/**
+ * @link https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
+ */
+export class CloseEvent extends Event {
+    #eventInitDict
+
+    constructor(
+        type: string,
+        eventInitDict: CloseEventInit = {}
+    ) {
+        super(type, eventInitDict)
+        this.#eventInitDict = eventInitDict
+    }
+
+    get wasClean(): boolean {
+        return this.#eventInitDict.wasClean ?? false
+    }
+
+    get code(): number {
+        return this.#eventInitDict.code ?? 0
+    }
+
+    get reason(): string {
+        return this.#eventInitDict.reason ?? ''
+    }
+}

--- a/packages/node-ws/src/events.ts
+++ b/packages/node-ws/src/events.ts
@@ -7,7 +7,7 @@ interface CloseEventInit extends EventInit {
 /**
  * @link https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
  */
-export class CloseEvent extends Event {
+export const CloseEvent = globalThis.CloseEvent ?? class extends Event {
     #eventInitDict
 
     constructor(

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -13,7 +13,7 @@ describe('WebSocket helper', () => {
 
   beforeEach(async () => {
     app = new Hono()
-    ;({ injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app }))
+      ; ({ injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app }))
 
     server = await new Promise<ServerType>((resolve) => {
       const server = serve({ fetch: app.fetch, port: 3030 }, () => resolve(server))
@@ -106,6 +106,19 @@ describe('WebSocket helper', () => {
     })
 
     connections.forEach((ws) => ws.close())
+  })
+
+  it('CloseEvent should be executed without crash', async () => {
+    app.get(
+      '/',
+      upgradeWebSocket(() => ({
+        onClose() {},
+      }))
+    )
+
+    const ws = new WebSocket('ws://localhost:3030/')
+    await new Promise<void>((resolve) => ws.on('open', resolve))
+    ws.close();
   })
 
   it('Should be able to send and receive binary content with good length', async () => {

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -126,7 +126,7 @@ describe('WebSocket helper', () => {
     await new Promise<void>((resolve) => ws.on('open', resolve))
     ws.send(binaryData)
 
-    const receivedMessage = await mainPromise;
+    const receivedMessage = await mainPromise
     expect(receivedMessage).toBeInstanceOf(Buffer)
     expect((receivedMessage as Buffer).byteLength).toBe(binaryData.length)
 

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -13,7 +13,8 @@ describe('WebSocket helper', () => {
 
   beforeEach(async () => {
     app = new Hono()
-      ; ({ injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app }))
+    
+    ;({ injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app }))
 
     server = await new Promise<ServerType>((resolve) => {
       const server = serve({ fetch: app.fetch, port: 3030 }, () => resolve(server))
@@ -112,13 +113,15 @@ describe('WebSocket helper', () => {
     app.get(
       '/',
       upgradeWebSocket(() => ({
-        onClose() {},
+        onClose() {
+          // doing some stuff here
+        },
       }))
     )
 
     const ws = new WebSocket('ws://localhost:3030/')
     await new Promise<void>((resolve) => ws.on('open', resolve))
-    ws.close();
+    ws.close()
   })
 
   it('Should be able to send and receive binary content with good length', async () => {

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer'
 import type { Server } from 'node:http'
 import type { Http2SecureServer, Http2Server } from 'node:http2'
 import type { Hono } from 'hono'
@@ -6,6 +5,7 @@ import type { UpgradeWebSocket, WSContext } from 'hono/ws'
 import type { WebSocket } from 'ws'
 import { WebSocketServer } from 'ws'
 import type { IncomingMessage } from 'http'
+import { CloseEvent } from './events'
 
 export interface NodeWebSocket {
   upgradeWebSocket: UpgradeWebSocket


### PR DESCRIPTION
Currently, `CloseEvent` doesn't exist in the latest versions of Node.js (v18.20.4, v20.15.1 and v22.4.) and you'll get the following error `Uncaught ReferenceError: CloseEvent is not defined` if you have this :

```javascript
app.get(
  '/',
  upgradeWebSocket(() => ({
    onClose() {
      // doing some stuff
    },
  }))
)
```

Fixes #595 
