### PR TITLE
fix(zod-openapi): infer env type parameter from middleware

### DIFF
--- a/.changeset/red-toes-reflect.md
+++ b/.changeset/red-toes-reflect.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+infer env type parameter from middleware

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -269,9 +269,17 @@ export type MiddlewareToHandlerType<M extends MiddlewareHandler<any, any, any>[]
   ? Last // Return the last remaining handler in the array
   : never
 
+type RouteMiddlewareParams<R extends RouteConfig> = OfHandlerType<
+  MiddlewareToHandlerType<AsArray<R['middleware']>>
+>
+
+export type RouteConfigToEnv<R extends RouteConfig> = RouteMiddlewareParams<R> extends never
+  ? Env
+  : RouteMiddlewareParams<R>['env']
+
 export type RouteHandler<
   R extends RouteConfig,
-  E extends Env = Env,
+  E extends Env = RouteConfigToEnv<R>,
   I extends Input = InputTypeParam<R> &
     InputTypeQuery<R> &
     InputTypeHeader<R> &
@@ -299,7 +307,7 @@ export type RouteHandler<
 
 export type RouteHook<
   R extends RouteConfig,
-  E extends Env = Env,
+  E extends Env = RouteConfigToEnv<R>,
   I extends Input = InputTypeParam<R> &
     InputTypeQuery<R> &
     InputTypeHeader<R> &
@@ -381,7 +389,7 @@ export class OpenAPIHono<
     handler: Handler<
       // use the env from the middleware if it's defined
       R['middleware'] extends MiddlewareHandler[] | MiddlewareHandler
-        ? OfHandlerType<MiddlewareToHandlerType<AsArray<R['middleware']>>>['env'] & E
+        ? RouteMiddlewareParams<R>['env'] & E
         : E,
       P,
       I,

--- a/packages/zod-openapi/test/handler.test-d.ts
+++ b/packages/zod-openapi/test/handler.test-d.ts
@@ -1,3 +1,4 @@
+import type { MiddlewareHandler } from 'hono'
 import type { RouteHandler } from '../src'
 import { OpenAPIHono, createRoute, z } from '../src'
 
@@ -51,5 +52,41 @@ describe('supports async handler', () => {
     const hono = new OpenAPIHono()
     hono.openapi(route, handler)
     hono.openapi(route, asyncHandler)
+  })
+
+  test('RouteHandler infers env type from middleware', () => {
+    type CustomEnv = { Variables: { customKey: string } }
+
+    const customMiddleware: MiddlewareHandler<CustomEnv> = (c, next) => {
+      c.set('customKey', 'customValue')
+      return next()
+    }
+
+    const routeWithMiddleware = createRoute({
+      method: 'get',
+      path: '/users',
+      middleware: [customMiddleware] as const,
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              schema: z.object({
+                id: z.string(),
+              }),
+            },
+          },
+          description: 'Retrieve the user',
+        },
+      },
+    })
+
+    const handler: RouteHandler<typeof routeWithMiddleware> = (c) => {
+      return c.json({
+        id: c.get('customKey'),
+      })
+    }
+
+    const hono = new OpenAPIHono()
+    hono.openapi(routeWithMiddleware, handler)
   })
 })


### PR DESCRIPTION
#807 introduced inference of `env` based on middleware. However, this was not extended to some of the abstract types themselves - this PR fixes this.