### PR TITLE
fix(auth.js): clone request directly for bun

### DIFF
--- a/.changeset/slimy-geese-promise.md
+++ b/.changeset/slimy-geese-promise.md
@@ -1,0 +1,5 @@
+---
+'@hono/auth-js': patch
+---
+
+clone request directly for bun

--- a/packages/auth-js/README.md
+++ b/packages/auth-js/README.md
@@ -112,8 +112,7 @@ const useSession = () => {
   return { session: data, status }
 }
 ```
-
-Working example repo https://github.com/divyam234/next-auth-hono-react
+For more details on how to Popup Oauth Login see [example](https://github.com/divyam234/next-auth-hono-react)
 
 ## Author
 

--- a/packages/auth-js/src/client.ts
+++ b/packages/auth-js/src/client.ts
@@ -85,6 +85,18 @@ export type SessionContextValue<R extends boolean = false> = R extends true
           status: 'unauthenticated' | 'loading'
         }
 
+export type WindowProps = {
+  url: string
+  title: string
+  width: number
+  height: number
+}
+
+export type AuthState = {
+  status:  'loading' | 'success' | 'errored'
+  error?: string
+}
+
 export async function fetchData<T = any>(
   path: string,
   config: {

--- a/packages/auth-js/test/index.test.ts
+++ b/packages/auth-js/test/index.test.ts
@@ -186,12 +186,12 @@ describe('Credentials Provider', () => {
       headers,
     })
     expect(res.status).toBe(200)
-    const obj = await res.json<{
+    const obj = await res.json() as {
       token: {
         name: string
         email: string
       }
-    }>()
+    }
     expect(obj.token.name).toBe(user.name)
     expect(obj.token.email).toBe(user.email)
   })


### PR DESCRIPTION
As bun now supports request cloning from  version 1.26 onwards  so workaround for cloning can be removed now @yusukebe. Ran test suite using bun its working fine. Also added popup login hook from example repo so that it can be imported directly from here.