### PR TITLE
docs(zod-openapi): fix missing arguments for `app.doc31`

### DIFF
--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -239,8 +239,8 @@ app.openapi(
 You can generate OpenAPI v3.1 spec using the following methods:
 
 ```ts
-app.doc31('/docs', { openapi: '3.1.0' }) // new endpoint
-app.getOpenAPI31Document({ openapi: '3.1.0' }) // raw json
+app.doc31('/docs', { openapi: '3.1.0', info: { title: 'foo', version: '1' } }) // new endpoint
+app.getOpenAPI31Document({ openapi: '3.1.0', info: { title: 'foo', version: '1' } }) // schema object
 ```
 
 ### The Registry


### PR DESCRIPTION
This PR adds the required `info` arg to both `doc31` and `getOpenAPI31Document` functions. Without it, we get the below error:

> Argument of type '{ openapi: string; }' is not assignable to parameter of type 'OpenAPIObjectConfigure<Env, "/docs">'.
  Property 'info' is missing in type '{ openapi: string; }' but required in type 'OpenAPIObjectConfig'.ts(2345)
openapi30.d.ts(7, 5): 'info' is declared here.

The type definition seems originated from [here](https://github.com/metadevpro/openapi3-ts/blob/71b55d772bacc58c127540b6a75d1b17a7ddadbb/src/model/openapi31.ts#L12-L14).

I also changed the comment `raw json` because getOpenAPI31Document returns an object, not a json string.