### PR TITLE
test(auth-js): use node 20.x in CI

### DIFF
--- a/.github/workflows/ci-auth-js.yml
+++ b/.github/workflows/ci-auth-js.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn test

--- a/packages/auth-js/test/index.test.ts
+++ b/packages/auth-js/test/index.test.ts
@@ -3,13 +3,8 @@ import type { Adapter } from '@auth/core/adapters'
 import Credentials from '@auth/core/providers/credentials'
 import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
-import { webcrypto } from 'node:crypto'
 import type { AuthConfig } from '../src'
 import { authHandler, verifyAuth, initAuthConfig, reqWithEnvUrl } from '../src'
-
-// @ts-expect-error - global crypto
-//needed for node 18 and below but should work in node 20 and above
-global.crypto = webcrypto
 
 describe('Config', () => {
   it('Should return 500 if AUTH_SECRET is missing', async () => {


### PR DESCRIPTION
Avoid needing to override `global.crypto` in tests