### PR TITLE
fix(typebox-validator): Fix @hono/typebox-validator, when imported as esm, transiently importing typebox as cjs

### DIFF
--- a/.changeset/purple-weeks-cross.md
+++ b/.changeset/purple-weeks-cross.md
@@ -1,0 +1,5 @@
+---
+'@hono/typebox-validator': patch
+---
+
+Fix transiently importing typebox as cjs even when typebox-validator imported as esm

--- a/packages/typebox-validator/package.json
+++ b/packages/typebox-validator/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "jest",
     "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:esm": "tsc -p tsconfig.esm.json && echo '{\"type\": \"module\"}' > dist/esm/package.json",
     "build": "rimraf dist && yarn build:cjs && yarn build:esm",
     "prerelease": "yarn build && yarn test",
     "release": "yarn publish"


### PR DESCRIPTION
Adds package.json to the esm build folder with `"type": "module"`, so that the runtime recognises the type of the package as esm. Then it will import typebox as esm. Fixes #873 