### PR TITLE
ci: initial coverage

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,5 +1,7 @@
 name: initial-coverage
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: ['*']
 


### PR DESCRIPTION
Whoops.. Looks like I missed actually uploading coverage on `main` 🙈 sorry!

Once this is done, we should be able to remove `.github/workflows/ci-coverage.yml`