### PR TITLE
feat(oidc-auth): support absolute path for redirect URI

### DIFF
--- a/.changeset/kind-cheetahs-give.md
+++ b/.changeset/kind-cheetahs-give.md
@@ -1,5 +1,5 @@
 ---
-'@hono/oidc-auth': patch
+'@hono/oidc-auth': minor
 ---
 
 Add support for absolute path in OIDC_REDIRECT_URI and set its default value to '/callback'

--- a/.changeset/kind-cheetahs-give.md
+++ b/.changeset/kind-cheetahs-give.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': patch
+---
+
+Add support for absolute path in OIDC_REDIRECT_URI and set its default value to '/callback'

--- a/packages/oidc-auth/README.md
+++ b/packages/oidc-auth/README.md
@@ -51,7 +51,7 @@ The middleware requires the following environment variables to be set:
 | OIDC_ISSUER                | The issuer URL of the OpenID Connect (OIDC) discovery. This URL is used to retrieve the OIDC provider's configuration.                                            | None, must be provided                 |
 | OIDC_CLIENT_ID             | The OAuth 2.0 client ID assigned to your application. This ID is used to identify your application to the OIDC provider.                                          | None, must be provided                 |
 | OIDC_CLIENT_SECRET         | The OAuth 2.0 client secret assigned to your application. This secret is used to authenticate your application to the OIDC provider.                              | None, must be provided                 |
-| OIDC_REDIRECT_URI          | The URL to which the OIDC provider should redirect the user after authentication. This URL must be registered as a redirect URI in the OIDC provider.             | None, must be provided                 |
+| OIDC_REDIRECT_URI          | The URL to which the OIDC provider should redirect the user after authentication. This URL must be registered as a redirect URI in the OIDC provider.             | `/callback`                            |
 | OIDC_SCOPES                | The scopes that should be used for the OIDC authentication                                                                                                        | The server provided `scopes_supported` |
 | OIDC_COOKIE_PATH           | The path to which the `oidc-auth` cookie is set. Restrict to not send it with every request to your domain                                                        | /                                      |
 | OIDC_COOKIE_NAME           | The name of the cookie to be set                                                                                                                                  | `oidc-auth`                            |
@@ -62,7 +62,6 @@ The middleware requires the following environment variables to be set:
 ```typescript
 import { Hono } from 'hono'
 import { oidcAuthMiddleware, getAuth, revokeSession, processOAuthCallback } from '@hono/oidc-auth'
-
 const app = new Hono()
 
 app.get('/logout', async (c) => {

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -277,9 +277,9 @@ const generateAuthorizationRequestUrl = async (
   const as = await getAuthorizationServer(c)
   const client = getClient(c)
   const authorizationRequestUrl = new URL(as.authorization_endpoint!)
-  const redirect_uri = new URL(env.OIDC_REDIRECT_URI, c.req.url).toString()
+  const redirectUri = new URL(env.OIDC_REDIRECT_URI, c.req.url).toString()
   authorizationRequestUrl.searchParams.set('client_id', client.client_id)
-  authorizationRequestUrl.searchParams.set('redirect_uri', redirect_uri)
+  authorizationRequestUrl.searchParams.set('redirect_uri', redirectUri)
   authorizationRequestUrl.searchParams.set('response_type', 'code')
   if (as.scopes_supported === undefined || as.scopes_supported.length === 0) {
     throw new HTTPException(500, {
@@ -340,12 +340,12 @@ export const processOAuthCallback = async (c: Context) => {
   if (code === undefined || nonce === undefined || code_verifier === undefined) {
     throw new HTTPException(500, { message: 'Missing required parameters / cookies' })
   }
-  const redirect_uri = new URL(env.OIDC_REDIRECT_URI, c.req.url).toString()
+  const redirectUri = new URL(env.OIDC_REDIRECT_URI, c.req.url).toString()
   const result = await exchangeAuthorizationCode(
     as,
     client,
     params,
-    redirect_uri,
+    redirectUri,
     nonce,
     code_verifier
   )
@@ -394,8 +394,8 @@ export const oidcAuthMiddleware = (): MiddlewareHandler => {
   return createMiddleware(async (c, next) => {
     const env = getOidcAuthEnv(c)
     const uri = new URL(c.req.url)
-    const redirect_uri = new URL(env.OIDC_REDIRECT_URI, c.req.url)
-    if (uri.pathname === redirect_uri.pathname && uri.origin === redirect_uri.origin) {
+    const redirectUri = new URL(env.OIDC_REDIRECT_URI, c.req.url)
+    if (uri.pathname === redirectUri.pathname && uri.origin === redirectUri.origin) {
       return processOAuthCallback(c)
     }
     try {

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -34,8 +34,9 @@ declare module 'hono' {
   }
 }
 
-const defaultOidcAuthCookieName = 'oidc-auth'
+const defaultOidcRedirectUri = '/callback'
 const defaultOidcAuthCookiePath = '/'
+const defaultOidcAuthCookieName = 'oidc-auth'
 const defaultRefreshInterval = 15 * 60 // 15 minutes
 const defaultExpirationInterval = 60 * 60 * 24 // 1 day
 
@@ -52,7 +53,7 @@ type OidcAuthEnv = {
   OIDC_ISSUER: string
   OIDC_CLIENT_ID: string
   OIDC_CLIENT_SECRET: string
-  OIDC_REDIRECT_URI: string
+  OIDC_REDIRECT_URI?: string
   OIDC_SCOPES?: string
   OIDC_COOKIE_PATH?: string
   OIDC_COOKIE_NAME?: string
@@ -83,8 +84,13 @@ const getOidcAuthEnv = (c: Context) => {
     if (oidcAuthEnv.OIDC_CLIENT_SECRET === undefined) {
       throw new HTTPException(500, { message: 'OIDC client secret is not provided' })
     }
-    if (oidcAuthEnv.OIDC_REDIRECT_URI === undefined) {
-      throw new HTTPException(500, { message: 'OIDC redirect URI is not provided' })
+    oidcAuthEnv.OIDC_REDIRECT_URI = oidcAuthEnv.OIDC_REDIRECT_URI ?? defaultOidcRedirectUri
+    if (!oidcAuthEnv.OIDC_REDIRECT_URI.startsWith('/')) {
+      try {
+        new URL(oidcAuthEnv.OIDC_REDIRECT_URI)
+      } catch (e) {
+        throw new HTTPException(500, { message: 'The OIDC redirect URI is invalid. It must be a full URL or an absolute path' })
+      }
     }
     oidcAuthEnv.OIDC_COOKIE_PATH = oidcAuthEnv.OIDC_COOKIE_PATH ?? defaultOidcAuthCookiePath
     oidcAuthEnv.OIDC_COOKIE_NAME = oidcAuthEnv.OIDC_COOKIE_NAME ?? defaultOidcAuthCookieName
@@ -271,8 +277,9 @@ const generateAuthorizationRequestUrl = async (
   const as = await getAuthorizationServer(c)
   const client = getClient(c)
   const authorizationRequestUrl = new URL(as.authorization_endpoint!)
+  const redirect_uri = new URL(env.OIDC_REDIRECT_URI, c.req.url).toString()
   authorizationRequestUrl.searchParams.set('client_id', client.client_id)
-  authorizationRequestUrl.searchParams.set('redirect_uri', env.OIDC_REDIRECT_URI)
+  authorizationRequestUrl.searchParams.set('redirect_uri', redirect_uri)
   authorizationRequestUrl.searchParams.set('response_type', 'code')
   if (as.scopes_supported === undefined || as.scopes_supported.length === 0) {
     throw new HTTPException(500, {
@@ -312,7 +319,7 @@ export const processOAuthCallback = async (c: Context) => {
 
   // Parses the authorization response and validates the state parameter
   const state = getCookie(c, 'state')
-  const path = new URL(env.OIDC_REDIRECT_URI).pathname
+  const path = new URL(env.OIDC_REDIRECT_URI, c.req.url).pathname
   deleteCookie(c, 'state', { path })
   const currentUrl: URL = new URL(c.req.url)
   const params = oauth2.validateAuthResponse(as, client, currentUrl, state)
@@ -333,11 +340,12 @@ export const processOAuthCallback = async (c: Context) => {
   if (code === undefined || nonce === undefined || code_verifier === undefined) {
     throw new HTTPException(500, { message: 'Missing required parameters / cookies' })
   }
+  const redirect_uri = new URL(env.OIDC_REDIRECT_URI, c.req.url).toString()
   const result = await exchangeAuthorizationCode(
     as,
     client,
     params,
-    env.OIDC_REDIRECT_URI,
+    redirect_uri,
     nonce,
     code_verifier
   )
@@ -385,14 +393,15 @@ const exchangeAuthorizationCode = async (
 export const oidcAuthMiddleware = (): MiddlewareHandler => {
   return createMiddleware(async (c, next) => {
     const env = getOidcAuthEnv(c)
-    const uri = c.req.url.split('?')[0]
-    if (uri === env.OIDC_REDIRECT_URI) {
+    const uri = new URL(c.req.url)
+    const redirect_uri = new URL(env.OIDC_REDIRECT_URI, c.req.url)
+    if (uri.pathname === redirect_uri.pathname && uri.origin === redirect_uri.origin) {
       return processOAuthCallback(c)
     }
     try {
       const auth = await getAuth(c)
       if (auth === null) {
-        const path = new URL(env.OIDC_REDIRECT_URI).pathname
+        const path = new URL(env.OIDC_REDIRECT_URI, c.req.url).pathname
         const cookieDomain = env.OIDC_COOKIE_DOMAIN
         // Redirect to IdP for login
         const state = oauth2.generateRandomState()


### PR DESCRIPTION
## Summary

The `OIDC_REDIRECT_URI` was initially expected to be a full URL, but rewriting the URL for development and production environments is cumbersome. By supporting absolute paths such as `/callback`, we aim to reduce the developer’s effort.

## Changes

- Added support for absolute paths in `OIDC_REDIRECT_URI` and set the default value to `/callback`.

## Testing

- Verified the behavior when `OIDC_REDIRECT_URI` is a relative path and when it is not set.
- Added tests for other environment variables.

## Tasks

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
