### PR TITLE
feat(zod-openapi): add target property to parameter of validation hook

### DIFF
--- a/.changeset/purple-lizards-change.md
+++ b/.changeset/purple-lizards-change.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: add target property to parameter of validation hook

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -185,7 +185,7 @@ export type RouteConfigToTypedResponse<R extends RouteConfig> = {
 }[keyof R['responses'] & RouteConfigStatusCode]
 
 export type Hook<T, E extends Env, P extends string, R> = (
-  result:
+  result: { target: keyof ValidationTargets } & (
     | {
         success: true
         data: T
@@ -193,7 +193,8 @@ export type Hook<T, E extends Env, P extends string, R> = (
     | {
         success: false
         error: ZodError
-      },
+      }
+  ),
   c: Context<E, P>
 ) => R
 


### PR DESCRIPTION
In #695, @bartekbp added a target property to the parameters of `zValidator` hooks. Since the version bump in #750, this property is already passed to validator hooks used with `zod-openapi`. This PR changes the `Hook` type of `zod-openapi` to include the `target` property.