### PR TITLE
fix(zod-openapi): infer OpenAPIObjectConfig

### DIFF
--- a/.changeset/unlucky-cheetahs-fry.md
+++ b/.changeset/unlucky-cheetahs-fry.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+fix(zod-openapi): infer OpenAPIObjectConfig

--- a/.changeset/unlucky-cheetahs-fry.md
+++ b/.changeset/unlucky-cheetahs-fry.md
@@ -1,5 +1,5 @@
 ---
-'@hono/zod-openapi': minor
+'@hono/zod-openapi': patch
 ---
 
 fix(zod-openapi): infer OpenAPIObjectConfig

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -12,7 +12,6 @@ import {
   OpenApiGeneratorV31,
   extendZodWithOpenApi,
 } from '@asteasolutions/zod-to-openapi'
-import type { OpenAPIObjectConfig } from '@asteasolutions/zod-to-openapi/dist/v3.0/openapi-generator'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import type {
@@ -251,6 +250,10 @@ export type RouteHook<
   P,
   RouteConfigToTypedResponse<R> | Response | Promise<Response> | void | Promise<void>
 >
+
+type OpenAPIObjectConfig = Parameters<
+  InstanceType<typeof OpenApiGeneratorV3>['generateDocument']
+>[0]
 
 export type OpenAPIObjectConfigure<E extends Env, P extends string> =
   | OpenAPIObjectConfig


### PR DESCRIPTION
Fixes #646.

Just infer the `OpenAPIObjectConfig` instead of importing it from the internals, this way `"moduleResolution": "NodeNext"` users will have right intellisense.

I could, of course, just add the `.js` extension to the import, but i think the inferring is the way since it doesn't look like a hack.