### PR TITLE
fix(zod-openapi): infer Env correctly if the middleware is `[]`

### DIFF
--- a/.changeset/dark-kiwis-check.md
+++ b/.changeset/dark-kiwis-check.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: infer Env correctly if the middleware is `[]`

--- a/packages/zod-openapi/src/index.test-d.ts
+++ b/packages/zod-openapi/src/index.test-d.ts
@@ -337,4 +337,25 @@ describe('Middleware', () => {
       }
     )
   })
+
+  it('Should infer Env correctly when the middleware is empty', async () => {
+    const app = new OpenAPIHono<{ Variables: { foo: string } }>()
+    app.openapi(
+      createRoute({
+        method: 'get',
+        path: '/books',
+        middleware: [] as const, // empty
+        responses: {
+          200: {
+            description: 'response',
+          },
+        },
+      }),
+      (c) => {
+        const foo = c.get('foo')
+        type verify = Expect<Equal<typeof foo, string>>
+        return c.json({})
+      }
+    )
+  })
 })

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -305,7 +305,7 @@ export type MiddlewareToHandlerType<M extends MiddlewareHandler<any, any, any>[]
     : never
   : M extends [infer Last]
   ? Last // Return the last remaining handler in the array
-  : never
+  : MiddlewareHandler<Env>
 
 type RouteMiddlewareParams<R extends RouteConfig> = OfHandlerType<
   MiddlewareToHandlerType<AsArray<R['middleware']>>

--- a/packages/zod-openapi/tsconfig.spec.json
+++ b/packages/zod-openapi/tsconfig.spec.json
@@ -2,9 +2,14 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/packages/zod-openapi",
-    "types": ["vitest/globals"]
+    "types": [
+      "vitest/globals"
+    ]
   },
-  "include": ["**/*.test.ts"],
+  "include": [
+    "**/*.test.ts",
+    "**/*.test-d.ts"
+  ],
   "references": [
     {
       "path": "./tsconfig.build.json"


### PR DESCRIPTION
Fixes the issue commented on https://github.com/honojs/middleware/issues/1102#issuecomment-2781766226

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
