### PR TITLE
fix(node-ws): allow `Hono` with custom Env for `createNodeWebSocket`

### DIFF
--- a/.changeset/ninety-dogs-decide.md
+++ b/.changeset/ninety-dogs-decide.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': patch
+---
+
+fix: allow `Hono` with custom Env for `createNodeWebSocket`

--- a/packages/node-ws/package.json
+++ b/packages/node-ws/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     "build": "tsup ./src/index.ts --format esm,cjs --dts",
     "publint": "publint",
     "release": "yarn build && yarn test && yarn publint && yarn publish"

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -149,4 +149,15 @@ describe('WebSocket helper', () => {
       expect((receivedMessage as Buffer).at(idx)).toBe(val)
     })
   })
+
+  describe('Types', () => {
+    it('Should not throw a type error with an app with Variables generics', () => {
+      const app = new Hono<{
+        Variables: {
+          foo: string
+        }
+      }>()
+      createNodeWebSocket({ app })
+    })
+  })
 })

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -12,7 +12,8 @@ export interface NodeWebSocket {
   injectWebSocket(server: Server | Http2Server | Http2SecureServer): void
 }
 export interface NodeWebSocketInit {
-  app: Hono
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app: Hono<any, any, any>
   baseUrl?: string | URL
 }
 


### PR DESCRIPTION
Fixes #948

`Hono<any, any, any>` can accept an app with custom Bindings/Variables types. This method is used in such the code:

https://github.com/honojs/hono/blob/093d3fd56ea4411aab305984dbc29e24ac3ac528/src/client/client.ts#L122


### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
