### PR TITLE
feat(oauth-providers): availbility to pass state into oauth middlewares

### DIFF
--- a/.changeset/red-cheetahs-argue.md
+++ b/.changeset/red-cheetahs-argue.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': minor
+---
+
+Add availbility to pass parameter state into OAuth middlewares

--- a/packages/oauth-providers/src/providers/facebook/facebookAuth.ts
+++ b/packages/oauth-providers/src/providers/facebook/facebookAuth.ts
@@ -12,10 +12,11 @@ export function facebookAuth(options: {
   fields: Fields[]
   client_id?: string
   client_secret?: string
+  state?: string
   redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
-    const newState = getRandomState()
+    const newState = options.state || getRandomState()
     // Create new Auth instance
     const auth = new AuthFlow({
       client_id: options.client_id || (env(c).FACEBOOK_ID as string),

--- a/packages/oauth-providers/src/providers/github/githubAuth.ts
+++ b/packages/oauth-providers/src/providers/github/githubAuth.ts
@@ -12,10 +12,11 @@ export function githubAuth(options: {
   client_secret?: string
   scope?: GitHubScope[]
   oauthApp?: boolean
+  state?: string
   redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
-    const newState = getRandomState()
+    const newState = options.state || getRandomState()
     // Create new Auth instance
     const auth = new AuthFlow({
       client_id: options.client_id || (env(c).GITHUB_ID as string),

--- a/packages/oauth-providers/src/providers/linkedin/linkedinAuth.ts
+++ b/packages/oauth-providers/src/providers/linkedin/linkedinAuth.ts
@@ -12,10 +12,11 @@ export function linkedinAuth(options: {
   client_secret?: string
   scope?: LinkedInScope[]
   appAuth?: boolean
+  state?: string
   redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
-    const newState = getRandomState()
+    const newState = options.state || getRandomState()
     // Create new Auth instance
     const auth = new AuthFlow({
       client_id: options.client_id || (env(c).LINKEDIN_ID as string),

--- a/packages/oauth-providers/src/providers/x/xAuth.ts
+++ b/packages/oauth-providers/src/providers/x/xAuth.ts
@@ -13,11 +13,12 @@ export function xAuth(options: {
   fields?: XFields[]
   client_id?: string
   client_secret?: string
+  state?: string
   redirect_uri?: string
 }): MiddlewareHandler {
   return async (c, next) => {
     // Generate encoded "keys"
-    const newState = getRandomState()
+    const newState = options.state || getRandomState()
     const challenge = await getCodeChallenge()
 
     const auth = new AuthFlow({


### PR DESCRIPTION
### Which middleware is the feature for?

@hono/oauth-providers

### What is the feature you are proposing?

Currently, I see that `@hono/oauth-providers` supports **discord**, **facebook**, **github**, **google**, **linkedin**, **x** OAuth. I have just test for **github** and **google** and it works probably.

But I face a problem, I want to configure the URL that clients can be redirected after authorized successfully (redirect from Hono context, not from the providers, they are callbacks).

Then, I see that the `googleAuth.ts` has a options that can pass the state:
```typescript
export function googleAuth(options: {
  scope: string[]
  login_hint?: string
  prompt?: 'none' | 'consent' | 'select_account'
  access_type?: 'online' | 'offline'
  client_id?: string
  client_secret?: string
  state?: string
  redirect_uri?: string
}): MiddlewareHandler {
  return async (c, next) => {
    const newState = options.state || getRandomState()
```
Then I can pass the `clientRedirectUrl` to the state, and extract it later.

But when dealing with **Github** (or other providers like the code I see), they don't have parameter `state`?
```typescript
export function githubAuth(options: {
  client_id?: string
  client_secret?: string
  scope?: GitHubScope[]
  oauthApp?: boolean
  redirect_uri?: string
}): MiddlewareHandler {
  return async (c, next) => {
    const newState = getRandomState()
```
The above block is the `githubAuth.ts` for example

Are there any reasons that we cannot pass the state to the middlewares? From my side, I think it's inconsistent when we do like that. And of course, I love to have a parameter "state", it will help for my case. 