### PR TITLE
fix(zod-openapi): return `Response` if response is not text or JSON

### DIFF
--- a/.changeset/fluffy-doors-carry.md
+++ b/.changeset/fluffy-doors-carry.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: return `Response` if response is not text or JSON

--- a/packages/zod-openapi/test/handler.test-d.ts
+++ b/packages/zod-openapi/test/handler.test-d.ts
@@ -123,4 +123,28 @@ describe('supports async handler', () => {
       >
     >
   })
+
+  test('Route accepts a response other than the response from c.json() and c.text()', () => {
+    const route = createRoute({
+      method: 'get',
+      path: '/html',
+      responses: {
+        200: {
+          content: {
+            'text/html': {
+              schema: z.string(),
+            },
+          },
+          description: 'Return HTML',
+        },
+      },
+    })
+
+    const handler: RouteHandler<typeof route> = (c) => {
+      return c.html('<h1>Hello from html</h1>')
+    }
+
+    const hono = new OpenAPIHono()
+    hono.openapi(route, handler)
+  })
 })

--- a/packages/zod-openapi/test/index.test-d.ts
+++ b/packages/zod-openapi/test/index.test-d.ts
@@ -76,7 +76,7 @@ describe('Types', () => {
             id: number
             message: string
           }
-          outputFormat: 'json' | 'text'
+          outputFormat: 'json'
           status: 200
         }
       }

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -1779,21 +1779,21 @@ describe('RouteConfigToTypedResponse', () => {
             age: number
           },
           200,
-          'json' | 'text'
+          'json'
         >
       | TypedResponse<
           {
             ok: boolean
           },
           400,
-          'json' | 'text'
+          'json'
         >
       | TypedResponse<
           {
             ok: boolean
           },
           ServerErrorStatusCode,
-          'json' | 'text'
+          'json'
         >
     type verify = Expect<Equal<Expected, Actual>>
   })


### PR DESCRIPTION
Fixes #842

#852 was a great PR to fix #842. However, type errors should not arise for responses other than HTML. Example: 
`application/xml`. So, the problem will be solved if we set `Response` to contents other than JSON or Text like the following.

* JSON - `TypedRespose` with `json`
* Text - `TypedResponse` with `text`
* Others - `Response`

This PR will correct whether the returned value should be a `TypedResponse` or a `Response` based on the specified content type.