### PR TITLE
feat: support `effect@3.10.0`

### DIFF
--- a/.changeset/red-files-fly.md
+++ b/.changeset/red-files-fly.md
@@ -1,0 +1,5 @@
+---
+'@hono/effect-validator': minor
+---
+
+feat: support `effect@3.10.0`

--- a/packages/effect-validator/package.json
+++ b/packages/effect-validator/package.json
@@ -38,12 +38,11 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "@effect/schema": ">=0.68.18",
+    "effect": ">=3.10.0",
     "hono": ">=4.4.13"
   },
   "devDependencies": {
-    "@effect/schema": "^0.68.21",
-    "effect": "^3.4.8",
+    "effect": "3.10.0",
     "hono": "^4.4.13",
     "tsup": "^8.1.0",
     "typescript": "^5.5.3",

--- a/packages/effect-validator/src/index.ts
+++ b/packages/effect-validator/src/index.ts
@@ -3,8 +3,6 @@ import type { Env, Input, MiddlewareHandler, ValidationTargets } from 'hono'
 import type { Simplify } from 'hono/utils/types'
 import { validator } from 'hono/validator'
 
-type RemoveReadonly<T> = { -readonly [P in keyof T]: RemoveReadonly<T[P]> }
-
 type HasUndefined<T> = undefined extends T ? true : false
 
 export const effectValidator = <
@@ -13,8 +11,8 @@ export const effectValidator = <
   P extends string,
   Type,
   Encoded,
-  In = Simplify<RemoveReadonly<Encoded>>,
-  Out = Simplify<RemoveReadonly<Type>>,
+  In = Simplify<Encoded>,
+  Out = Simplify<Type>,
   I extends Input = {
     in: HasUndefined<In> extends true
       ? {

--- a/packages/effect-validator/src/index.ts
+++ b/packages/effect-validator/src/index.ts
@@ -1,5 +1,4 @@
-import { Schema as S, ParseResult } from 'effect'
-import { Either } from 'effect'
+import { Schema as S, ParseResult, Either } from 'effect'
 import type { Env, Input, MiddlewareHandler, ValidationTargets } from 'hono'
 import type { Simplify } from 'hono/utils/types'
 import { validator } from 'hono/validator'

--- a/packages/effect-validator/test/index.test.ts
+++ b/packages/effect-validator/test/index.test.ts
@@ -44,14 +44,14 @@ describe('Basic', () => {
     '/author': {
       $post: {
         input: {
-          json: {
+          json: Readonly<{
             name: string
             age: number
-          }
+          }>
         } & {
-          query?: {
+          query?: Readonly<{
             name?: string | string[] | undefined
-          }
+          }>
         }
         output: {
           success: boolean
@@ -127,9 +127,9 @@ describe('coerce', () => {
     '/page': {
       $get: {
         input: {
-          query: {
+          query: Readonly<{
             page: string | string[]
-          }
+          }>
         }
         output: {
           page: number

--- a/packages/effect-validator/test/index.test.ts
+++ b/packages/effect-validator/test/index.test.ts
@@ -1,5 +1,4 @@
-import type { ArrayFormatter } from '@effect/schema'
-import { Schema as S } from '@effect/schema'
+import { Schema as S } from 'effect'
 import { Hono } from 'hono'
 import type { StatusCode } from 'hono/utils/http-status'
 import type { Equal, Expect } from 'hono/utils/types'
@@ -104,7 +103,7 @@ describe('Basic', () => {
     expect(res).not.toBeNull()
     expect(res.status).toBe(400)
 
-    const data = await res.json<{ success: boolean; error: ArrayFormatter.Issue[] }>()
+    const data = await res.json()
     expect(data.success).toBe(false)
     expect(data.error[0].path).toEqual(['age'])
     expect(data.error[0].message).toBeDefined()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,7 +2535,7 @@ __metadata:
     typescript: "npm:^5.5.3"
     vitest: "npm:^2.0.1"
   peerDependencies:
-    effect: ">=3.0.0"
+    effect: ">=3.10.0"
     hono: ">=4.4.13"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,17 +1041,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@effect/schema@npm:^0.68.21":
-  version: 0.68.21
-  resolution: "@effect/schema@npm:0.68.21"
-  dependencies:
-    fast-check: "npm:^3.19.0"
-  peerDependencies:
-    effect: ^3.5.1
-  checksum: 127b4b89ce637c9be1dc84d933cefd63fdbf30f1fad9acf656c32a19df41875b646f2775129b331db9090f198a08f67f3ffe277af914a157a0c6711f3669b9a7
-  languageName: node
-  linkType: hard
-
 "@emnapi/runtime@npm:^0.44.0":
   version: 0.44.0
   resolution: "@emnapi/runtime@npm:0.44.0"
@@ -2540,14 +2529,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hono/effect-validator@workspace:packages/effect-validator"
   dependencies:
-    "@effect/schema": "npm:^0.68.21"
-    effect: "npm:^3.4.8"
+    effect: "npm:3.10.0"
     hono: "npm:^4.4.13"
     tsup: "npm:^8.1.0"
     typescript: "npm:^5.5.3"
     vitest: "npm:^2.0.1"
   peerDependencies:
-    "@effect/schema": ">=0.68.18"
+    effect: ">=3.0.0"
     hono: ">=4.4.13"
   languageName: unknown
   linkType: soft
@@ -8610,10 +8598,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"effect@npm:^3.4.8":
-  version: 3.4.8
-  resolution: "effect@npm:3.4.8"
-  checksum: 951962386775fa8506a6bfae75dc2802b00557dc58d9aecc7dff552c2e01ba651b87d662bdbf1f7c5ba1e450bc1a58f6daf44628222b0260471c5b52e0e76a8f
+"effect@npm:3.10.0":
+  version: 3.10.0
+  resolution: "effect@npm:3.10.0"
+  dependencies:
+    fast-check: "npm:^3.21.0"
+  checksum: 9d59b7c50ece9e9f9b87df587941927f206e863226ebad607a0880aab3287d67d751288e796db138d6682a130c97a92361a881c2fa1b6864810905372ecff159
   languageName: node
   linkType: hard
 
@@ -10173,12 +10163,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-check@npm:^3.19.0":
-  version: 3.19.0
-  resolution: "fast-check@npm:3.19.0"
+"fast-check@npm:^3.21.0":
+  version: 3.23.1
+  resolution: "fast-check@npm:3.23.1"
   dependencies:
     pure-rand: "npm:^6.1.0"
-  checksum: 5a15484d380fb5a3e94ec951c97e59b940ac4f2e1f3f7a05578d67851e5cb5283121bcf08c57e3238bc85899ce691b47ab477a6dd481a6f520e2e7ab4952d1ee
+  checksum: d61ee4a7a2e1abc5126bf2f1894413f532f686b3d1fc15c67fefb60dcca66024934b69a6454d3eba92e6568ac1abbb9882080e212d255865c3b3bbe52c5bf702
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `@effect/schema` package has been migrated from [Effect-TS/schema](https://github.com/Effect-TS/schema) to [Effect-TS/effect](https://github.com/Effect-TS/effect).
As a result, all `@effect/schema` imports have been updated to `effect`.

During the update, I encountered type errors, which have been resolved.

Since `import { Schema } from 'effect'` was introduced in version 3.10.0, I added `effect@3.10.0` to `peerDependencies`.