### PR TITLE
feat(sentry): configure `HTTPException` status codes to report

### DIFF
--- a/.changeset/wet-foxes-eat.md
+++ b/.changeset/wet-foxes-eat.md
@@ -1,0 +1,5 @@
+---
+'@hono/sentry': major
+---
+
+Adds a configuration so that the user can filter which `HTTPException`s are reported to Sentry. By default, if the error is an `HTTPException` instance, only those with status codes between 500 and 599 are reported to Sentry.

--- a/packages/sentry/README.md
+++ b/packages/sentry/README.md
@@ -76,6 +76,24 @@ app.onError((e, c) => {
 })
 ```
 
+### Handling `HTTPException`
+
+You can specify which HTTP exceptions (`HTTPException`) should be captured by using the `includeStatusCodes` option.
+
+```ts
+app.use(
+  '*',
+  sentry({
+    dsn: 'https://xxxxxx@xxx.ingest.sentry.io/xxxxxx',
+    // Includes only 500-599 status codes by default.
+    includeStatusCodes: [{ min: 500, max: 599 }],
+    // Or, you can combine a specific status code and a range.
+    // includeStatusCodes: [500, { min: 503, max: 599 }],
+    // If you want to exclude all HTTPExceptions, you can set an empty array.
+  })
+)
+```
+
 ## Authors
 
 - Samuel Lippert - <https://github.com/sam-lippert>

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -86,7 +86,7 @@ export const sentry = (
         : true
       : false
 
-    if (shouldCapture && c.error) {
+    if (shouldCapture) {
       sentry.captureException(c.error)
     }
   }

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -80,12 +80,13 @@ export const sentry = (
 
     await next()
 
-    const shouldCapture =
-      c.error instanceof HTTPException
+    const shouldCapture = c.error
+      ? c.error instanceof HTTPException
         ? shouldCaptureHTTPException(c.error, includeStatusCodes)
-        : !!c.error
+        : true
+      : false
 
-    if (shouldCapture) {
+    if (shouldCapture && c.error) {
       sentry.captureException(c.error)
     }
   }

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -80,14 +80,13 @@ export const sentry = (
 
     await next()
 
-    const error = c.error
     const shouldCapture =
-      error instanceof HTTPException
-        ? shouldCaptureHTTPException(error, includeStatusCodes)
-        : true
+      c.error instanceof HTTPException
+        ? shouldCaptureHTTPException(c.error, includeStatusCodes)
+        : !!c.error
 
     if (shouldCapture) {
-      sentry.captureException(error)
+      sentry.captureException(c.error)
     }
   }
 }

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -62,6 +62,7 @@ export const sentry = (
     } catch {
       hasExecutionContext = false
     }
+    const { includeStatusCodes, ...sentryOpts } = options ?? {}
     const sentry = new Toucan({
       dsn: c.env?.SENTRY_DSN ?? c.env?.NEXT_PUBLIC_SENTRY_DSN,
       requestDataOptions: {
@@ -70,7 +71,7 @@ export const sentry = (
       },
       request: c.req.raw,
       context: hasExecutionContext ? c.executionCtx : new MockContext(),
-      ...options,
+      ...sentryOpts,
     })
     c.set('sentry', sentry)
     if (callback) {

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -83,7 +83,7 @@ export const sentry = (
     const error = c.error
     const shouldCapture =
       error instanceof HTTPException
-        ? shouldCaptureHTTPException(error, options?.includeStatusCodes)
+        ? shouldCaptureHTTPException(error, includeStatusCodes)
         : true
 
     if (shouldCapture) {

--- a/packages/sentry/test/index.test.ts
+++ b/packages/sentry/test/index.test.ts
@@ -67,6 +67,14 @@ describe('Sentry middleware', () => {
     expect(captureException).toHaveBeenCalled()
   })
 
+  it('Should not report if there is no error', async () => {
+    const req = new Request('http://localhost/sentry/foo')
+    const res = await app.fetch(req, {}, new Context())
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
   describe('Handle HTTPExceptions through `includeStatusCodes` option', () => {
     it('Should only report HTTPExceptions of range 500-599 if `includeStatusCodes` is not provided', async () => {
       const req = new Request('http://localhost/sentry/http-exception/500')

--- a/packages/sentry/test/index.test.ts
+++ b/packages/sentry/test/index.test.ts
@@ -1,4 +1,6 @@
 import { Hono } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+
 import { getSentry, sentry } from '../src'
 
 // Mock
@@ -22,6 +24,10 @@ jest.mock('toucan-js', () => ({
 const callback = jest.fn()
 
 describe('Sentry middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   const app = new Hono()
 
   app.use('/sentry/*', sentry(undefined, callback))
@@ -31,6 +37,10 @@ describe('Sentry middleware', () => {
   app.get('/sentry/bar', (c) => getSentry(c).log('bar') || c.text('bar'))
   app.get('/sentry/error', () => {
     throw new Error('a catastrophic error')
+  })
+  app.get('/sentry/http-exception/:code', (c) => {
+    const statusCode = c.req.param('code')
+    throw new HTTPException(parseInt(statusCode))
   })
 
   it('Should initialize Toucan', async () => {
@@ -55,5 +65,81 @@ describe('Sentry middleware', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(500)
     expect(captureException).toHaveBeenCalled()
+  })
+
+  describe('Handle HTTPExceptions through `includeStatusCodes` option', () => {
+    it('Should only report HTTPExceptions of range 500-599 if `includeStatusCodes` is not provided', async () => {
+      const req = new Request('http://localhost/sentry/http-exception/500')
+      const res = await app.fetch(req, {}, new Context())
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(500)
+      expect(captureException).toHaveBeenCalled()
+    })
+
+    it('Should not report HTTPExceptions other than range 500-599 if `includeStatusCodes` is not provided', async () => {
+      const req = new Request('http://localhost/sentry/http-exception/400')
+      const res = await app.fetch(req, {}, new Context())
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(400)
+      expect(captureException).not.toHaveBeenCalled()
+    })
+
+    const app2 = new Hono()
+
+    app2.use('/sentry/*', sentry({ includeStatusCodes: [403, { min: 500, max: 599 }] }, callback))
+    app2.get('/sentry/http-exception/:code', (c) => {
+      const statusCode = c.req.param('code')
+      throw new HTTPException(parseInt(statusCode))
+    })
+
+    it('Should report HTTPException if status code is included', async () => {
+      const req = new Request('http://localhost/sentry/http-exception/403')
+      const res = await app2.fetch(req, {}, new Context())
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(403)
+      expect(captureException).toHaveBeenCalled()
+    })
+
+    it('Should report HTTPException if status code is included', async () => {
+      const req = new Request('http://localhost/sentry/http-exception/500')
+      const res = await app2.fetch(req, {}, new Context())
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(500)
+      expect(captureException).toHaveBeenCalled()
+    })
+
+    it('Should not report HTTPException if status code is not included', async () => {
+      const req = new Request('http://localhost/sentry/http-exception/401')
+      const res = await app.fetch(req, {}, new Context())
+      expect(res).not.toBeNull()
+      expect(res.status).toBe(401)
+      expect(captureException).not.toHaveBeenCalled()
+    })
+
+    describe('Empty `includeStatusCodes` array', () => {
+      const app3 = new Hono()
+
+      app3.use('/sentry/*', sentry({ includeStatusCodes: [] }, callback))
+      app3.get('/sentry/http-exception/:code', (c) => {
+        const statusCode = c.req.param('code')
+        throw new HTTPException(parseInt(statusCode))
+      })
+
+      it('Ignores all HTTPExceptions for status code 400', async () => {
+        const req = new Request('http://localhost/sentry/http-exception/400')
+        const res = await app3.fetch(req, {}, new Context())
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(400)
+        expect(captureException).not.toHaveBeenCalled()
+      })
+
+      it('Ignores all HTTPExceptions for status code 500', async () => {
+        const req = new Request('http://localhost/sentry/http-exception/500')
+        const res = await app3.fetch(req, {}, new Context())
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(500)
+        expect(captureException).not.toHaveBeenCalled()
+      })
+    })
   })
 })


### PR DESCRIPTION
Closes #490

### Summary
In `@hono/sentry`, adds a configuration so that the user can filter which `HTTPException`s are reported to Sentry.

### Description
Currently, the middleware always reports all `HTTPException`s thrown to Sentry, and there was no way for the user to report only 500 status codes, for example. This results in many issues being unnecessarily reported to Sentry.

This was also discussed in another Sentry package, where they have already added support to filter specific HTTP status codes ([see this](https://github.com/getsentry/sentry-python/discussions/2494#discussioncomment-7507924)).

Since in Hono it's recommended to handle these errors by throwing [HTTPException](https://hono.dev/docs/api/exception), having the ability to filter which statuses are sent to Sentry is very helpful.

### New config
```typescript
  sentry({
    dsn: 'https://xxxxxx@xxx.ingest.sentry.io/xxxxxx',
    // Includes only 500-599 status codes by default.
    includeStatusCodes: [{ min: 500, max: 599 }],
    // Or, you can combine a specific status code and a range.
    // includeStatusCodes: [500, { min: 503, max: 599 }],
    // If you want to exclude all HTTPExceptions, you can set an empty array.
  })
```

By default, if the error is an `HTTPException` instance, only those with status codes between 500 and 599 are reported to Sentry.

### Tests
- Added tests to handle HTTPExceptions through the includeStatusCodes config.
- Added a test to ensure that if no Error is present, it should not report to Sentry (obvious but was missing).
- Added jest.clearAllMocks() before each test run to ensure that all mocks are cleared before each test. This prevents any state from previous tests from affecting the current test (for example, verifying expect(captureException).not.toHaveBeenCalled() after a successful expect(captureException).toHaveBeenCalled() leads to incorrect state).
