### PR TITLE
fix(oauth-providers): Update twitter authorization url

### DIFF
--- a/.changeset/violet-melons-glow.md
+++ b/.changeset/violet-melons-glow.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': patch
+---
+
+fix: Update twitter authorization url

--- a/packages/oauth-providers/src/providers/x/authFlow.ts
+++ b/packages/oauth-providers/src/providers/x/authFlow.ts
@@ -74,7 +74,7 @@ export class AuthFlow {
       code_challenge: this.code_challenge,
       code_challenge_method: 'S256',
     })
-    return `https://twitter.com/i/oauth2/authorize?${parsedOptions}`
+    return `https://x.com/i/oauth2/authorize?${parsedOptions}`
   }
 
   private async getTokenFromCode() {


### PR DESCRIPTION
The twitter authorization URL didn't work for me. Patched it locally to `x.com/[...]` and it works for me. 