### PR TITLE
Move "default" entrypoint down in "typia-validator"

### DIFF
--- a/packages/typia-validator/package.json
+++ b/packages/typia-validator/package.json
@@ -8,16 +8,16 @@
   "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
-      "default": "./dist/cjs/index.js",
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
-      "types": "./dist/esm/index.d.ts"
+      "types": "./dist/esm/index.d.ts",
+      "default": "./dist/cjs/index.js"
     },
     "./http": {
-      "default": "./dist/cjs/http.js",
       "require": "./dist/cjs/http.js",
       "import": "./dist/esm/http.js",
-      "types": "./dist/esm/http.d.ts"
+      "types": "./dist/esm/http.d.ts",
+      "default": "./dist/cjs/http.js"
     }
   },
   "files": [


### PR DESCRIPTION
The "typia-validator" middleware just doesn't work in ESM builds. Has nobody used it before?

The entry point "default" should be the last option in the `package.json`:
https://nodejs.org/api/packages.html#conditional-exports
