### PR TITLE
feat(oidc-auth): restrict cookie paths

### DIFF
--- a/.changeset/kind-dolphins-itch.md
+++ b/.changeset/kind-dolphins-itch.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': minor
+---
+
+Optionally restrict cookie path with new envvar OIDC_COOKIE_PATH

--- a/.changeset/odd-islands-act.md
+++ b/.changeset/odd-islands-act.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': minor
+---
+
+Restrict path of callback cookies to pathname of OIDC_REDIRECT_URI

--- a/packages/oidc-auth/package.json
+++ b/packages/oidc-auth/package.json
@@ -36,8 +36,10 @@
     "hono": ">=3.*"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240821.1",
     "@types/jest": "^29.5.11",
     "@types/jsonwebtoken": "^9.0.5",
+    "@types/node": "^22.5.0",
     "hono": "^4.0.1",
     "jest": "^29.7.0",
     "jsonwebtoken": "^9.0.2",

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -40,6 +40,7 @@ type OidcAuthEnv = {
   OIDC_CLIENT_ID: string
   OIDC_CLIENT_SECRET: string
   OIDC_REDIRECT_URI: string
+  OIDC_COOKIE_PATH?: string
 }
 
 /**
@@ -120,9 +121,9 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
       return null
     }
     try {
-      auth = await verify(session_jwt, env.OIDC_AUTH_SECRET)
+      auth = await verify(session_jwt, env.OIDC_AUTH_SECRET) as OidcAuth
     } catch (e) {
-      deleteCookie(c, oidcAuthCookieName)
+      deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/'} )
       return null
     }
     if (auth === null || auth.rtkexp === undefined || auth.ssnexp === undefined) {
@@ -137,7 +138,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
     if (auth.rtkexp < now) {
       // Refresh the token if it has expired
       if (auth.rtk === undefined || auth.rtk === '') {
-        deleteCookie(c, oidcAuthCookieName)
+        deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/'})
         return null
       }
       const as = await getAuthorizationServer(c)
@@ -146,7 +147,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
       const result = await oauth2.processRefreshTokenResponse(as, client, response)
       if (oauth2.isOAuth2Error(result)) {
         // The refresh_token might be expired or revoked
-        deleteCookie(c, oidcAuthCookieName)
+        deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/'})
         return null
       }
       auth = await updateAuth(c, auth, result)
@@ -186,7 +187,7 @@ const updateAuth = async (
     ssnexp: orig?.ssnexp || Math.floor(Date.now() / 1000) + authExpires,
   }
   const session_jwt = await sign(updated, env.OIDC_AUTH_SECRET)
-  setCookie(c, oidcAuthCookieName, session_jwt, { path: '/', httpOnly: true, secure: true })
+  setCookie(c, oidcAuthCookieName, session_jwt, { path: env.OIDC_COOKIE_PATH ?? '/', httpOnly: true, secure: true })
   c.set('oidcAuthJwt', session_jwt)
   return updated
 }
@@ -198,8 +199,8 @@ export const revokeSession = async (c: Context): Promise<void> => {
   const session_jwt = getCookie(c, oidcAuthCookieName)
   if (session_jwt !== undefined) {
     const env = getOidcAuthEnv(c)
-    deleteCookie(c, oidcAuthCookieName)
-    const auth: OidcAuth = await verify(session_jwt, env.OIDC_AUTH_SECRET)
+    deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/' })
+    const auth: OidcAuth = await verify(session_jwt, env.OIDC_AUTH_SECRET) as OidcAuth
     if (auth.rtk !== undefined && auth.rtk !== '') {
       // revoke refresh token
       const as = await getAuthorizationServer(c)
@@ -215,7 +216,7 @@ export const revokeSession = async (c: Context): Promise<void> => {
       }
     }
   }
-  c.set('oidcAuth', undefined)
+  c.set('oidcAuth', null)
 }
 
 /**
@@ -273,7 +274,8 @@ export const processOAuthCallback = async (c: Context) => {
 
   // Parses the authorization response and validates the state parameter
   const state = getCookie(c, 'state')
-  deleteCookie(c, 'state')
+  const path = new URL(env.OIDC_REDIRECT_URI).pathname
+  deleteCookie(c, 'state', { path })
   const currentUrl: URL = new URL(c.req.url)
   const params = oauth2.validateAuthResponse(as, client, currentUrl, state)
   if (oauth2.isOAuth2Error(params)) {
@@ -285,11 +287,11 @@ export const processOAuthCallback = async (c: Context) => {
   // Exchanges the authorization code for a refresh token
   const code = c.req.query('code')
   const nonce = getCookie(c, 'nonce')
-  deleteCookie(c, 'nonce')
+  deleteCookie(c, 'nonce', { path })
   const code_verifier = getCookie(c, 'code_verifier')
-  deleteCookie(c, 'code_verifier')
+  deleteCookie(c, 'code_verifier', { path })
   const continue_url = getCookie(c, 'continue')
-  deleteCookie(c, 'continue')
+  deleteCookie(c, 'continue', { path })
   if (code === undefined || nonce === undefined || code_verifier === undefined) {
     throw new HTTPException(500, { message: 'Missing required parameters / cookies' })
   }
@@ -352,20 +354,21 @@ export const oidcAuthMiddleware = (): MiddlewareHandler => {
     try {
       const auth = await getAuth(c)
       if (auth === null) {
+        const path = new URL(env.OIDC_REDIRECT_URI).pathname
         // Redirect to IdP for login
         const state = oauth2.generateRandomState()
         const nonce = oauth2.generateRandomNonce()
         const code_verifier = oauth2.generateRandomCodeVerifier()
         const code_challenge = await oauth2.calculatePKCECodeChallenge(code_verifier)
         const url = await generateAuthorizationRequestUrl(c, state, nonce, code_challenge)
-        setCookie(c, 'state', state, { path: '/', httpOnly: true, secure: true })
-        setCookie(c, 'nonce', nonce, { path: '/', httpOnly: true, secure: true })
-        setCookie(c, 'code_verifier', code_verifier, { path: '/', httpOnly: true, secure: true })
-        setCookie(c, 'continue', c.req.url, { path: '/', httpOnly: true, secure: true })
+        setCookie(c, 'state', state, { path, httpOnly: true, secure: true })
+        setCookie(c, 'nonce', nonce, { path, httpOnly: true, secure: true })
+        setCookie(c, 'code_verifier', code_verifier, { path, httpOnly: true, secure: true })
+        setCookie(c, 'continue', c.req.url, { path, httpOnly: true, secure: true })
         return c.redirect(url)
       }
     } catch (e) {
-      deleteCookie(c, oidcAuthCookieName)
+      deleteCookie(c, oidcAuthCookieName, { path: env.OIDC_COOKIE_PATH ?? '/' })
       throw new HTTPException(500, { message: 'Invalid session' })
     }
     await next()
@@ -373,7 +376,7 @@ export const oidcAuthMiddleware = (): MiddlewareHandler => {
     // Workaround to set the session cookie when the response is returned by the origin server
     const session_jwt = c.get('oidcAuthJwt')
     if (session_jwt !== undefined) {
-      setCookie(c, oidcAuthCookieName, session_jwt, { path: '/', httpOnly: true, secure: true })
+      setCookie(c, oidcAuthCookieName, session_jwt, { path: env.OIDC_COOKIE_PATH ?? '/', httpOnly: true, secure: true })
     }
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,6 +978,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workers-types@npm:^4.20240821.1":
+  version: 4.20240821.1
+  resolution: "@cloudflare/workers-types@npm:4.20240821.1"
+  checksum: 5abf7cfb4241ee7babd382807f6061ab4315c7703957673289238234a5e4ed7c24154afe8b3cda15c0e60ea52e4c2e44b3554a10e854f85a5f5ea2d5bf5cde46
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -2426,8 +2433,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hono/oidc-auth@workspace:packages/oidc-auth"
   dependencies:
+    "@cloudflare/workers-types": "npm:^4.20240821.1"
     "@types/jest": "npm:^29.5.11"
     "@types/jsonwebtoken": "npm:^9.0.5"
+    "@types/node": "npm:^22.5.0"
     hono: "npm:^4.0.1"
     jest: "npm:^29.7.0"
     jsonwebtoken: "npm:^9.0.2"
@@ -4648,6 +4657,15 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.5.0":
+  version: 22.5.0
+  resolution: "@types/node@npm:22.5.0"
+  dependencies:
+    undici-types: "npm:~6.19.2"
+  checksum: 45aa75c5e71645fac42dced4eff7f197c3fdfff6e8a9fdacd0eb2e748ff21ee70ffb73982f068a58e8d73b2c088a63613142c125236cdcf3c072ea97eada1559
   languageName: node
   linkType: hard
 
@@ -19142,6 +19160,13 @@ __metadata:
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
   checksum: bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.19.2":
+  version: 6.19.8
+  resolution: "undici-types@npm:6.19.8"
+  checksum: 078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I'd like to restrict the cookie path, e.g. to '/api' only. For that, this pull request introduced an envvar OIDC_COOKIE_PATH that defaults back to '/'.
Also, it restricts the path of the callback cookies to the pathname of OIDC_REDIRECT_URI