### PR TITLE
fix(zod-validator): support for case-insensitive `headers` target validation

### DIFF
--- a/.changeset/odd-clocks-sin.md
+++ b/.changeset/odd-clocks-sin.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': patch
+---
+
+Case-insensitive Zod schemas for headers

--- a/packages/zod-validator/test/index.test.ts
+++ b/packages/zod-validator/test/index.test.ts
@@ -339,3 +339,33 @@ describe('Only Types', () => {
     type verify = Expect<Equal<Expected, Actual>>
   })
 })
+
+describe('Case-Insensitive Headers', () => {
+  it('Should ignore the case for headers in the Zod schema and return 200', () => {
+    const app = new Hono()
+    const headerSchema = z.object({
+      'Content-Type': z.string(),
+      ApiKey: z.string(),
+      onlylowercase: z.string(),
+      ONLYUPPERCASE: z.string(),
+    })
+
+    const route = app.get('/', zValidator('header', headerSchema), (c) => {
+      const headers = c.req.valid('header')
+      return c.json(headers)
+    })
+
+    type Actual = ExtractSchema<typeof route>
+    type Expected = {
+      '/': {
+        $get: {
+          input: {
+            header: z.infer<typeof headerSchema>
+          }
+          output: z.infer<typeof headerSchema>
+        }
+      }
+    }
+    type verify = Expect<Equal<Expected, Actual>>
+  })
+})


### PR DESCRIPTION
Issue explained [here](https://github.com/honojs/middleware/issues/857#issuecomment-2509167288).

While it does make sense to keep `headers` case-insensitive (aka always casting to lowercase), it's easy to miss when writing your own validation schema. My little implementation makes sure the Zod schema doesn't care for lower/upper casing of the headers and treats them the same.

Fixes the issue above, with included test-cases.