### PR TITLE
feat(zod-openapi): allow multiple mimetype

### DIFF
--- a/.changeset/clean-buses-shop.md
+++ b/.changeset/clean-buses-shop.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+Allow multiple mime type response

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -180,7 +180,7 @@ export type RouteConfigToTypedResponse<R extends RouteConfig> = {
     : TypedResponse<
         JSONParsed<ExtractContent<R['responses'][Status]['content']>>,
         ExtractStatusCode<Status>,
-        'json'
+        'json' | 'text'
       >
 }[keyof R['responses'] & RouteConfigStatusCode]
 

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -797,43 +797,45 @@ describe('JSON and Text response', () => {
       200: {
         content: {
           'application/json': {
-            schema: z.object({})
+            schema: z.object({}),
           },
           'text/plain': {
-            schema: z.string()
-          }
+            schema: z.string(),
+          },
         },
         description: 'response',
-      }
-    }
+      },
+    },
   })
 
   const app = new OpenAPIHono()
 
-  app.openapi(route, (c: Context) => {
+  app.openapi(route, (c) => {
     const mimeTypes = ['application/json', 'text/plain']
-    if (accepts(c, {
-      default: mimeTypes[0],
-      header: 'Accept',
-      supports: mimeTypes
-    }) === mimeTypes[0]) {
-      return c.json<{}, 200>({})
+    if (
+      accepts(c, {
+        default: mimeTypes[0],
+        header: 'Accept',
+        supports: mimeTypes,
+      }) === mimeTypes[0]
+    ) {
+      return c.json({})
     }
-    return c.text<string, 200>('')
+    return c.text('')
   })
 
-  test('should responde with JSON fallback', async () => {
+  test('should respond with JSON fallback', async () => {
     const res = await app.request('/hello', {
-      method: 'GET'
+      method: 'GET',
     })
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({})
   })
-  test('should responde with Text', async () => {
+  test('should respond with Text', async () => {
     const res = await app.request('/hello', {
       method: 'GET',
       headers: {
-        'accept': 'text/plain',
+        accept: 'text/plain',
       },
     })
     expect(res.status).toBe(200)

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -8,6 +8,7 @@ import { OpenAPIHono, createRoute, z } from '../src/index'
 import type { Equal, Expect } from 'hono/utils/types'
 import type { ServerErrorStatusCode } from 'hono/utils/http-status'
 import { stringify } from 'yaml'
+import { accepts } from 'hono/accepts'
 
 describe('Constructor', () => {
   it('Should not require init object', () => {
@@ -785,6 +786,58 @@ describe('JSON and Form', () => {
     expect(functionInJSON).toHaveBeenCalled()
     functionInForm.mockReset()
     functionInJSON.mockReset()
+  })
+})
+
+describe('JSON and Text response', () => {
+  const route = createRoute({
+    method: 'get',
+    path: '/hello',
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: z.object({})
+          },
+          'text/plain': {
+            schema: z.string()
+          }
+        },
+        description: 'response',
+      }
+    }
+  })
+
+  const app = new OpenAPIHono()
+
+  app.openapi(route, (c: Context) => {
+    const mimeTypes = ['application/json', 'text/plain']
+    if (accepts(c, {
+      default: mimeTypes[0],
+      header: 'Accept',
+      supports: mimeTypes
+    }) === mimeTypes[0]) {
+      return c.json<{}, 200>({})
+    }
+    return c.text<string, 200>('')
+  })
+
+  test('should responde with JSON fallback', async () => {
+    const res = await app.request('/hello', {
+      method: 'GET'
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({})
+  })
+  test('should responde with Text', async () => {
+    const res = await app.request('/hello', {
+      method: 'GET',
+      headers: {
+        'accept': 'text/plain',
+      },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toEqual('')
   })
 })
 
@@ -1724,21 +1777,21 @@ describe('RouteConfigToTypedResponse', () => {
             age: number
           },
           200,
-          'json'
+          'json' | 'text'
         >
       | TypedResponse<
           {
             ok: boolean
           },
           400,
-          'json'
+          'json' | 'text'
         >
       | TypedResponse<
           {
             ok: boolean
           },
           ServerErrorStatusCode,
-          'json'
+          'json' | 'text'
         >
     type verify = Expect<Equal<Expected, Actual>>
   })


### PR DESCRIPTION
quick fix for #703. Does not differentiate between json-only response and mixed text/json response type, yet.