### PR TITLE
fix(typebox-validator): correct exporting in `package.json`

### DIFF
--- a/.changeset/breezy-moose-hide.md
+++ b/.changeset/breezy-moose-hide.md
@@ -1,0 +1,5 @@
+---
+'@hono/typebox-validator': patch
+---
+
+fix: correct exporting in `package.json`

--- a/packages/typebox-validator/package.json
+++ b/packages/typebox-validator/package.json
@@ -2,9 +2,12 @@
   "name": "@hono/typebox-validator",
   "version": "0.3.1",
   "description": "Validator middleware using TypeBox",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js",
+    "types": "./dist/esm/index.d.ts"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixes #947

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
