### PR TITLE
fix(auth-js): remove config.basePath

### DIFF
--- a/packages/auth-js/package.json
+++ b/packages/auth-js/package.json
@@ -57,7 +57,7 @@
     "react": ">=18"
   },
   "devDependencies": {
-    "@auth/core": "^0.30.0",
+    "@auth/core": "^0.35.3",
     "@types/react": "^18",
     "hono": "^3.11.7",
     "jest": "^29.7.0",

--- a/packages/auth-js/src/index.ts
+++ b/packages/auth-js/src/index.ts
@@ -34,7 +34,6 @@ export type ConfigHandler = (c: Context) => AuthConfig
 
 export function setEnvDefaults(env: AuthEnv, config: AuthConfig) {
   config.secret ??= env.AUTH_SECRET
-  config.basePath ||= '/api/auth'
   coreSetEnvDefaults(env, config)
 }
 

--- a/packages/auth-js/test/index.test.ts
+++ b/packages/auth-js/test/index.test.ts
@@ -3,7 +3,7 @@ import { skipCSRFCheck } from '@auth/core'
 import type { Adapter } from '@auth/core/adapters'
 import Credentials from '@auth/core/providers/credentials'
 import { Hono } from 'hono'
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it, vi } from 'vitest'
 import type { AuthConfig } from '../src'
 import { authHandler, verifyAuth, initAuthConfig, reqWithEnvUrl } from '../src'
 
@@ -39,6 +39,7 @@ describe('Config', () => {
       '/*',
       initAuthConfig(() => {
         return {
+          basePath: '/api/auth',
           providers: [],
         }
       })
@@ -78,7 +79,7 @@ describe('Config', () => {
   })
 })
 
-describe('reqWithEnvUrl()', async() => {
+describe('reqWithEnvUrl()', async () => {
   const req = new Request('http://request-base/request-path')
   const newReq = await reqWithEnvUrl(req, 'https://auth-url-base/auth-url-path')
   it('Should rewrite the base path', () => {
@@ -126,7 +127,6 @@ describe('Credentials Provider', () => {
       password: {},
     },
     authorize: (credentials) => {
-
       if (credentials.password === 'password') {
         return user
       }
@@ -193,8 +193,8 @@ describe('Credentials Provider', () => {
 
   it('Should respect x-forwarded-proto and x-forwarded-host', async () => {
     const headers = new Headers()
-    headers.append('x-forwarded-proto', "https")
-    headers.append('x-forwarded-host', "example.com")
+    headers.append('x-forwarded-proto', 'https')
+    headers.append('x-forwarded-host', 'example.com')
     const res = await app.request('http://localhost/api/auth/signin', {
       headers,
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,15 +71,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@auth/core@npm:^0.30.0":
-  version: 0.30.0
-  resolution: "@auth/core@npm:0.30.0"
+"@auth/core@npm:^0.35.3":
+  version: 0.35.3
+  resolution: "@auth/core@npm:0.35.3"
   dependencies:
     "@panva/hkdf": "npm:^1.1.1"
     "@types/cookie": "npm:0.6.0"
     cookie: "npm:0.6.0"
     jose: "npm:^5.1.3"
-    oauth4webapi: "npm:^2.4.0"
+    oauth4webapi: "npm:^2.10.4"
     preact: "npm:10.11.3"
     preact-render-to-string: "npm:5.2.3"
   peerDependencies:
@@ -93,7 +93,7 @@ __metadata:
       optional: true
     nodemailer:
       optional: true
-  checksum: caa94cc9b42c354fef57e337a844bca0c0770ac809ba1cf00b30d7fc2e383d1d42dafeb3e39b9dde92b85a9eb821cde905b662638bfe98d8e2439c6d3e64c8cd
+  checksum: 0543d5ec0eea4df14826aabd5e220dd64772d9f8e81920f0d5c3971cf6298cdc1e089ddead18ab3a30de295f35e5227eeaa7631d64f35749a50b73cfea538c4c
   languageName: node
   linkType: hard
 
@@ -2257,7 +2257,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hono/auth-js@workspace:packages/auth-js"
   dependencies:
-    "@auth/core": "npm:^0.30.0"
+    "@auth/core": "npm:^0.35.3"
     "@types/react": "npm:^18"
     hono: "npm:^3.11.7"
     jest: "npm:^29.7.0"
@@ -15398,10 +15398,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oauth4webapi@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "oauth4webapi@npm:2.4.0"
-  checksum: da9fae4b6c116a1d80e2e0408e70530703691bb3a5dd6ca2e59a212e8f3b9b04a2a3bf68400f949e627e97af7c7de07b7975bd374629e4f7f4ef9906d5afad10
+"oauth4webapi@npm:^2.10.4":
+  version: 2.17.0
+  resolution: "oauth4webapi@npm:2.17.0"
+  checksum: a3be4f07f3050c982c9f47a899cb34eb4ce1b2072818eab37f241c7db932cf0dac31ed90b0913eaaaebfd7b23e8bf397ecef249a11aea699efb62c7657884ba5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request aims to remove the warning message: [auth][warn][env-url-basepath-redundant]. For more information, please see: https://warnings.authjs.dev#env-url-basepath-redundant.