### PR TITLE
fix(swagger-ui): fix configuration bug

### DIFF
--- a/.changeset/sixty-tomatoes-fold.md
+++ b/.changeset/sixty-tomatoes-fold.md
@@ -1,0 +1,6 @@
+---
+'@hono/swagger-ui': patch
+---
+
+- fix(swagger-ui): Handle undefined options and improve rendering logic for non-RENDER_TYPE_MAP edge cases
+- test(option-renderer): Add tests for filtering and handling invalid properties

--- a/packages/swagger-ui/src/swagger/renderer.ts
+++ b/packages/swagger-ui/src/swagger/renderer.ts
@@ -127,23 +127,28 @@ export const renderSwaggerUIOptions = (options: DistSwaggerUIOptions) => {
   const optionsStrings = Object.entries(options)
     .map(([k, v]) => {
       const key = k as keyof typeof RENDER_TYPE_MAP
-      if (RENDER_TYPE_MAP[key] === RENDER_TYPE.STRING) {
-        return `${key}: '${v}'`
+
+      if (!RENDER_TYPE_MAP[key] || v === undefined) {
+        return ''
       }
-      if (RENDER_TYPE_MAP[key] === RENDER_TYPE.STRING_ARRAY) {
-        if (!Array.isArray(v)) {
+
+      switch (RENDER_TYPE_MAP[key]) {
+        case RENDER_TYPE.STRING:
+          return `${key}: '${v}'`
+        case RENDER_TYPE.STRING_ARRAY:
+          if (!Array.isArray(v)) {
+            return ''
+          }
+          return `${key}: [${v.map((ve) => `${ve}`).join(',')}]`
+        case RENDER_TYPE.JSON_STRING:
+          return `${key}: ${JSON.stringify(v)}`
+        case RENDER_TYPE.RAW:
+          return `${key}: ${v}`
+        default:
           return ''
-        }
-        return `${key}: [${v.map((ve) => `${ve}`).join(',')}]`
       }
-      if (RENDER_TYPE_MAP[key] === RENDER_TYPE.JSON_STRING) {
-        return `${key}: ${JSON.stringify(v)}`
-      }
-      if (RENDER_TYPE_MAP[key] === RENDER_TYPE.RAW) {
-        return `${key}: ${v}`
-      }
-      return ''
     })
+    .filter(item => item !== '')
     .join(',')
 
   return optionsStrings

--- a/packages/swagger-ui/test/option-renderer.test.ts
+++ b/packages/swagger-ui/test/option-renderer.test.ts
@@ -187,6 +187,31 @@ describe('SwaggerUIOption Rendering', () => {
       { parameterMacro: '(parameter) => parameter', url: baseUrl },
       `parameterMacro: (parameter) => parameter,url: '${baseUrl}'`,
     ],
+    [
+      'filters out properties not in RENDER_TYPE_MAP',
+      { url: baseUrl, title: 'My API', customProperty: 'value' } as DistSwaggerUIOptions & { title: string },
+      `url: '${baseUrl}'`
+    ],
+    [
+      'filters out undefined values',
+      { url: baseUrl, layout: undefined },
+      `url: '${baseUrl}'`
+    ],
+    [
+      'handles multiple invalid properties gracefully',
+      { 
+        url: baseUrl, 
+        title: 'My API', // Not in RENDER_TYPE_MAP but used in HTML <title>
+        presets: null as unknown, // Invalid type
+        withCredentials: true 
+      } as DistSwaggerUIOptions & { title: string },
+      `url: '${baseUrl}',withCredentials: true`
+    ],
+    [
+      'handles empty input gracefully',
+      { url: '' },
+      `url: ''`
+    ]
   ]
 
   it.each(commonTests)('renders correctly with %s', (_, input, expected) => {


### PR DESCRIPTION

This PR fixes #974 

## Improvements to option handling and rendering logic:

* [`packages/swagger-ui/src/swagger/renderer.ts`](diffhunk://#diff-ccca2844de07070d9888be6dfd16d8521ec7274b90337478481a5343b0b88191L130-R151): Enhanced the `renderSwaggerUIOptions` function to handle undefined options and improve rendering logic for non-RENDER_TYPE_MAP edge cases. Added a switch statement to manage different render types and a filter to remove empty strings from the options.

## Testing enhancements:

* [`packages/swagger-ui/test/option-renderer.test.ts`](diffhunk://#diff-6ce2374220877a06c4f196ed2d4c04657516f0c789f5f862739864ca37f26c0bR190-R214): Added tests to ensure the `renderSwaggerUIOptions` function correctly filters out properties not in `RENDER_TYPE_MAP`, handles undefined values, manages multiple invalid properties gracefully, and handles empty input gracefully.

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
