### PR TITLE
fix(standard-validator): fix hook's  result type

### DIFF
--- a/.changeset/gorgeous-crabs-doubt.md
+++ b/.changeset/gorgeous-crabs-doubt.md
@@ -1,0 +1,5 @@
+---
+'@hono/standard-validator': patch
+---
+
+fix result type

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -1,6 +1,6 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { Context, Env, Input, MiddlewareHandler, TypedResponse, ValidationTargets } from 'hono'
 import { validator } from 'hono/validator'
-import type { StandardSchemaV1 } from '@standard-schema/spec'
 
 type HasUndefined<T> = undefined extends T ? true : false
 type TOrPromiseOfT<T> = T | Promise<T>
@@ -54,7 +54,7 @@ const sValidator = <
 
     if (hook) {
       const hookResult = await hook(
-        !!result.issues
+        result.issues
           ? { data: value, error: result.issues, success: false, target }
           : { data: value, success: true, target },
         c

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -13,8 +13,8 @@ type Hook<
   O = {}
 > = (
   result: (
-    | { success: boolean; data: T }
-    | { success: boolean; error: ReadonlyArray<StandardSchemaV1.Issue>; data: T }
+    | { success: true; data: T }
+    | { success: false; error: ReadonlyArray<StandardSchemaV1.Issue>; data: T }
   ) & {
     target: Target
   },

--- a/packages/standard-validator/test/__schemas__/arktype.ts
+++ b/packages/standard-validator/test/__schemas__/arktype.ts
@@ -23,6 +23,7 @@ const queryPaginationSchema = type({
 })
 
 const querySortSchema = type({
+  // eslint-disable-next-line quotes
   order: "'asc'|'desc'",
 })
 

--- a/packages/standard-validator/test/index.test.ts
+++ b/packages/standard-validator/test/index.test.ts
@@ -1,11 +1,12 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { Hono } from 'hono'
 import type { Equal, Expect, UnionToIntersection } from 'hono/utils/types'
-import { sValidator } from '../src'
 import { vi } from 'vitest'
+import { sValidator } from '../src'
 
+import * as arktypeSchemas from './__schemas__/arktype'
 import * as valibotSchemas from './__schemas__/valibot'
 import * as zodSchemas from './__schemas__/zod'
-import * as arktypeSchemas from './__schemas__/arktype'
 
 type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
 type MergeDiscriminatedUnion<U> = UnionToIntersection<U> extends infer O
@@ -183,6 +184,9 @@ describe('Standard Schema Validation', () => {
           '/post',
           sValidator('json', schema, (result, c) => {
             if (!result.success) {
+              type verify = Expect<
+                Equal<ReadonlyArray<StandardSchemaV1.Issue>, typeof result.error>
+              >
               return c.text(`${result.data.id} is invalid!`, 400)
             }
           }),


### PR DESCRIPTION
fix type error

```typescript
import { Hono } from "hono";
import { minLength, object, pipe,  string } from "valibot";

const createSchema = object({
  name: pipe(string(), minLength(3)),
});

const route = new Hono()
  .post(
    "/",
    sValidator("form", createSchema, (result, c) => {
      if (!result.success) {
        return c.json({ errors: result.error }, 400);  // <- type error
      }
    }),
    async (c) => {
      const { name } = c.req.valid("form");
      return c.json({name});
    }
  );


```

```
Property 'error' does not exist on type '({ success: boolean; data: { name: string; }; } | { success: boolean; error: readonly Issue[]; data: { name: string; }; }) & { target: "form"; }'.
  Property 'error' does not exist on type '{ success: boolean; data: { name: string; }; } & { target: "form"; }'
```

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
