### PR TITLE
fix(graphql-server): add type to Middleware Handler

### DIFF
--- a/.changeset/soft-donuts-mix.md
+++ b/.changeset/soft-donuts-mix.md
@@ -1,0 +1,5 @@
+---
+'@hono/graphql-server': patch
+---
+
+fix: add type to Middleware Handler

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -17,7 +17,7 @@ import type {
   GraphQLFormattedError,
 } from 'graphql'
 
-import type { Context, Env, Input } from 'hono'
+import type { Context, Env, Input, MiddlewareHandler } from 'hono'
 import { parseBody } from './parse-body'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +40,7 @@ type Options<E extends Env = any, P extends string = any, I extends Input = {}> 
 export const graphqlServer = <E extends Env = any, P extends string = any, I extends Input = {}>(
   // eslint-enable-next-line @typescript-eslint/no-explicit-any
   options: Options<E, P, I>
-) => {
+): MiddlewareHandler => {
   const schema = options.schema
   const pretty = options.pretty ?? false
   const validationRules = options.validationRules ?? []


### PR DESCRIPTION
Added type to the GraphQL Server Middleware Handler and fixed it to accept a `Next` type argument.