### PR TITLE
perf(swagger-ui): use jsdelivr instead of unpkg to serve swagger-ui assets

### DIFF
--- a/.changeset/beige-snails-cover.md
+++ b/.changeset/beige-snails-cover.md
@@ -1,0 +1,5 @@
+---
+'@hono/swagger-ui': patch
+---
+
+perf: use jsdelivr instead of unpkg to serve swagger-ui assets

--- a/packages/swagger-ui/src/swagger/resource.ts
+++ b/packages/swagger-ui/src/swagger/resource.ts
@@ -1,17 +1,19 @@
 export interface AssetURLs {
-  css: string[]
-  js: string[]
+  css: string[];
+  js: string[];
 }
 
 type ResourceConfig = {
-  version?: string
-}
+  version?: string;
+};
 
 export const remoteAssets = ({ version }: ResourceConfig): AssetURLs => {
-  const url = `https://unpkg.com/swagger-ui-dist${version !== undefined ? `@${version}` : ''}`
+  const url = `https://cdn.jsdelivr.net/npm/swagger-ui-dist${
+    version !== undefined ? `@${version}` : ""
+  }`;
 
   return {
     css: [`${url}/swagger-ui.css`],
     js: [`${url}/swagger-ui-bundle.js`],
-  }
-}
+  };
+};

--- a/packages/swagger-ui/src/swagger/resource.ts
+++ b/packages/swagger-ui/src/swagger/resource.ts
@@ -1,19 +1,19 @@
 export interface AssetURLs {
-  css: string[];
-  js: string[];
+  css: string[]
+  js: string[]
 }
 
 type ResourceConfig = {
-  version?: string;
-};
+  version?: string
+}
 
 export const remoteAssets = ({ version }: ResourceConfig): AssetURLs => {
   const url = `https://cdn.jsdelivr.net/npm/swagger-ui-dist${
-    version !== undefined ? `@${version}` : ""
-  }`;
+    version !== undefined ? `@${version}` : ''
+  }`
 
   return {
     css: [`${url}/swagger-ui.css`],
     js: [`${url}/swagger-ui-bundle.js`],
-  };
-};
+  }
+}

--- a/packages/swagger-ui/test/index.test.ts
+++ b/packages/swagger-ui/test/index.test.ts
@@ -1,15 +1,15 @@
-import { Hono } from 'hono'
-import { SwaggerUI, swaggerUI } from '../src'
+import { Hono } from "hono";
+import { SwaggerUI, swaggerUI } from "../src";
 
-describe('SwaggerUI Rendering', () => {
-  const url = 'https://petstore3.swagger.io/api/v3/openapi.json'
+describe("SwaggerUI Rendering", () => {
+  const url = "https://petstore3.swagger.io/api/v3/openapi.json";
 
-  it('renders correctly with default UI version', () => {
+  it("renders correctly with default UI version", () => {
     expect(SwaggerUI({ url }).toString()).toEqual(`
     <div>
       <div id="swagger-ui"></div>
-      <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
-      <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css" />
+      <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js" crossorigin="anonymous"></script>
       <script>
         window.onload = () => {
           window.ui = SwaggerUIBundle({
@@ -18,15 +18,15 @@ describe('SwaggerUI Rendering', () => {
         }
       </script>
     </div>
-  `)
-  })
+  `);
+  });
 
-  it('renders correctly with specified UI version', () => {
-    expect(SwaggerUI({ url, version: '5.0.0' }).toString()).toEqual(`
+  it("renders correctly with specified UI version", () => {
+    expect(SwaggerUI({ url, version: "5.0.0" }).toString()).toEqual(`
     <div>
       <div id="swagger-ui"></div>
-      <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui.css" />
-      <script src="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.0.0/swagger-ui.css" />
+      <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.0.0/swagger-ui-bundle.js" crossorigin="anonymous"></script>
       <script>
         window.onload = () => {
           window.ui = SwaggerUIBundle({
@@ -35,15 +35,15 @@ describe('SwaggerUI Rendering', () => {
         }
       </script>
     </div>
-  `)
-  })
+  `);
+  });
 
-  it('use urls for configuration', () => {
+  it("use urls for configuration", () => {
     expect(
       SwaggerUI({
         urls: [
           {
-            name: 'Petstore',
+            name: "Petstore",
             url,
           },
         ],
@@ -51,8 +51,8 @@ describe('SwaggerUI Rendering', () => {
     ).toEqual(`
     <div>
       <div id="swagger-ui"></div>
-      <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
-      <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css" />
+      <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js" crossorigin="anonymous"></script>
       <script>
         window.onload = () => {
           window.ui = SwaggerUIBundle({
@@ -61,10 +61,10 @@ describe('SwaggerUI Rendering', () => {
         }
       </script>
     </div>
-  `)
-  })
+  `);
+  });
 
-  it('renders correctly with custom UI', () => {
+  it("renders correctly with custom UI", () => {
     expect(
       SwaggerUI({
         url,
@@ -73,7 +73,9 @@ describe('SwaggerUI Rendering', () => {
         <div>
           <div id="swagger-ui-manually"></div>
           ${asset.css.map((url) => `<link rel="stylesheet" href="${url}" />`)}
-          ${asset.js.map((url) => `<script src="${url}" crossorigin="anonymous"></script>`)}
+          ${asset.js.map(
+            (url) => `<script src="${url}" crossorigin="anonymous"></script>`
+          )}
           <script>
             window.onload = () => {
               window.ui = SwaggerUIBundle({
@@ -89,8 +91,8 @@ describe('SwaggerUI Rendering', () => {
       `
         <div>
           <div id="swagger-ui-manually"></div>
-          <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
-          <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+          <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css" />
+          <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js" crossorigin="anonymous"></script>
           <script>
             window.onload = () => {
               window.ui = SwaggerUIBundle({
@@ -101,46 +103,54 @@ describe('SwaggerUI Rendering', () => {
           </script>
         </div>
     `.trim()
-    )
-  })
-})
+    );
+  });
+});
 
-describe('SwaggerUI Middleware', () => {
-  let app: Hono
+describe("SwaggerUI Middleware", () => {
+  let app: Hono;
 
   beforeEach(() => {
-    app = new Hono()
-  })
+    app = new Hono();
+  });
 
-  it('responds with status 200', async () => {
-    app.get('/', swaggerUI({ url: 'https://petstore3.swagger.io/api/v3/openapi.json' }))
-
-    const res = await app.request('/')
-    expect(res.status).toBe(200)
-  })
-
-  it('collectly renders SwaggerUI with custom options', async () => {
+  it("responds with status 200", async () => {
     app.get(
-      '/',
+      "/",
+      swaggerUI({ url: "https://petstore3.swagger.io/api/v3/openapi.json" })
+    );
+
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+  });
+
+  it("collectly renders SwaggerUI with custom options", async () => {
+    app.get(
+      "/",
       swaggerUI({
-        url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+        url: "https://petstore3.swagger.io/api/v3/openapi.json",
         spec: {
           info: {
-            title: 'Custom UI',
-            version: '1.0.0',
+            title: "Custom UI",
+            version: "1.0.0",
           },
         },
-        presets: ['SwaggerUIStandalonePreset', 'SwaggerUIBundle.presets.apis'],
-        operationsSorter: '(a, b) => a.get("path").localeCompare(b.get("path"))',
+        presets: ["SwaggerUIStandalonePreset", "SwaggerUIBundle.presets.apis"],
+        operationsSorter:
+          '(a, b) => a.get("path").localeCompare(b.get("path"))',
       })
-    )
-    const res = await app.request('/')
-    expect(res.status).toBe(200)
-    const html = await res.text()
-    expect(html).toContain('https://petstore3.swagger.io/api/v3/openapi.json') // RENDER_TYPE.STRING
-    expect(html).toContain('[SwaggerUIStandalonePreset,SwaggerUIBundle.presets.apis]') // RENDER_TYPE.STRING_ARRAY
-    expect(html).toContain('(a, b) => a.get("path").localeCompare(b.get("path"))') // RENDER_TYPE.RAW
-    expect(html).toContain('{"info":{"title":"Custom UI","version":"1.0.0"}}') // RENDER_TYPE.JSON_STRING
-    expect(html).toContain('window.ui = SwaggerUIBundle({') // entry point of SwaggerUI
-  })
-})
+    );
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("https://petstore3.swagger.io/api/v3/openapi.json"); // RENDER_TYPE.STRING
+    expect(html).toContain(
+      "[SwaggerUIStandalonePreset,SwaggerUIBundle.presets.apis]"
+    ); // RENDER_TYPE.STRING_ARRAY
+    expect(html).toContain(
+      '(a, b) => a.get("path").localeCompare(b.get("path"))'
+    ); // RENDER_TYPE.RAW
+    expect(html).toContain('{"info":{"title":"Custom UI","version":"1.0.0"}}'); // RENDER_TYPE.JSON_STRING
+    expect(html).toContain("window.ui = SwaggerUIBundle({"); // entry point of SwaggerUI
+  });
+});

--- a/packages/swagger-ui/test/index.test.ts
+++ b/packages/swagger-ui/test/index.test.ts
@@ -1,10 +1,10 @@
-import { Hono } from "hono";
-import { SwaggerUI, swaggerUI } from "../src";
+import { Hono } from 'hono'
+import { SwaggerUI, swaggerUI } from '../src'
 
-describe("SwaggerUI Rendering", () => {
-  const url = "https://petstore3.swagger.io/api/v3/openapi.json";
+describe('SwaggerUI Rendering', () => {
+  const url = 'https://petstore3.swagger.io/api/v3/openapi.json'
 
-  it("renders correctly with default UI version", () => {
+  it('renders correctly with default UI version', () => {
     expect(SwaggerUI({ url }).toString()).toEqual(`
     <div>
       <div id="swagger-ui"></div>
@@ -18,11 +18,11 @@ describe("SwaggerUI Rendering", () => {
         }
       </script>
     </div>
-  `);
-  });
+  `)
+  })
 
-  it("renders correctly with specified UI version", () => {
-    expect(SwaggerUI({ url, version: "5.0.0" }).toString()).toEqual(`
+  it('renders correctly with specified UI version', () => {
+    expect(SwaggerUI({ url, version: '5.0.0' }).toString()).toEqual(`
     <div>
       <div id="swagger-ui"></div>
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.0.0/swagger-ui.css" />
@@ -35,15 +35,15 @@ describe("SwaggerUI Rendering", () => {
         }
       </script>
     </div>
-  `);
-  });
+  `)
+  })
 
-  it("use urls for configuration", () => {
+  it('use urls for configuration', () => {
     expect(
       SwaggerUI({
         urls: [
           {
-            name: "Petstore",
+            name: 'Petstore',
             url,
           },
         ],
@@ -61,10 +61,10 @@ describe("SwaggerUI Rendering", () => {
         }
       </script>
     </div>
-  `);
-  });
+  `)
+  })
 
-  it("renders correctly with custom UI", () => {
+  it('renders correctly with custom UI', () => {
     expect(
       SwaggerUI({
         url,
@@ -73,9 +73,7 @@ describe("SwaggerUI Rendering", () => {
         <div>
           <div id="swagger-ui-manually"></div>
           ${asset.css.map((url) => `<link rel="stylesheet" href="${url}" />`)}
-          ${asset.js.map(
-            (url) => `<script src="${url}" crossorigin="anonymous"></script>`
-          )}
+          ${asset.js.map((url) => `<script src="${url}" crossorigin="anonymous"></script>`)}
           <script>
             window.onload = () => {
               window.ui = SwaggerUIBundle({
@@ -103,54 +101,46 @@ describe("SwaggerUI Rendering", () => {
           </script>
         </div>
     `.trim()
-    );
-  });
-});
+    )
+  })
+})
 
-describe("SwaggerUI Middleware", () => {
-  let app: Hono;
+describe('SwaggerUI Middleware', () => {
+  let app: Hono
 
   beforeEach(() => {
-    app = new Hono();
-  });
+    app = new Hono()
+  })
 
-  it("responds with status 200", async () => {
+  it('responds with status 200', async () => {
+    app.get('/', swaggerUI({ url: 'https://petstore3.swagger.io/api/v3/openapi.json' }))
+
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+  })
+
+  it('collectly renders SwaggerUI with custom options', async () => {
     app.get(
-      "/",
-      swaggerUI({ url: "https://petstore3.swagger.io/api/v3/openapi.json" })
-    );
-
-    const res = await app.request("/");
-    expect(res.status).toBe(200);
-  });
-
-  it("collectly renders SwaggerUI with custom options", async () => {
-    app.get(
-      "/",
+      '/',
       swaggerUI({
-        url: "https://petstore3.swagger.io/api/v3/openapi.json",
+        url: 'https://petstore3.swagger.io/api/v3/openapi.json',
         spec: {
           info: {
-            title: "Custom UI",
-            version: "1.0.0",
+            title: 'Custom UI',
+            version: '1.0.0',
           },
         },
-        presets: ["SwaggerUIStandalonePreset", "SwaggerUIBundle.presets.apis"],
-        operationsSorter:
-          '(a, b) => a.get("path").localeCompare(b.get("path"))',
+        presets: ['SwaggerUIStandalonePreset', 'SwaggerUIBundle.presets.apis'],
+        operationsSorter: '(a, b) => a.get("path").localeCompare(b.get("path"))',
       })
-    );
-    const res = await app.request("/");
-    expect(res.status).toBe(200);
-    const html = await res.text();
-    expect(html).toContain("https://petstore3.swagger.io/api/v3/openapi.json"); // RENDER_TYPE.STRING
-    expect(html).toContain(
-      "[SwaggerUIStandalonePreset,SwaggerUIBundle.presets.apis]"
-    ); // RENDER_TYPE.STRING_ARRAY
-    expect(html).toContain(
-      '(a, b) => a.get("path").localeCompare(b.get("path"))'
-    ); // RENDER_TYPE.RAW
-    expect(html).toContain('{"info":{"title":"Custom UI","version":"1.0.0"}}'); // RENDER_TYPE.JSON_STRING
-    expect(html).toContain("window.ui = SwaggerUIBundle({"); // entry point of SwaggerUI
-  });
-});
+    )
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('https://petstore3.swagger.io/api/v3/openapi.json') // RENDER_TYPE.STRING
+    expect(html).toContain('[SwaggerUIStandalonePreset,SwaggerUIBundle.presets.apis]') // RENDER_TYPE.STRING_ARRAY
+    expect(html).toContain('(a, b) => a.get("path").localeCompare(b.get("path"))') // RENDER_TYPE.RAW
+    expect(html).toContain('{"info":{"title":"Custom UI","version":"1.0.0"}}') // RENDER_TYPE.JSON_STRING
+    expect(html).toContain('window.ui = SwaggerUIBundle({') // entry point of SwaggerUI
+  })
+})

--- a/packages/swagger-ui/test/remote-assets.test.ts
+++ b/packages/swagger-ui/test/remote-assets.test.ts
@@ -1,24 +1,20 @@
-import { remoteAssets } from "../src/swagger/resource";
+import { remoteAssets } from '../src/swagger/resource'
 
-describe("remoteAssets", () => {
-  it("should return default assets when no version is provided", () => {
-    const assets = remoteAssets({});
-    expect(assets.css).toEqual([
-      "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css",
-    ]);
-    expect(assets.js).toEqual([
-      "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js",
-    ]);
-  });
+describe('remoteAssets', () => {
+  it('should return default assets when no version is provided', () => {
+    const assets = remoteAssets({})
+    expect(assets.css).toEqual(['https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css'])
+    expect(assets.js).toEqual(['https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js'])
+  })
 
-  it("should return assets with version when version is provided", () => {
-    const version = "1.2.3";
-    const assets = remoteAssets({ version });
+  it('should return assets with version when version is provided', () => {
+    const version = '1.2.3'
+    const assets = remoteAssets({ version })
     expect(assets.css).toEqual([
       `https://cdn.jsdelivr.net/npm/swagger-ui-dist@${version}/swagger-ui.css`,
-    ]);
+    ])
     expect(assets.js).toEqual([
       `https://cdn.jsdelivr.net/npm/swagger-ui-dist@${version}/swagger-ui-bundle.js`,
-    ]);
-  });
-});
+    ])
+  })
+})

--- a/packages/swagger-ui/test/remote-assets.test.ts
+++ b/packages/swagger-ui/test/remote-assets.test.ts
@@ -1,16 +1,24 @@
-import { remoteAssets } from '../src/swagger/resource'
+import { remoteAssets } from "../src/swagger/resource";
 
-describe('remoteAssets', () => {
-  it('should return default assets when no version is provided', () => {
-    const assets = remoteAssets({})
-    expect(assets.css).toEqual(['https://unpkg.com/swagger-ui-dist/swagger-ui.css'])
-    expect(assets.js).toEqual(['https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js'])
-  })
+describe("remoteAssets", () => {
+  it("should return default assets when no version is provided", () => {
+    const assets = remoteAssets({});
+    expect(assets.css).toEqual([
+      "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css",
+    ]);
+    expect(assets.js).toEqual([
+      "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js",
+    ]);
+  });
 
-  it('should return assets with version when version is provided', () => {
-    const version = '1.2.3'
-    const assets = remoteAssets({ version })
-    expect(assets.css).toEqual([`https://unpkg.com/swagger-ui-dist@${version}/swagger-ui.css`])
-    expect(assets.js).toEqual([`https://unpkg.com/swagger-ui-dist@${version}/swagger-ui-bundle.js`])
-  })
-})
+  it("should return assets with version when version is provided", () => {
+    const version = "1.2.3";
+    const assets = remoteAssets({ version });
+    expect(assets.css).toEqual([
+      `https://cdn.jsdelivr.net/npm/swagger-ui-dist@${version}/swagger-ui.css`,
+    ]);
+    expect(assets.js).toEqual([
+      `https://cdn.jsdelivr.net/npm/swagger-ui-dist@${version}/swagger-ui-bundle.js`,
+    ]);
+  });
+});


### PR DESCRIPTION
https://6sense.com/tech/content-delivery-network-cdn/jsdelivr-vs-unpkg

In the Content Delivery Network (CDN) market, jsDelivr has a 21.23% market share in comparison to UNPKG's 1.24%.

Also, unpkg is blocked in China while jsdelivr is not