### PR TITLE
fix(@hono/oauth-providers): Added missing URL parameters prompt, login_hint, and access_type in the Google OAuth provider.

### DIFF
--- a/.changeset/rare-fishes-sort.md
+++ b/.changeset/rare-fishes-sort.md
@@ -1,0 +1,5 @@
+---
+"@hono/oauth-providers": patch
+---
+
+fix(@hono/oauth-providers): google provider attach custom parameters

--- a/packages/oauth-providers/src/providers/google/authFlow.ts
+++ b/packages/oauth-providers/src/providers/google/authFlow.ts
@@ -14,6 +14,7 @@ type GoogleAuthFlow = {
   state?: string
   login_hint?: string
   prompt?: 'none' | 'consent' | 'select_account'
+  access_type?: 'offline' | 'online'
 }
 
 export class AuthFlow {
@@ -28,6 +29,7 @@ export class AuthFlow {
   prompt: 'none' | 'consent' | 'select_account' | undefined
   user: Partial<GoogleUser> | undefined
   granted_scopes: string[] | undefined
+  access_type: 'offline' | 'online' | undefined
 
   constructor({
     client_id,
@@ -39,6 +41,7 @@ export class AuthFlow {
     state,
     code,
     token,
+    access_type
   }: GoogleAuthFlow) {
     this.client_id = client_id
     this.client_secret = client_secret
@@ -51,6 +54,7 @@ export class AuthFlow {
     this.token = token
     this.user = undefined
     this.granted_scopes = undefined
+    this.access_type = access_type
 
     if (
       this.client_id === undefined ||
@@ -71,6 +75,9 @@ export class AuthFlow {
       include_granted_scopes: true,
       scope: this.scope.join(' '),
       state: this.state,
+      prompt: this.prompt,
+      login_hint: this.login_hint,
+      access_type: this.access_type,
     })
     return `https://accounts.google.com/o/oauth2/v2/auth?${parsedOptions}`
   }

--- a/packages/oauth-providers/src/providers/google/authFlow.ts
+++ b/packages/oauth-providers/src/providers/google/authFlow.ts
@@ -41,7 +41,7 @@ export class AuthFlow {
     state,
     code,
     token,
-    access_type
+    access_type,
   }: GoogleAuthFlow) {
     this.client_id = client_id
     this.client_secret = client_secret

--- a/packages/oauth-providers/src/providers/google/googleAuth.ts
+++ b/packages/oauth-providers/src/providers/google/googleAuth.ts
@@ -1,6 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
-import { getCookie, setCookie } from 'hono/cookie'
 import { env } from 'hono/adapter'
+import { getCookie, setCookie } from 'hono/cookie'
 import { HTTPException } from 'hono/http-exception'
 
 import { getRandomState } from '../../utils/getRandomState'
@@ -10,6 +10,7 @@ export function googleAuth(options: {
   scope: string[]
   login_hint?: string
   prompt?: 'none' | 'consent' | 'select_account'
+  access_type?: 'online' | 'offline'
   client_id?: string
   client_secret?: string
   state?: string
@@ -24,6 +25,7 @@ export function googleAuth(options: {
       redirect_uri: options.redirect_uri || c.req.url.split('?')[0],
       login_hint: options.login_hint,
       prompt: options.prompt,
+      access_type: options.access_type,
       scope: options.scope,
       state: newState,
       code: c.req.query('code'),


### PR DESCRIPTION
Added missing URL parameters `prompt`, `login_hint,` and `access_type` in the Google OAuth provider.

https://developers.google.com/identity/protocols/oauth2/web-server#httprest