### PR TITLE
oidc-auth: restrict cookie path

### DIFF
--- a/.changeset/new-months-trade.md
+++ b/.changeset/new-months-trade.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': minor
+---
+
+Optionally restrict cookie path with new envvar OIDC_COOKIE_PATH

--- a/.changeset/nine-geese-sniff.md
+++ b/.changeset/nine-geese-sniff.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': minor
+---
+
+Restrict path of callback cookies to pathname of OIDC_REDIRECT_URI

--- a/packages/oidc-auth/package.json
+++ b/packages/oidc-auth/package.json
@@ -38,17 +38,17 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240815.0",
     "@jest/globals": "^29.7.0",
-    "@types/jest": "^29.5.11",
-    "@types/jsonwebtoken": "^9.0.5",
+    "@types/jest": "^29.5.12",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^22.4.1",
-    "hono": "^4.0.1",
+    "hono": "^4.5.6",
     "jest": "^29.7.0",
     "jsonwebtoken": "^9.0.2",
-    "ts-jest": "^29.1.1",
-    "tsup": "^8.0.1",
-    "typescript": "^5.3.3"
+    "ts-jest": "^29.2.4",
+    "tsup": "^8.2.4",
+    "typescript": "^5.5.4"
   },
   "dependencies": {
-    "oauth4webapi": "^2.6.0"
+    "oauth4webapi": "^2.12.0"
   }
 }

--- a/packages/oidc-auth/package.json
+++ b/packages/oidc-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono/oidc-auth",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "OpenID Connect Authentication middleware for Hono",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/oidc-auth/package.json
+++ b/packages/oidc-auth/package.json
@@ -36,8 +36,11 @@
     "hono": ">=3.*"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240815.0",
+    "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.11",
     "@types/jsonwebtoken": "^9.0.5",
+    "@types/node": "^22.4.1",
     "hono": "^4.0.1",
     "jest": "^29.7.0",
     "jsonwebtoken": "^9.0.2",

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -120,7 +120,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
       return null
     }
     try {
-      auth = await verify(session_jwt, env.OIDC_AUTH_SECRET)
+      auth = await verify(session_jwt, env.OIDC_AUTH_SECRET) as OidcAuth
     } catch (e) {
       deleteCookie(c, oidcAuthCookieName)
       return null
@@ -199,7 +199,7 @@ export const revokeSession = async (c: Context): Promise<void> => {
   if (session_jwt !== undefined) {
     const env = getOidcAuthEnv(c)
     deleteCookie(c, oidcAuthCookieName)
-    const auth: OidcAuth = await verify(session_jwt, env.OIDC_AUTH_SECRET)
+    const auth: OidcAuth = await verify(session_jwt, env.OIDC_AUTH_SECRET) as OidcAuth
     if (auth.rtk !== undefined && auth.rtk !== '') {
       // revoke refresh token
       const as = await getAuthorizationServer(c)
@@ -215,7 +215,7 @@ export const revokeSession = async (c: Context): Promise<void> => {
       }
     }
   }
-  c.set('oidcAuth', undefined)
+  c.set('oidcAuth', null)
 }
 
 /**

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -4,7 +4,7 @@
 
 import type { Context, MiddlewareHandler } from 'hono'
 import { env } from 'hono/adapter'
-import { getCookie, setCookie, deleteCookie } from 'hono/cookie'
+import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
 import { HTTPException } from 'hono/http-exception'
 import { sign, verify } from 'hono/jwt'
@@ -123,7 +123,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
     try {
       auth = await verify(session_jwt, env.OIDC_AUTH_SECRET) as OidcAuth
     } catch (e) {
-      deleteCookie(c, oidcAuthCookieName)
+      deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/'} )
       return null
     }
     if (auth === null || auth.rtkexp === undefined || auth.ssnexp === undefined) {
@@ -138,7 +138,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
     if (auth.rtkexp < now) {
       // Refresh the token if it has expired
       if (auth.rtk === undefined || auth.rtk === '') {
-        deleteCookie(c, oidcAuthCookieName)
+        deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/'})
         return null
       }
       const as = await getAuthorizationServer(c)
@@ -147,7 +147,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
       const result = await oauth2.processRefreshTokenResponse(as, client, response)
       if (oauth2.isOAuth2Error(result)) {
         // The refresh_token might be expired or revoked
-        deleteCookie(c, oidcAuthCookieName)
+        deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/'})
         return null
       }
       auth = await updateAuth(c, auth, result)
@@ -199,7 +199,7 @@ export const revokeSession = async (c: Context): Promise<void> => {
   const session_jwt = getCookie(c, oidcAuthCookieName)
   if (session_jwt !== undefined) {
     const env = getOidcAuthEnv(c)
-    deleteCookie(c, oidcAuthCookieName)
+    deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/' })
     const auth: OidcAuth = await verify(session_jwt, env.OIDC_AUTH_SECRET) as OidcAuth
     if (auth.rtk !== undefined && auth.rtk !== '') {
       // revoke refresh token
@@ -274,7 +274,8 @@ export const processOAuthCallback = async (c: Context) => {
 
   // Parses the authorization response and validates the state parameter
   const state = getCookie(c, 'state')
-  deleteCookie(c, 'state')
+  const path = new URL(env.OIDC_REDIRECT_URI).pathname
+  deleteCookie(c, 'state', { path })
   const currentUrl: URL = new URL(c.req.url)
   const params = oauth2.validateAuthResponse(as, client, currentUrl, state)
   if (oauth2.isOAuth2Error(params)) {
@@ -286,11 +287,11 @@ export const processOAuthCallback = async (c: Context) => {
   // Exchanges the authorization code for a refresh token
   const code = c.req.query('code')
   const nonce = getCookie(c, 'nonce')
-  deleteCookie(c, 'nonce')
+  deleteCookie(c, 'nonce', { path })
   const code_verifier = getCookie(c, 'code_verifier')
-  deleteCookie(c, 'code_verifier')
+  deleteCookie(c, 'code_verifier', { path })
   const continue_url = getCookie(c, 'continue')
-  deleteCookie(c, 'continue')
+  deleteCookie(c, 'continue', { path })
   if (code === undefined || nonce === undefined || code_verifier === undefined) {
     throw new HTTPException(500, { message: 'Missing required parameters / cookies' })
   }
@@ -353,7 +354,7 @@ export const oidcAuthMiddleware = (): MiddlewareHandler => {
     try {
       const auth = await getAuth(c)
       if (auth === null) {
-        const path = new URL(env.OIDC_REDIRECT_URI).pathname;
+        const path = new URL(env.OIDC_REDIRECT_URI).pathname
         // Redirect to IdP for login
         const state = oauth2.generateRandomState()
         const nonce = oauth2.generateRandomNonce()
@@ -367,7 +368,7 @@ export const oidcAuthMiddleware = (): MiddlewareHandler => {
         return c.redirect(url)
       }
     } catch (e) {
-      deleteCookie(c, oidcAuthCookieName)
+      deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/' })
       throw new HTTPException(500, { message: 'Invalid session' })
     }
     await next()

--- a/packages/oidc-auth/test/index.test.ts
+++ b/packages/oidc-auth/test/index.test.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { jest } from '@jest/globals'
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 import { Hono } from 'hono'
 import jwt from 'jsonwebtoken'
 import * as oauth2 from 'oauth4webapi'

--- a/packages/oidc-auth/tsconfig.json
+++ b/packages/oidc-auth/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
+    "module": "ESNext"
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
I'd like to restrict the cookie path, e.g. to '/api' only. For that, this pull request introduced an envvar `OIDC_COOKIE_PATH` that defaults back to '/'.
Also, it restricts the path of the callback cookies to the pathname of `OIDC_REDIRECT_URI`