### PR TITLE
docs(zod-openapi): use tuple in middleware example

### DIFF
--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -285,7 +285,10 @@ const route = createRoute({
   request: {
     params: ParamsSchema,
   },
-  middleware: [prettyJSON(), cache({ cacheName: 'my-cache' })],
+  middleware: [
+    prettyJSON(),
+    cache({ cacheName: 'my-cache' })
+  ] as const, // Use `as const` to ensure TypeScript infers the middleware's Context.
   responses: {
     200: {
       content: {


### PR DESCRIPTION
With this PR I am changing the middleware example of zod-openapi to use a tuple.

**Potentially resolving:**
https://github.com/honojs/middleware/issues/637