### PR TITLE
feat(effect-validator): use array formatting for errors

### DIFF
--- a/.changeset/hot-pumas-destroy.md
+++ b/.changeset/hot-pumas-destroy.md
@@ -1,5 +1,5 @@
 ---
-'@hono/effect-validator': major
+'@hono/effect-validator': minor
 ---
 
 format errors with array formatting for improved readability

--- a/.changeset/hot-pumas-destroy.md
+++ b/.changeset/hot-pumas-destroy.md
@@ -1,0 +1,5 @@
+---
+'@hono/effect-validator': major
+---
+
+format errors with array formatting for improved readability

--- a/packages/effect-validator/src/index.ts
+++ b/packages/effect-validator/src/index.ts
@@ -1,3 +1,4 @@
+import { ArrayFormatter } from '@effect/schema'
 import * as S from '@effect/schema/Schema'
 import { Either } from 'effect'
 import type { Env, Input, MiddlewareHandler, ValidationTargets } from 'hono'
@@ -45,7 +46,8 @@ export const effectValidator = <
     const result = S.decodeUnknownEither(schema)(value)
 
     return Either.match(result, {
-      onLeft: (error) => c.json({ success: false, error: JSON.parse(JSON.stringify(error)) }, 400),
+      onLeft: (error) =>
+        c.json({ success: false, error: ArrayFormatter.formatErrorSync(error) }, 400),
       onRight: (data) => {
         c.req.addValidatedData(target, data as object)
         return data

--- a/packages/effect-validator/test/index.test.ts
+++ b/packages/effect-validator/test/index.test.ts
@@ -1,3 +1,4 @@
+import type { ArrayFormatter } from '@effect/schema'
 import { Schema as S } from '@effect/schema'
 import { Hono } from 'hono'
 import type { StatusCode } from 'hono/utils/http-status'
@@ -103,8 +104,10 @@ describe('Basic', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(400)
 
-    const data = (await res.json()) as { success: boolean }
+    const data = await res.json<{ success: boolean; error: ArrayFormatter.Issue[] }>()
     expect(data.success).toBe(false)
+    expect(data.error[0].path).toEqual(['age'])
+    expect(data.error[0].message).toBeDefined()
   })
 })
 


### PR DESCRIPTION
`@effect/schema` uses `TreeFormatter` as the default way of formatting errors. ([more here](https://github.com/Effect-TS/effect/tree/main/packages/schema#formatting-errors))

The result is hard to read in an http 400 response (although it is really nice in a terminal):

```json
{
  "success": false,
  "error": {
    "_id": "ParseError",
    "message": "{ readonly name: string; readonly password: string; readonly email: a string matching the pattern ^(?!\\.)(?!.*\\.\\.)([A-Z0-9_+-.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\\.)+[A-Z]{2,}$ }\n└─ [\"password\"]\n   └─ is missing"
  }
}
```

With the `ArrayFormatter` it us much better:
```json
{
  "success": false,
  "error": [
    {
      "_tag": "Missing",
      "path": [
        "password"
      ],
      "message": "is missing"
    }
  ]
}
```

What are your thoughts about this ?