### PR TITLE
fix(typebox-validator): export modules correctly

### DIFF
--- a/.changeset/tall-llamas-refuse.md
+++ b/.changeset/tall-llamas-refuse.md
@@ -1,0 +1,5 @@
+---
+'@hono/typebox-validator': patch
+---
+
+fix: export modules correctly


### PR DESCRIPTION
Fixes #1029

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
