### PR TITLE
[@hono/auth-js] don't use request body

### DIFF
--- a/.changeset/hono-auth-js-stop-use-body.md
+++ b/.changeset/hono-auth-js-stop-use-body.md
@@ -1,0 +1,5 @@
+---
+"@hono/auth-js": patch
+---
+
+[@hono/auth-js] stop using request body

--- a/packages/auth-js/src/index.ts
+++ b/packages/auth-js/src/index.ts
@@ -42,8 +42,6 @@ async function cloneRequest(input: URL | string, request: Request, headers?: Hea
     return new Request(input, {
       method: request.method,
       headers: headers ?? new Headers(request.headers),
-      body:
-        request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.blob(),
       // @ts-ignore: TS2353
       referrer: 'referrer' in request ? (request.referrer as string) : undefined,
       // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
auth-js don't need request body.
accessing request body prevent future usage by other hono handlers