### PR TITLE
fix: exported Hook type in valibot and typebox validators

### DIFF
--- a/packages/typebox-validator/src/index.ts
+++ b/packages/typebox-validator/src/index.ts
@@ -3,7 +3,7 @@ import { Value, type ValueError } from '@sinclair/typebox/value'
 import type { Context, Env, MiddlewareHandler, ValidationTargets } from 'hono'
 import { validator } from 'hono/validator'
 
-type Hook<T, E extends Env, P extends string> = (
+export type Hook<T, E extends Env, P extends string> = (
   result: { success: true; data: T } | { success: false; errors: ValueError[] },
   c: Context<E, P>
 ) => Response | Promise<Response> | void

--- a/packages/valibot-validator/src/index.ts
+++ b/packages/valibot-validator/src/index.ts
@@ -3,7 +3,7 @@ import { validator } from 'hono/validator'
 import type { GenericSchema, GenericSchemaAsync, InferInput, InferOutput, SafeParseResult } from 'valibot'
 import { safeParseAsync } from 'valibot'
 
-type Hook<T extends GenericSchema | GenericSchemaAsync, E extends Env, P extends string> = (
+export type Hook<T extends GenericSchema | GenericSchemaAsync, E extends Env, P extends string> = (
   result: SafeParseResult<T>,
   c: Context<E, P>
 ) => Response | Promise<Response> | void | Promise<Response | void>


### PR DESCRIPTION
- [x] Exported the `Hook` type from these validators similar to other validators implementation like [`@hono/zod-validator`](https://github.com/honojs/middleware/blob/main/packages/zod-validator/src/index.ts#L5) and [`@hono/arktype-validator`](https://github.com/honojs/middleware/blob/main/packages/arktype-validator/src/index.ts#L5)