### PR TITLE
feat(oidc-auth): access and set claims

### DIFF
--- a/.changeset/gorgeous-berries-float.md
+++ b/.changeset/gorgeous-berries-float.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': minor
+---
+
+define custom scope, access oauth response and set custom session claims

--- a/packages/oidc-auth/test/index.test.ts
+++ b/packages/oidc-auth/test/index.test.ts
@@ -205,7 +205,7 @@ describe('oidcAuthMiddleware()', () => {
     const res = await app.request(req, {}, {})
     expect(res).not.toBeNull()
     expect(res.status).toBe(302)
-    expect(res.headers.get('location')).toMatch(/scope=openid(%20|\+)email&/)
+    expect(res.headers.get('location')).toMatch(/scope=openid(%20|\+)email(%20|\+)profile&/)
     expect(res.headers.get('location')).toMatch('access_type=offline&prompt=consent')
     expect(res.headers.get('set-cookie')).toMatch(`state=${MOCK_STATE}`)
     expect(res.headers.get('set-cookie')).toMatch(`nonce=${MOCK_NONCE}`)

--- a/packages/oidc-auth/test/index.test.ts
+++ b/packages/oidc-auth/test/index.test.ts
@@ -10,6 +10,7 @@ const MOCK_CLIENT_SECRET = 'CLIENT_SECRET_001'
 const MOCK_REDIRECT_URI = 'http://localhost/callback'
 const MOCK_SUBJECT = 'USER_ID_001'
 const MOCK_EMAIL = 'user001@example.com'
+const MOCK_NAME = 'John Doe'
 const MOCK_STATE = crypto.randomBytes(16).toString('hex') // 32 bytes
 const MOCK_NONCE = crypto.randomBytes(16).toString('hex') // 32 bytes
 const MOCK_AUTH_SECRET = crypto.randomBytes(16).toString('hex') // 32 bytes
@@ -19,6 +20,8 @@ const MOCK_ID_TOKEN = jwt.sign(
     iss: MOCK_ISSUER,
     aud: MOCK_CLIENT_ID,
     sub: MOCK_SUBJECT,
+    email: MOCK_EMAIL,
+    name: MOCK_NAME,
     exp: Math.floor(Date.now() / 1000) + 10 * 60, // 10 minutes
     nonce: MOCK_NONCE,
   },
@@ -153,12 +156,20 @@ jest.unstable_mockModule('oauth4webapi', () => {
   }
 })
 
-const { oidcAuthMiddleware, getAuth, revokeSession } = await import('../src')
+const { oidcAuthMiddleware, getAuth, processOAuthCallback, revokeSession } = await import('../src')
 
 const app = new Hono()
 app.get('/logout', async (c) => {
   await revokeSession(c)
   return c.text('OK')
+})
+app.get('/callback-custom', async (c) => {
+  c.set('oidcClaimsHook', async (orig, claims, response) => ({
+    name: claims?.name as string ?? orig?.name ?? '',
+    sub: claims?.sub ?? orig?.sub ?? '',
+    token: response.access_token
+  }))
+  return processOAuthCallback(c)
 })
 app.use('/*', oidcAuthMiddleware())
 app.all('/*', async (c) => {
@@ -168,11 +179,12 @@ app.all('/*', async (c) => {
 
 beforeEach(() => {
   process.env.OIDC_ISSUER = MOCK_ISSUER
-  ;(process.env.OIDC_CLIENT_ID = MOCK_CLIENT_ID),
-    (process.env.OIDC_CLIENT_SECRET = MOCK_CLIENT_SECRET),
-    (process.env.OIDC_REDIRECT_URI = MOCK_REDIRECT_URI)
+  process.env.OIDC_CLIENT_ID = MOCK_CLIENT_ID
+  process.env.OIDC_CLIENT_SECRET = MOCK_CLIENT_SECRET
+  process.env.OIDC_REDIRECT_URI = MOCK_REDIRECT_URI
   process.env.OIDC_AUTH_SECRET = MOCK_AUTH_SECRET
   process.env.OIDC_AUTH_EXPIRES = MOCK_AUTH_EXPIRES
+  delete process.env.OIDC_SCOPES
 })
 describe('oidcAuthMiddleware()', () => {
   test('Should respond with 200 OK if session is active', async () => {
@@ -212,6 +224,32 @@ describe('oidcAuthMiddleware()', () => {
     expect(res.headers.get('set-cookie')).toMatch('code_verifier=')
     expect(res.headers.get('set-cookie')).toMatch('continue=http%3A%2F%2Flocalhost%2F')
   })
+  test('Should use custom scope, if defined', async () => {
+    process.env.OIDC_SCOPES = 'openid email'
+    const req = new Request('http://localhost/', {
+      method: 'GET',
+      headers: { cookie: `oidc-auth=${MOCK_JWT_EXPIRED_SESSION}` },
+    })
+    const res = await app.request(req, {}, {})
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toMatch(/scope=openid(%20|\+)email&/)
+    expect(res.headers.get('location')).toMatch('access_type=offline&prompt=consent')
+    expect(res.headers.get('set-cookie')).toMatch(`state=${MOCK_STATE}`)
+    expect(res.headers.get('set-cookie')).toMatch(`nonce=${MOCK_NONCE}`)
+    expect(res.headers.get('set-cookie')).toMatch('code_verifier=')
+    expect(res.headers.get('set-cookie')).toMatch('continue=http%3A%2F%2Flocalhost%2F')
+  })
+  test('Custom scope is limited to supported scopes', async () => {
+    process.env.OIDC_SCOPES = 'openid email salary'
+    const req = new Request('http://localhost/', {
+      method: 'GET',
+      headers: { cookie: `oidc-auth=${MOCK_JWT_EXPIRED_SESSION}` },
+    })
+    const res = await app.request(req, {}, {})
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(500)
+  })
   test('Should redirect to authorization endpoint if no session cookie is found', async () => {
     const req = new Request('http://localhost/', {
       method: 'GET',
@@ -250,6 +288,26 @@ describe('processOAuthCallback()', () => {
       },
     })
     const res = await app.request(req, {}, {})
+    const { email, name, sub } = JSON.parse(atob(res.headers.get('set-cookie')?.match(/oidc-auth=[^;]+/)?.[0]?.split('.')[1] as string))
+    expect(sub).toBe(MOCK_SUBJECT)
+    expect(email).toBe(MOCK_EMAIL)
+    expect(name).toBeUndefined()
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('http://localhost/1234')
+  })
+  test('Should respond with customized claims', async () => {
+    const req = new Request(`${MOCK_REDIRECT_URI}-custom?code=1234&state=${MOCK_STATE}`, {
+      method: 'GET',
+      headers: {
+        cookie: `state=${MOCK_STATE}; nonce=${MOCK_NONCE}; code_verifier=1234; continue=http%3A%2F%2Flocalhost%2F1234`,
+      },
+    })
+    const res = await app.request(req, {}, {})
+    const { email, name, sub } = JSON.parse(atob(res.headers.get('set-cookie')?.match(/oidc-auth=[^;]+/)?.[0]?.split('.')[1] as string))
+    expect(sub).toBe(MOCK_SUBJECT)
+    expect(email).toBeUndefined()
+    expect(name).toBe(MOCK_NAME)
     expect(res).not.toBeNull()
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('http://localhost/1234')

--- a/packages/oidc-auth/tsconfig.json
+++ b/packages/oidc-auth/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "module": "ESNext",
     "rootDir": "./src",
     "outDir": "./dist",
   },


### PR DESCRIPTION
I'd like to use '`profile`' scope to get additional claims from google. In order to not having to forward all id claims to the session token, this pull request proposes an "`oidcClaimsHook`" as environment variable. If used, it has access to the claims, actual response (i.e. for retrieving full profile from access server) and returning claims for the session token.

Define environment variable to define oauth scope instead of full `scopes_supported`, e.g.
```
OIDC_SCOPES=openid email profile
```

Define an `oidcClaimsHook` to access original claims and return the ones for session token, e.g.:
```ts
import type { IDToken, OidcAuth, TokenEndpointResponses } from '@hono/oidc-auth';

declare module 'hono' {
  interface OidcAuthClaims {
    name: string
    sub: string
  }
}

const oidcClaimsHook = async (orig: OidcAuth | undefined, claims: IDToken | undefined, _response: TokenEndpointResponses): Promise<OidcAuthClaims> => ({
  name: claims?.name as string ?? orig?.name ?? '',
  sub: claims?.sub ?? orig?.sub ?? ''
}),
...
app.get('/callback', async (c) => {
  c.set('oidcClaimsHook', oidcClaimsHook);
  return processOAuthCallback(c);
})
...
...
```