### PR TITLE
docs(zod-openapi): fix tip block in readme

### DIFF
--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -51,7 +51,8 @@ const UserSchema = z
   .openapi('User')
 ```
 
-> [!TIP] > `UserSchema` schema will be registered as `"#/components/schemas/User"` refs in the OpenAPI document.
+> [!TIP]
+> `UserSchema` schema will be registered as `"#/components/schemas/User"` refs in the OpenAPI document.
 > If you want to register the schema as referenced components, use `.openapi()` method.
 
 Next, create a route:


### PR DESCRIPTION
The `> [!TIP]` block is now formatted correctly, allowing correct display within GitHub.