### PR TITLE
feat: customize html title for swagger-ui

### DIFF
--- a/.changeset/swift-pigs-smile.md
+++ b/.changeset/swift-pigs-smile.md
@@ -1,0 +1,5 @@
+---
+'@hono/swagger-ui': minor
+---
+
+customize html title for swagger-ui

--- a/packages/swagger-ui/src/index.ts
+++ b/packages/swagger-ui/src/index.ts
@@ -35,6 +35,7 @@ type OriginalSwaggerUIOptions = {
    * ```
    */
   manuallySwaggerUIHtml?: (asset: AssetURLs) => string
+  title?: string
 }
 
 type SwaggerUIOptions = OriginalSwaggerUIOptions & DistSwaggerUIOptions
@@ -68,13 +69,14 @@ const SwaggerUI = (options: SwaggerUIOptions) => {
 const middleware =
   <E extends Env>(options: SwaggerUIOptions): MiddlewareHandler<E> =>
   async (c) => {
+    const title = options?.title ?? "SwaggerUI"
     return c.html(/* html */ `
       <html lang="en">
         <head>
           <meta charset="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="description" content="SwaggerUI" />
-          <title>SwaggerUI</title>
+          <title>${title}</title>
         </head>
         <body>
           ${SwaggerUI(options)}


### PR DESCRIPTION
This pull request includes updates to the `SwaggerUI` middleware to allow customization of the HTML title. The most important changes include adding a `title` option to the `SwaggerUIOptions` type and updating the middleware to use this new option.

Enhancements to `SwaggerUI` middleware:

* [`packages/swagger-ui/src/index.ts`](diffhunk://#diff-8acefcfd603b5fa0a8a33b63d561ff1fa4ea5e40230e7aece4e18068b2a916a1R38): Added a `title` property to the `OriginalSwaggerUIOptions` type.
* [`packages/swagger-ui/src/index.ts`](diffhunk://#diff-8acefcfd603b5fa0a8a33b63d561ff1fa4ea5e40230e7aece4e18068b2a916a1R72-R79): Updated the `SwaggerUI` middleware to use the `title` option, defaulting to "SwaggerUI" if not provided.