### PR TITLE
fix(zod-openapi): replace path param strings correctly in basePath

### DIFF
--- a/.changeset/dry-squids-flash.md
+++ b/.changeset/dry-squids-flash.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: replace path param strings correctly in basePath

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -701,7 +701,7 @@ function addBasePathToDocument(document: Record<string, any>, basePath: string) 
   const updatedPaths: Record<string, any> = {}
 
   Object.keys(document.paths).forEach((path) => {
-    updatedPaths[mergePath(basePath, path)] = document.paths[path]
+    updatedPaths[mergePath(basePath.replaceAll(/:([^\/]+)/g, '{$1}'), path)] = document.paths[path]
   })
 
   return {

--- a/packages/zod-openapi/test/index.test.ts
+++ b/packages/zod-openapi/test/index.test.ts
@@ -1239,6 +1239,41 @@ describe('basePath()', () => {
 
     expect(paths).not.toStrictEqual(['/message1', '/message2', '/hello'])
   })
+
+  it('Should correctly handle path parameters in basePath', async () => {
+    const app = new OpenAPIHono().basePath('/:param')
+
+    app.openapi(
+      createRoute({
+        method: 'get',
+        path: '/',
+        responses: {
+          200: {
+            description: 'Get message',
+          },
+        },
+      }),
+      (c) => {
+        return c.json({ path: c.req.param('param') })
+      }
+    )
+
+    const json = app.getOpenAPIDocument({
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'My API',
+      },
+    })
+
+    const paths = Object.keys(json.paths)
+
+    expect(paths).toStrictEqual(['/{param}'])
+
+    const res = await app.request('/abc')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ path: 'abc' })
+  })
 })
 
 describe('With hc', () => {


### PR DESCRIPTION
Fixes #989

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
