### PR TITLE
feat(cloudflare-access): Handle Access organization does not exist and Access not available cases

### DIFF
--- a/.changeset/heavy-bugs-perform.md
+++ b/.changeset/heavy-bugs-perform.md
@@ -1,0 +1,5 @@
+---
+'@hono/cloudflare-access': minor
+---
+
+Handle Access organization does not exist and Access not available cases

--- a/packages/cloudflare-access/README.md
+++ b/packages/cloudflare-access/README.md
@@ -38,13 +38,12 @@ const app = new Hono<{ Variables: myVariables & CloudflareAccessVariables }>()
 app.use('*', cloudflareAccess('my-access-team-name'))
 app.get('/', (c) => {
   const payload = c.get('accessPayload')
-  
+
   return c.text(`You just authenticated with the email ${payload.email}`)
 })
 
 export default app
 ```
-
 
 ## Errors throw by the middleware
 
@@ -55,6 +54,8 @@ export default app
 | Authentication error: Token is expired                                                                 | 401       |
 | Authentication error: Expected team name {your-team-name}, but received ${different-team-signed-token} | 401       |
 | Authentication error: Invalid Token                                                                    | 401       |
+| Authentication error: The Access Organization 'my-team-name' does not exist                            | 500       |
+| Authentication error: Received unexpected HTTP code 500 from Cloudflare Access                         | 500       |
 
 ## Author
 


### PR DESCRIPTION
In the current version of `@hono/cloudflare-access`, both of the actions bellow will result into an "internal error" with a stack trace from the middleware:
- defining an access team name that does not exist
- fetching the access certificates when access is "generally" unavailable

This pr adds a good error message that correctly describes what the middleware received from Cloudflare Access.

This throws normal JS Error's because this is a fatal exception that the user should handle, but if the Hono maintainers think otherwise, i'm happy to change this into `throw new HTTPException(500, { message: '...' })`