### PR TITLE
feat(zod-openapi): infer env from routeMiddleware

### DIFF
--- a/.changeset/shy-pigs-buy.md
+++ b/.changeset/shy-pigs-buy.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+introduce routeMiddleware Env inference


### PR DESCRIPTION
This PR is my initial proposal for adding type inference support for the zod-openapi middleware package, improving type safety when using middleware within the router definition.

**Example usecase:**
https://github.com/honojs/middleware/blob/aca9bfd35f775fd455a0ceb9ed37e617d698571d/packages/zod-openapi/test/index.test-d.ts#L268-L304

**Background**

I'm fairly new to HonoJS, but I've been very excited to explore its potential, especially the zod-openapi integration. However, I noticed that middleware types seem to be dropped when used alongside the OpenAPI package, which can impact type consistency and developer experience.

**Potentially resolving:**
* https://github.com/honojs/middleware/issues/715
* https://github.com/honojs/middleware/issues/637
* ...

**Potential alternative**
* https://github.com/honojs/middleware/issues/715#issuecomment-2395783576


Thank you for considering this suggestion! Please feel free to suggest improvements or adjustments to align it with the project's requirements.