### PR TITLE
fix(trpc-server) The Request.url getter can only be used on instances of Request

### DIFF
--- a/.changeset/spotty-hounds-relate.md
+++ b/.changeset/spotty-hounds-relate.md
@@ -1,0 +1,5 @@
+---
+'@hono/trpc-server': patch
+---
+
+fix(trpc-server) wrap Request with Proxy getter receiver should Request-instance

--- a/packages/trpc-server/src/index.ts
+++ b/packages/trpc-server/src/index.ts
@@ -37,11 +37,11 @@ export const trpcServer = ({
       req: canWithBody
         ? c.req.raw
         : new Proxy(c.req.raw, {
-            get(t, p, r) {
+            get(t, p, _r) {
               if (bodyProps.has(p as BodyProp)) {
                 return () => c.req[p as BodyProp]()
               }
-              return Reflect.get(t, p, r)
+              return Reflect.get(t, p, t)
             },
           }),
     }).then((res) => c.body(res.body, res))


### PR DESCRIPTION
wrap Request with Proxy getter receiver should Request-instance