### PR TITLE
chore: update valibot dependency to v1

### DIFF
--- a/.changeset/sharp-ravens-shave.md
+++ b/.changeset/sharp-ravens-shave.md
@@ -1,0 +1,5 @@
+---
+'@hono/valibot-validator': minor
+---
+
+Upgrade Valibot peer dependency to v1.0.0

--- a/packages/valibot-validator/package.json
+++ b/packages/valibot-validator/package.json
@@ -32,12 +32,12 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=3.9.0",
-    "valibot": ">=0.31.0 <1"
+    "valibot": "^1.0.0"
   },
   "devDependencies": {
     "hono": "^4.5.1",
     "jest": "^29.7.0",
     "tsup": "^8.3.0",
-    "valibot": "^0.31.0"
+    "valibot": "^1.0.0-beta.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,10 +2687,10 @@ __metadata:
     hono: "npm:^4.5.1"
     jest: "npm:^29.7.0"
     tsup: "npm:^8.3.0"
-    valibot: "npm:^0.31.0"
+    valibot: "npm:^1.0.0-beta.0"
   peerDependencies:
     hono: ">=3.9.0"
-    valibot: ">=0.31.0 <1"
+    valibot: ^1.0.0
   languageName: unknown
   linkType: soft
 
@@ -19823,17 +19823,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"valibot@npm:^0.31.0":
-  version: 0.31.1
-  resolution: "valibot@npm:0.31.1"
-  checksum: 666abefeffe1b92e324bc1f35e9052929365d9646f324197d21a506ada07e605958853e04144996b698c866cc327be78138712a5b79e1dbe98caf52229b49fc0
-  languageName: node
-  linkType: hard
-
 "valibot@npm:^0.36.0":
   version: 0.36.0
   resolution: "valibot@npm:0.36.0"
   checksum: deff84cdcdc324d5010c2087e553cd26b07752ac18912c9152eccd241b507a49a9ad77fed57501d45bcbef9bec6a7a6707b17d9bef8d35e681d45f098a70e466
+  languageName: node
+  linkType: hard
+
+"valibot@npm:^1.0.0-beta.0":
+  version: 1.0.0-beta.0
+  resolution: "valibot@npm:1.0.0-beta.0"
+  peerDependencies:
+    typescript: ">=5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 0b5525fb3504f65011d2c7f57679d187f63c1205da2f441397f3d263514672938d2a8145b85ea2e1e46c505b5641d79f5628ba3262689b34fb918177176660fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I've updated the Valibot dependency of the adapter to v1. We've changed the type signature, so this change is necessary. All other changes in our v1 beta version are only internal.

---

An union of schema library authors (Zod, Valibot, ArkType, ...) collaborating on a standard interface for schema libraries called [Standard Schema](https://github.com/standard-schema/standard-schema). This simplifies implementation and prevents vendor lock-in. So far Valibot v1 supports this spec and Zod will follow soon. In the long run, the explicit implementation of a Valibot and Zod adapter may no longer be necessary.