### PR TITLE
fix(zod-openapi): republish without workspace reference

### DIFF
--- a/.changeset/full-words-design.md
+++ b/.changeset/full-words-design.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Republish v0.19.3 without workspace reference

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,12 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
-      - name: Build
-        run: yarn build
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: yarn changeset publish
+          publish: yarn run publish
+          version: yarn changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "yarn workspaces foreach --all --topological --verbose run build",
     "publint": "yarn workspaces foreach --all --topological --verbose run publint",
+    "publish": "yarn workspaces foreach --all --no-private --topological --verbose npm publish --tolerate-republish",
     "typecheck": "yarn tsc --build",
     "typecheck:clean": "yarn tsc --build --clean",
     "typecheck:watch": "yarn tsc --build --watch",


### PR DESCRIPTION
Due to changesets/changesets#674 the `workspace:` protocol isn't handled correctly.

Using [`yarn npm publish`](https://yarnpkg.com/cli/npm/publish) will update the workspace reference during publishing.

This van be verified by running pack in every workspace..

`yarn workspaces foreach --all --topological pack`

..or just from `@hono/zod-openapi`

`yarn workspaces foreach --from @hono/zod-openapi --recursive --topological --verbose pack`

Both commands will pack `@hono/zod-validator` before `@hono/zod-openapi`, and the workspace reference in the `package.tgz` will point to the current version of `@hono/zod-validator`

fixes #1109