### PR TITLE
docs(zod-validator): add usage docs for `zErrValidator`

### DIFF
--- a/packages/zod-validator/README.md
+++ b/packages/zod-validator/README.md
@@ -47,13 +47,8 @@ import { ZodSchema } from "zod";
 import type { ValidationTargets } from "hono";
 import { zValidator as zv } from "@hono/zod-validator";
 
-export const zValidator = <
-  T extends ZodSchema,
-  Target extends keyof ValidationTargets,
->(
-  target: Target,
-  schema: T,
-) => zv(target, schema, (result, c) => {
+export const zValidator = (target: keyof ValidationTargets,  schema: ZodSchema) => 
+zv(target, schema, (result, c) => {
   if (!result.success) {
     throw new HTTPException(400, { cause: result.error });
   }

--- a/packages/zod-validator/README.md
+++ b/packages/zod-validator/README.md
@@ -55,7 +55,7 @@ export const zValidator = <
   schema: T,
 ) => zv(target, schema, (result, c) => {
   if (!result.success) {
-    throw result.error
+    throw new HTTPException(400, { cause: result.error });
   }
 })
 

--- a/packages/zod-validator/README.md
+++ b/packages/zod-validator/README.md
@@ -37,6 +37,37 @@ app.post(
 )
 ```
 
+Throw Error:
+
+throw a zod validate error instead of directly returning an error response.
+
+```ts
+// file: validator-wrapper.ts
+import { ZodSchema } from "zod";
+import type { ValidationTargets } from "hono";
+import { zValidator as zv } from "@hono/zod-validator";
+
+export const zValidator = <
+  T extends ZodSchema,
+  Target extends keyof ValidationTargets,
+>(
+  target: Target,
+  schema: T,
+) => zv(target, schema, (result, c) => {
+  if (!result.success) {
+    throw result.error
+  }
+})
+
+// usage
+import { zValidator } from './validator-wrapper'
+app.post(
+  '/post',
+  zValidator('json', schema)
+  //...
+)
+```
+
 ## Author
 
 Yusuke Wada <https://github.com/yusukebe>


### PR DESCRIPTION
…dating error instead of directly returning an error response. 
throw a validating error instead of directly returning an error response.

relate pr: #897

close: #890