### PR TITLE
fix(valibot-validator): add support for v1 dist-tags

### DIFF
--- a/.changeset/early-tools-press.md
+++ b/.changeset/early-tools-press.md
@@ -1,0 +1,5 @@
+---
+'@hono/valibot-validator': patch
+---
+
+Fix Valibot peer dependency to support dist-tags

--- a/packages/valibot-validator/package.json
+++ b/packages/valibot-validator/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=3.9.0",
-    "valibot": "^1.0.0"
+    "valibot": "^1.0.0 || ^1.0.0-beta || ^1.0.0-rc"
   },
   "devDependencies": {
     "hono": "^4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2690,7 +2690,7 @@ __metadata:
     valibot: "npm:^1.0.0-beta.0"
   peerDependencies:
     hono: ">=3.9.0"
-    valibot: ^1.0.0
+    valibot: ^1.0.0 || ^1.0.0-beta || ^1.0.0-rc
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Looks like the npm install broke with the upgrade to Valibot v1. This PR should fix that.