### PR TITLE
zod-openapi: Allow multiple mimetype

### DIFF
--- a/.changeset/lazy-crabs-smoke.md
+++ b/.changeset/lazy-crabs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+Allow multiple mime type response

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -44,6 +44,7 @@
     "@cloudflare/workers-types": "^4.20240117.0",
     "hono": "^4.5.4",
     "jest": "^29.7.0",
+    "openapi3-ts": "^4.3.3",
     "tsup": "^8.0.1",
     "typescript": "^5.4.4",
     "vitest": "^1.4.0",

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import type { OpenAPIObject } from 'openapi3-ts/oas30'
 import type {
   RouteConfig as RouteConfigBase,
   ZodContentObject,
@@ -180,7 +181,7 @@ export type RouteConfigToTypedResponse<R extends RouteConfig> = {
     : TypedResponse<
         JSONParsed<ExtractContent<R['responses'][Status]['content']>>,
         ExtractStatusCode<Status>,
-        'json'
+        'json' | 'text'
       >
 }[keyof R['responses'] & RouteConfigStatusCode]
 
@@ -445,7 +446,7 @@ export class OpenAPIHono<
 
   getOpenAPIDocument = (
     config: OpenAPIObjectConfig
-  ): ReturnType<typeof generator.generateDocument> => {
+  ): OpenAPIObject => {
     const generator = new OpenApiGeneratorV3(this.openAPIRegistry.definitions)
     const document = generator.generateDocument(config)
     // @ts-expect-error the _basePath is a private property
@@ -454,7 +455,7 @@ export class OpenAPIHono<
 
   getOpenAPI31Document = (
     config: OpenAPIObjectConfig
-  ): ReturnType<typeof generator.generateDocument> => {
+  ): OpenAPIObject => {
     const generator = new OpenApiGeneratorV31(this.openAPIRegistry.definitions)
     const document = generator.generateDocument(config)
     // @ts-expect-error the _basePath is a private property
@@ -578,7 +579,7 @@ export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'
 extendZodWithOpenApi(z)
 export { extendZodWithOpenApi, z }
 
-function addBasePathToDocument(document: Record<string, any>, basePath: string) {
+function addBasePathToDocument(document: OpenAPIObject, basePath: string): OpenAPIObject {
   const updatedPaths: Record<string, any> = {}
 
   Object.keys(document.paths).forEach((path) => {


### PR DESCRIPTION
quick fix for #703. Does not differentiate between json-only response and mixed text/json response type, yet.