### PR TITLE
feat(node-ws): Reject unexpected WebSocket connections

### DIFF
--- a/.changeset/selfish-lies-sing.md
+++ b/.changeset/selfish-lies-sing.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': minor
+---
+
+Added rejection of WebSocket connections when the app does not expect them

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -51,6 +51,40 @@ describe('WebSocket helper', () => {
     expect(await mainPromise).toBe(true)
   })
 
+  it('Should be rejected if upgradeWebSocket is not used', async () => {
+    app.get(
+      '/', (c)=>c.body('')
+    )
+
+    {
+      const ws = new WebSocket('ws://localhost:3030/')
+      const mainPromise = new Promise<boolean>((resolve) => {
+        ws.onerror = () => {
+          resolve(true)
+        }
+        ws.onopen = () => {
+          resolve(false)
+        }
+      })
+
+      expect(await mainPromise).toBe(true)
+    }
+
+    { //also should rejected on fallback
+      const ws = new WebSocket('ws://localhost:3030/notFound')
+      const mainPromise = new Promise<boolean>((resolve) => {
+        ws.onerror = () => {
+          resolve(true)
+        }
+        ws.onopen = () => {
+          resolve(false)
+        }
+      })
+
+      expect(await mainPromise).toBe(true)
+    }
+  })
+
   it('Should be able to connect', async () => {
     const mainPromise = new Promise<boolean>((resolve) =>
       app.get(


### PR DESCRIPTION
This PR addresses an issue in which WebSocket connections are permanently established even when the app does not expect them. As a result, these unwanted connections remain active indefinitely, potentially leading to resource leaks and other unintended behavior.

### Problem:

- The server currently accepts all WebSocket connection attempts without verifying if the app expects them.
- Unwanted WebSocket connections remain open, causing unnecessary resource consumption and potential security risks.

### Changes:

If the server detects a WebSocket connection that is not expected by the application, it immediately rejects the handshake and closes the connection.

This behaviour can be disabled by  ```createNodeWebSocket({ app, strict: false })```