### PR TITLE
fix(zod-openapi): correctly handle path parameters in basePath

### DIFF
--- a/.changeset/smooth-grapes-pay.md
+++ b/.changeset/smooth-grapes-pay.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix(zod-openapi): correctly handle path parameters in basePath

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -638,7 +638,7 @@ export class OpenAPIHono<
             path: mergePath(
               pathForOpenAPI,
               // @ts-expect-error _basePath is private
-              app._basePath,
+              app._basePath.replaceAll(/:([^\/]+)/g, '{$1}'),
               def.route.path
             ),
           })
@@ -649,7 +649,7 @@ export class OpenAPIHono<
             path: mergePath(
               pathForOpenAPI,
               // @ts-expect-error _basePath is private
-              app._basePath,
+              app._basePath.replaceAll(/:([^\/]+)/g, '{$1}'),
               def.webhook.path
             ),
           })


### PR DESCRIPTION
This fixes an issue, that wasn't covered by #992.

I don't know where to actually put the `replaceAll`, because if it put it before the `app.openAPIRegistry`, `_basePath` isn't always defined and therefore will fail.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
