### PR TITLE
fix(zod-openapi): accept `c.html` when html-like content type specified

### DIFF
--- a/.changeset/eighty-doors-destroy.md
+++ b/.changeset/eighty-doors-destroy.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Fix type error when using `c.html` in route expected to return html-like content

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -61,6 +61,14 @@ type IsJson<T> = T extends string
     : never
   : never
 
+type IsHtml<T> = T extends string
+  ? T extends `text/html${infer _Rest}` | `application/xhtml+xml${infer _Rest}`
+    ? 'html'
+    : T extends `application/vnd.${infer _Start}html${infer _Rest}`
+    ? 'html'
+    : never
+  : never
+
 type IsForm<T> = T extends string
   ? T extends
       | `multipart/form-data${infer _Rest}`

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -184,7 +184,13 @@ export type RouteConfigToTypedResponse<R extends RouteConfig> = {
   [Status in keyof R['responses'] & RouteConfigStatusCode]: IsJson<
     keyof R['responses'][Status]['content']
   > extends never
-    ? TypedResponse<{}, ExtractStatusCode<Status>, string>
+    ? IsHtml<keyof R['responses'][Status]['content']> extends never
+      ? TypedResponse<{}, ExtractStatusCode<Status>, string>
+      : /**
+         *  c.html returns Response
+         *  see: HTMLRespond in honojs/hono/context.ts
+         */
+        Response
     : TypedResponse<
         JSONParsed<ExtractContent<R['responses'][Status]['content']>>,
         ExtractStatusCode<Status>,

--- a/packages/zod-openapi/test/handler.test-d.ts
+++ b/packages/zod-openapi/test/handler.test-d.ts
@@ -123,4 +123,48 @@ describe('supports async handler', () => {
       >
     >
   })
+
+  test('Route accepts c.html when html like content type is specified', () => {
+    const route = createRoute({
+      method: 'get',
+      path: '/html',
+      responses: {
+        200: {
+          content: {
+            'text/html': {
+              schema: z.string(),
+            },
+          },
+          description: 'Return HTML',
+        },
+      },
+    })
+
+    const handler: RouteHandler<typeof route> = (c) => {
+      return c.html('<h1>Hello from html</h1>')
+    }
+
+    const route2 = createRoute({
+      method: 'get',
+      path: '/vnd/html',
+      responses: {
+        200: {
+          content: {
+            'application/vnd.dtg.local.html': {
+              schema: z.string(),
+            },
+          },
+          description: 'Return HTML',
+        },
+      },
+    })
+
+    const handler2: RouteHandler<typeof route2> = (c) => {
+      return c.html('<h1>Hello from vnd html</h1>')
+    }
+
+    const hono = new OpenAPIHono()
+    hono.openapi(route, handler)
+    hono.openapi(route2, handler2)
+  })
 })


### PR DESCRIPTION
## Outline
closes #842 

This PR prevents type error when using `c.html` in a handler, if the content type is expected to return HTML.