### PR TITLE
chore(standard-validator): exported the Hook type

### DIFF
--- a/.changeset/gold-stingrays-grin.md
+++ b/.changeset/gold-stingrays-grin.md
@@ -1,0 +1,5 @@
+---
+'@hono/standard-validator': patch
+---
+
+Exported Hook type

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -5,7 +5,7 @@ import { validator } from 'hono/validator'
 type HasUndefined<T> = undefined extends T ? true : false
 type TOrPromiseOfT<T> = T | Promise<T>
 
-type Hook<
+export type Hook<
   T,
   E extends Env,
   P extends string,


### PR DESCRIPTION
- [x] Exported the `Hook` type from the file. I need this for `hono-openapi`
