### PR TITLE
feat(oidc-auth): optional cookie name

### DIFF
--- a/.changeset/bright-teachers-knock.md
+++ b/.changeset/bright-teachers-knock.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': minor
+---
+
+Optionally specify a custom cookie name using the OIDC_COOKIE_NAME environment variable (default is 'oidc-auth')

--- a/packages/oidc-auth/README.md
+++ b/packages/oidc-auth/README.md
@@ -54,6 +54,7 @@ The middleware requires the following environment variables to be set:
 | OIDC_REDIRECT_URI          | The URL to which the OIDC provider should redirect the user after authentication. This URL must be registered as a redirect URI in the OIDC provider.       | None, must be provided                 |
 | OIDC_SCOPES                | The scopes that should be used for the OIDC authentication                                                                                                  | The server provided `scopes_supported` |
 | OIDC_COOKIE_PATH           | The path to which the `oidc-auth` cookie is set. Restrict to not send it with every request to your domain                                                  | /                                      |
+| OIDC_COOKIE_NAME           | The name of the cookie to be set                                                                                                                            | `oidc-auth`                            |
 
 ## How to Use
 


### PR DESCRIPTION
## Summary

I want to add a environment variable `OIDC_COOKIE_NAME` that allows the cookie name used to be customized, which will enhance security, avoid namespace conflicts, etc.

## Changes

- Added a configuration option `OIDC_COOKIE_NAME`
- Merged validation logic for all environment variables in `getOidcAuthEnv()`

## Testing

- Tested custom cookie names. (default name test is done in other tests).
- Verified no impact on authentication flow.