### PR TITLE
[@hono/otel] Use `req.routePath` when tagging spans

### DIFF
--- a/.changeset/ripe-parents-sing.md
+++ b/.changeset/ripe-parents-sing.md
@@ -1,0 +1,5 @@
+---
+'@hono/otel': patch
+---
+
+Use `req.routePath` to augment spans with the path that handled the request.

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono/otel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry middleware for Hono",
   "type": "module",
   "module": "dist/index.js",

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono/otel",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "OpenTelemetry middleware for Hono",
   "type": "module",
   "module": "dist/index.js",

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -30,9 +30,9 @@ export const otel = <E extends Env = any, P extends string = any, I extends Inpu
       const result = await next()
       const span = trace.getActiveSpan()
       if (span != null) {
-        const route = c.req.matchedRoutes[c.req.matchedRoutes.length - 1]
-        span.setAttribute(ATTR_HTTP_ROUTE, route.path)
-        span.updateName(`${c.req.method} ${route.path}`)
+        const routePath = c.req.routePath
+        span.setAttribute(ATTR_HTTP_ROUTE, routePath)
+        span.updateName(`${c.req.method} ${routePath}`)
       }
       return result
     })
@@ -40,15 +40,15 @@ export const otel = <E extends Env = any, P extends string = any, I extends Inpu
   const tracerProvider = options.tracerProvider ?? trace.getTracerProvider()
   const tracer = tracerProvider.getTracer(PACKAGE_NAME, PACKAGE_VERSION)
   return createMiddleware<E, P, I>(async (c, next) => {
-    const route = c.req.matchedRoutes[c.req.matchedRoutes.length - 1]
+    const routePath = c.req.routePath
     await tracer.startActiveSpan(
-      `${c.req.method} ${route.path}`,
+      `${c.req.method} ${routePath}`,
       {
         kind: SpanKind.SERVER,
         attributes: {
           [ATTR_HTTP_REQUEST_METHOD]: c.req.method,
           [ATTR_URL_FULL]: c.req.url,
-          [ATTR_HTTP_ROUTE]: route.path,
+          [ATTR_HTTP_ROUTE]: routePath,
         },
       },
       async (span) => {


### PR DESCRIPTION
This PR updates `@hono/otel` to use `req.routePath` when tagging spans. The previous implementation used the last entry in `req.matchedRoutes` which worked for simple examples but would present incorrect data for complex routers.

Specifically, when a router had a catchall as the final route that catchall would be used as the route path.

Fixes: #1112 

### The author should do the following, if applicable

- [ ] ~~Add tests~~ not applicable
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)