### PR TITLE
fix(graphql-server): the resolver always has context as the argument

### DIFF
--- a/.changeset/new-peaches-fix.md
+++ b/.changeset/new-peaches-fix.md
@@ -1,5 +1,5 @@
 ---
-'@hono/graphql-server': major
+'@hono/graphql-server': patch
 ---
 
 Make argument (context) for the root resolver function from optional to required.

--- a/.changeset/new-peaches-fix.md
+++ b/.changeset/new-peaches-fix.md
@@ -1,0 +1,5 @@
+---
+'@hono/graphql-server': major
+---
+
+Make argument (context) for the root resolver function from optional to required.

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -23,7 +23,7 @@ import { parseBody } from './parse-body'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RootResolver<E extends Env = any, P extends string = any, I extends Input = {}> = (
   // eslint-enable-next-line @typescript-eslint/no-explicit-any
-  c?: Context<E, P, I>
+  c: Context<E, P, I>
 ) => Promise<unknown> | unknown
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/graphql-server/test/index.test.ts
+++ b/packages/graphql-server/test/index.test.ts
@@ -79,8 +79,8 @@ describe('GraphQL Middleware - Simple way', () => {
     }
   `)
 
-    const rootResolver: RootResolver = (ctx?: Context) => {
-      const name = ctx?.get('name')
+    const rootResolver: RootResolver = (c: Context) => {
+      const name = c.get('name')
       return {
         hi: `hi ${name}`,
       }


### PR DESCRIPTION
This PR is to improve the type of root resolver function.

Closes  https://github.com/honojs/middleware/issues/655