### PR TITLE
fix(zod-openapi): multi-middleware complex type inference

### DIFF
--- a/.changeset/stale-hairs-wonder.md
+++ b/.changeset/stale-hairs-wonder.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Fix multi-middleware complex object type inference

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -221,7 +221,9 @@ type AsArray<T> = T extends undefined // TODO move to utils?
  */
 export type DeepSimplify<T> = {
   // TODO move to utils?
-  [KeyType in keyof T]: T[KeyType] extends object ? DeepSimplify<T[KeyType]> : T[KeyType]
+  [KeyType in keyof T]: T[KeyType] extends Record<string, unknown>
+    ? DeepSimplify<T[KeyType]>
+    : T[KeyType]
 } & {}
 
 /**


### PR DESCRIPTION
Fixed the inference of complex types in `zod-openapi`.

Issue explained in detail [here](https://github.com/honojs/middleware/issues/847)