### PR TITLE
feat(zod-validator): pass target from zod-validator to a hook

### DIFF
--- a/.changeset/olive-hounds-shout.md
+++ b/.changeset/olive-hounds-shout.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': minor
+---
+
+feat(zod-validator): pass target to a hook

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -3,8 +3,8 @@ import { validator } from 'hono/validator'
 import type { z, ZodSchema, ZodError } from 'zod'
 
 export type Hook<T, E extends Env, P extends string, O = {}> = (
-  result: { success: true; data: T } | { success: false; error: ZodError; data: T },
-  c: Context<E, P>
+  result: ({ success: true; data: T} | { success: false; error: ZodError; data: T }) & {target: keyof ValidationTargets },
+  c: Context<E, P>,
 ) => Response | void | TypedResponse<O> | Promise<Response | void | TypedResponse<O>>
 
 type HasUndefined<T> = undefined extends T ? true : false
@@ -45,7 +45,7 @@ export const zValidator = <
     const result = await schema.safeParseAsync(value)
 
     if (hook) {
-      const hookResult = await hook({ data: value, ...result }, c)
+      const hookResult = await hook({ data: value, ...result, target, }, c)
       if (hookResult) {
         if (hookResult instanceof Response) {
           return hookResult

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -2,8 +2,8 @@ import type { Context, MiddlewareHandler, Env, ValidationTargets, TypedResponse,
 import { validator } from 'hono/validator'
 import type { z, ZodSchema, ZodError } from 'zod'
 
-export type Hook<T, E extends Env, P extends string, O = {}> = (
-  result: ({ success: true; data: T} | { success: false; error: ZodError; data: T }) & {target: keyof ValidationTargets },
+export type Hook<T, E extends Env, P extends string, Target extends keyof ValidationTargets = keyof ValidationTargets, O = {}> = (
+  result: ({ success: true; data: T} | { success: false; error: ZodError; data: T }) & {target: Target },
   c: Context<E, P>,
 ) => Response | void | TypedResponse<O> | Promise<Response | void | TypedResponse<O>>
 
@@ -38,7 +38,7 @@ export const zValidator = <
 >(
   target: Target,
   schema: T,
-  hook?: Hook<z.infer<T>, E, P>
+  hook?: Hook<z.infer<T>, E, P, Target>
 ): MiddlewareHandler<E, P, V> =>
   // @ts-expect-error not typed well
   validator(target, async (value, c) => {

--- a/packages/zod-validator/test/index.test.ts
+++ b/packages/zod-validator/test/index.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { zValidator } from '../src'
 import {vi} from 'vitest'
 
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
 

--- a/packages/zod-validator/test/index.test.ts
+++ b/packages/zod-validator/test/index.test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import type { Equal, Expect } from 'hono/utils/types'
 import { z } from 'zod'
 import { zValidator } from '../src'
+import {vi} from 'vitest'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
@@ -254,5 +255,48 @@ describe('With Async Hook', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(400)
     expect(await res.text()).toBe('123 is invalid!')
+  })
+})
+
+
+describe('With target', () => {
+  it('should call hook for correctly validated target', async () => {
+    const app = new Hono()
+
+    const schema = z.object({
+      id: z.string(),
+    })
+
+    const jsonHook = vi.fn()
+    const paramHook = vi.fn()
+    const queryHook = vi.fn()
+    app.post(
+      '/:id/post',
+      zValidator('json', schema, jsonHook),
+      zValidator('param', schema, paramHook),
+      zValidator('query', schema, queryHook),
+      (c) => {
+        return c.text('ok')
+      }
+    )
+
+    const req = new Request('http://localhost/1/post?id=2', {
+      body: JSON.stringify({
+        id: '3',
+      }),
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    const res = await app.request(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('ok')
+    expect(paramHook).toHaveBeenCalledWith({data: {id: '1'}, success: true, target:
+        'param'}, expect.anything())
+    expect(queryHook).toHaveBeenCalledWith({data: {id: '2'}, success: true, target: 'query'}, expect.anything())
+    expect(jsonHook).toHaveBeenCalledWith({data: {id: '3'}, success: true, target: 'json'}, expect.anything())
   })
 })


### PR DESCRIPTION
Today, when we use `zod-openapi` and pass schema for `body` and `params`, we can pass a hook which is called with the result of the validation. 

The function doesn't get information about the target being validated. This is problematic when we want to return custom error responses depending on the target being validated. For example, one may want to:
-  return status `415 Unsupported Media Type` when body parsing failed due to missing content-type. Such behaviour doesn't make sense for `params`
- include in the error message the place where the validation failed. For `json` we may write in the response body 'body validation failed', for `params` 'path validation failed' and for `query` 'search params validation failed' .

This pull request adds this functionality.