### PR TITLE
feat(zod-validator): support enum types for `query`

### DIFF
--- a/.changeset/bright-teachers-remember.md
+++ b/.changeset/bright-teachers-remember.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': minor
+---
+
+feat: support enum types for `query`

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -27,17 +27,13 @@ export const zValidator = <
   I extends Input = {
     in: HasUndefined<In> extends true
       ? {
-          [K in Target]?: K extends 'json'
+          [K in Target]?: In extends ValidationTargets[K]
             ? In
-            : HasUndefined<keyof ValidationTargets[K]> extends true
-            ? { [K2 in keyof In]?: ValidationTargets[K][K2] }
-            : { [K2 in keyof In]: ValidationTargets[K][K2] }
+            : { [K2 in keyof In]?: ValidationTargets[K][K2] }
         }
       : {
-          [K in Target]: K extends 'json'
+          [K in Target]: In extends ValidationTargets[K]
             ? In
-            : HasUndefined<keyof ValidationTargets[K]> extends true
-            ? { [K2 in keyof In]?: ValidationTargets[K][K2] }
             : { [K2 in keyof In]: ValidationTargets[K][K2] }
         }
     out: { [K in Target]: Out }

--- a/packages/zod-validator/test/index.test.ts
+++ b/packages/zod-validator/test/index.test.ts
@@ -49,7 +49,7 @@ describe('Basic', () => {
         } & {
           query?:
             | {
-                name?: string | string[] | undefined
+                name?: string | undefined
               }
             | undefined
         }
@@ -305,5 +305,37 @@ describe('With target', () => {
       { data: { id: '3' }, success: true, target: 'json' },
       expect.anything()
     )
+  })
+})
+
+describe('Only Types', () => {
+  it('Should return correct enum types for query', () => {
+    const app = new Hono()
+
+    const querySchema = z.object({
+      order: z.enum(['asc', 'desc']),
+    })
+
+    const route = app.get('/', zValidator('query', querySchema), (c) => {
+      const data = c.req.valid('query')
+      return c.json(data)
+    })
+
+    type Actual = ExtractSchema<typeof route>
+    type Expected = {
+      '/': {
+        $get: {
+          input: {
+            query: {
+              order: 'asc' | 'desc'
+            }
+          }
+          output: {
+            order: 'asc' | 'desc'
+          }
+        }
+      }
+    }
+    type verify = Expect<Equal<Expected, Actual>>
   })
 })


### PR DESCRIPTION
Closes https://github.com/honojs/hono/issues/2481