### PR TITLE
chore: add tsup to monorepo root

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint": "^9.17.0",
     "npm-run-all2": "^6.2.2",
     "prettier": "^2.7.1",
+    "tsup": "^8.4.0",
     "typescript": "^5.2.2",
     "vitest": "^3.0.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11047,6 +11047,7 @@ __metadata:
     eslint: "npm:^9.17.0"
     npm-run-all2: "npm:^6.2.2"
     prettier: "npm:^2.7.1"
+    tsup: "npm:^8.4.0"
     typescript: "npm:^5.2.2"
     vitest: "npm:^3.0.8"
   languageName: unknown


### PR DESCRIPTION
This should fix `yarn build` failing due to `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'tsup'`

I'm a little concerned that `yarn workspaces foreach build` isn't using the version of `tsup` defined in the workspace 😕