### PR TITLE
feat(oidc-auth): optional cookie domain

### DIFF
--- a/.changeset/ten-trainers-jam.md
+++ b/.changeset/ten-trainers-jam.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': minor
+---
+
+Optionally specify a custom cookie domain using the OIDC_COOKIE_DOMAIN environment variable (default is domain of the request)

--- a/packages/oidc-auth/README.md
+++ b/packages/oidc-auth/README.md
@@ -43,18 +43,19 @@ npm i hono @hono/oidc-auth
 
 The middleware requires the following environment variables to be set:
 
-| Environment Variable       | Description                                                                                                                                                 | Default Value                          |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| OIDC_AUTH_SECRET           | The secret key used for signing the session JWT. It is used to verify the JWT in the cookie and prevent tampering. (Must be at least 32 characters long)    | None, must be provided                 |
-| OIDC_AUTH_REFRESH_INTERVAL | The interval (in seconds) at which the session should be implicitly refreshed.                                                                              | 15 \* 60 (15 minutes)                  |
-| OIDC_AUTH_EXPIRES          | The interval (in seconds) after which the session should be considered expired. Once expired, the user will be redirected to the IdP for re-authentication. | 60 _ 60 _ 24 (1 day)                   |
-| OIDC_ISSUER                | The issuer URL of the OpenID Connect (OIDC) discovery. This URL is used to retrieve the OIDC provider's configuration.                                      | None, must be provided                 |
-| OIDC_CLIENT_ID             | The OAuth 2.0 client ID assigned to your application. This ID is used to identify your application to the OIDC provider.                                    | None, must be provided                 |
-| OIDC_CLIENT_SECRET         | The OAuth 2.0 client secret assigned to your application. This secret is used to authenticate your application to the OIDC provider.                        | None, must be provided                 |
-| OIDC_REDIRECT_URI          | The URL to which the OIDC provider should redirect the user after authentication. This URL must be registered as a redirect URI in the OIDC provider.       | None, must be provided                 |
-| OIDC_SCOPES                | The scopes that should be used for the OIDC authentication                                                                                                  | The server provided `scopes_supported` |
-| OIDC_COOKIE_PATH           | The path to which the `oidc-auth` cookie is set. Restrict to not send it with every request to your domain                                                  | /                                      |
-| OIDC_COOKIE_NAME           | The name of the cookie to be set                                                                                                                            | `oidc-auth`                            |
+| Environment Variable       | Description                                                                                                                                                       | Default Value                          |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| OIDC_AUTH_SECRET           | The secret key used for signing the session JWT. It is used to verify the JWT in the cookie and prevent tampering. (Must be at least 32 characters long)          | None, must be provided                 |
+| OIDC_AUTH_REFRESH_INTERVAL | The interval (in seconds) at which the session should be implicitly refreshed.                                                                                    | 15 \* 60 (15 minutes)                  |
+| OIDC_AUTH_EXPIRES          | The interval (in seconds) after which the session should be considered expired. Once expired, the user will be redirected to the IdP for re-authentication.       | 60 _ 60 _ 24 (1 day)                   |
+| OIDC_ISSUER                | The issuer URL of the OpenID Connect (OIDC) discovery. This URL is used to retrieve the OIDC provider's configuration.                                            | None, must be provided                 |
+| OIDC_CLIENT_ID             | The OAuth 2.0 client ID assigned to your application. This ID is used to identify your application to the OIDC provider.                                          | None, must be provided                 |
+| OIDC_CLIENT_SECRET         | The OAuth 2.0 client secret assigned to your application. This secret is used to authenticate your application to the OIDC provider.                              | None, must be provided                 |
+| OIDC_REDIRECT_URI          | The URL to which the OIDC provider should redirect the user after authentication. This URL must be registered as a redirect URI in the OIDC provider.             | None, must be provided                 |
+| OIDC_SCOPES                | The scopes that should be used for the OIDC authentication                                                                                                        | The server provided `scopes_supported` |
+| OIDC_COOKIE_PATH           | The path to which the `oidc-auth` cookie is set. Restrict to not send it with every request to your domain                                                        | /                                      |
+| OIDC_COOKIE_NAME           | The name of the cookie to be set                                                                                                                                  | `oidc-auth`                            |
+| OIDC_COOKIE_DOMAIN         | The custom domain of the cookie. For example, set this like `example.com` to enable authentication across subdomains (e.g., `a.example.com` and `b.example.com`). | Domain of the request                  |
 
 ## How to Use
 


### PR DESCRIPTION
closes: https://github.com/honojs/middleware/issues/760

## Summary

I want to add a environment variable `OIDC_COOKIE_DOMAIN` that allows to set `domain` cookie attribute, which will enhance usage of authentication

## Changes

- Added a configuration option `OIDC_COOKIE_DOMAIN`

## Testing

- Tested case of environment value set and not set
- Verified no impact on authentication flow.

## Tasks

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
