### PR TITLE
fix(auth-js): fix cloned request causing request body to be unavailab…

### DIFF
--- a/.changeset/rare-toys-decide.md
+++ b/.changeset/rare-toys-decide.md
@@ -1,0 +1,5 @@
+---
+'@hono/auth-js': major
+---
+
+fix cloned request causing request body to be unavailable in middleware

--- a/packages/auth-js/src/index.ts
+++ b/packages/auth-js/src/index.ts
@@ -47,8 +47,8 @@ export function reqWithEnvUrl(req: Request, authUrl?: string) {
     }
     return new Request(reqUrlObj.href, req)
   }
-  const newReq = new Request(req)
-  const url = new URL(newReq.url)
+  const url = new URL(req.url)
+  const newReq = new Request(url.href, req)
   const proto = newReq.headers.get('x-forwarded-proto')
   const host = newReq.headers.get('x-forwarded-host') ?? newReq.headers.get('host')
   if (proto != null) url.protocol = proto.endsWith(':') ? proto : `${proto}:`
@@ -128,7 +128,7 @@ export function authHandler(): MiddlewareHandler {
     if (!config.secret || config.secret.length === 0) {
       throw new HTTPException(500, { message: 'Missing AUTH_SECRET' })
     }
-    
+
     const res = await Auth(reqWithEnvUrl(c.req.raw, ctxEnv.AUTH_URL), config)
     return new Response(res.body, res)
   }

--- a/packages/auth-js/test/index.test.ts
+++ b/packages/auth-js/test/index.test.ts
@@ -122,6 +122,11 @@ describe('Credentials Provider', () => {
     return c.json(auth)
   })
 
+  app.post('/api/create', async (c) => {
+    const data = await c.req.json()
+    return c.json({ data })
+  })
+
   const credentials = Credentials({
     credentials: {
       password: {},
@@ -186,7 +191,7 @@ describe('Credentials Provider', () => {
       headers,
     })
     expect(res.status).toBe(200)
-    const obj = await res.json() as {
+    const obj = (await res.json()) as {
       token: {
         name: string
         email: string
@@ -194,6 +199,26 @@ describe('Credentials Provider', () => {
     }
     expect(obj.token.name).toBe(user.name)
     expect(obj.token.email).toBe(user.email)
+  })
+
+  it('Should authorize and return 200 - /api/create', async () => {
+    const data = { name: 'Hono' }
+
+    const headers = new Headers()
+    headers.append('cookie', cookie[1])
+    headers.append('Content-Type', 'application/json')
+    const res = await app.request('http://localhost/api/create', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(data),
+    })
+    expect(res.status).toBe(200)
+    const obj = (await res.json()) as {
+      data: {
+        name: string
+      }
+    }
+    expect(obj.data.name).toBe(data.name)
   })
 
   it('Should respect x-forwarded-proto and x-forwarded-host', async () => {


### PR DESCRIPTION
I fixed some issues and found that auth-js, when used with zod-validator, would throw: malformed JSON in the request body.

The reason for this is that after cloning the request, the request body is not available in hono/validator via c.req.json.