### PR TITLE
fix(oidc-auth): Fixed type error

### DIFF
--- a/.changeset/eighty-trains-peel.md
+++ b/.changeset/eighty-trains-peel.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': patch
+---
+
+Fix type error

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -142,14 +142,14 @@ export const getClient = (c: Context): oauth2.Client => {
  */
 export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
   const env = getOidcAuthEnv(c)
-  let auth: Partial<OidcAuth> | null = c.get('oidcAuth')
+  let auth = c.get('oidcAuth')
   if (auth === undefined) {
     const session_jwt = getCookie(c, env.OIDC_COOKIE_NAME)
     if (session_jwt === undefined) {
       return null
     }
     try {
-      auth = await verify(session_jwt, env.OIDC_AUTH_SECRET)
+      auth = await verify(session_jwt, env.OIDC_AUTH_SECRET) as OidcAuth
     } catch (e) {
       deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
       return null
@@ -178,11 +178,11 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
         deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
         return null
       }
-      auth = await updateAuth(c, auth as OidcAuth, result)
+      auth = await updateAuth(c, auth, result)
     }
-    c.set('oidcAuth', auth as OidcAuth)
+    c.set('oidcAuth', auth)
   }
-  return auth as OidcAuth
+  return auth
 }
 
 /**
@@ -239,7 +239,7 @@ export const revokeSession = async (c: Context): Promise<void> => {
   const session_jwt = getCookie(c, env.OIDC_COOKIE_NAME)
   if (session_jwt !== undefined) {
     deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
-    const auth = await verify(session_jwt, env.OIDC_AUTH_SECRET)
+    const auth = await verify(session_jwt, env.OIDC_AUTH_SECRET) as OidcAuth
     if (auth.rtk !== undefined && auth.rtk !== '') {
       // revoke refresh token
       const as = await getAuthorizationServer(c)


### PR DESCRIPTION
## Summary

While running the oidc-oauth test, I encountered the following error. Therefore, I have fixed it.

The test worked in other environments, so I suspect that the issue was caused by the esbuild version update.

```
    src/index.ts:152:7 - error TS2322: Type 'JWTPayload' is not assignable to type 'Partial<OidcAuth>'.
      'string' index signatures are incompatible.
        Type 'unknown' is not assignable to type 'JsonValue | undefined'.

    152       auth = await verify(session_jwt, env.OIDC_AUTH_SECRET)
              ~~~~
    src/index.ts:248:69 - error TS2345: Argument of type '{} | null' is not assignable to parameter of type 'string'.
      Type 'null' is not assignable to type 'string'.

    248         const response = await oauth2.revocationRequest(as, client, auth.rtk)
                                                                            ~~~~~~~~
```

## Changes

- Fixed type error

## Tasks

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
