### PR TITLE
chore(zod-openapi): lock zod-to-openapi to `^7.3.0` to fix `z.custom`

### DIFF
--- a/.changeset/proud-shrimps-try.md
+++ b/.changeset/proud-shrimps-try.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+chore: lock zod-to-openapi to `^7.3.0` to fix `z.custom`

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -52,7 +52,7 @@
     "zod": "^3.22.1"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^7.1.0",
+    "@asteasolutions/zod-to-openapi": "^7.3.0",
     "@hono/zod-validator": "workspace:^"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,7 +99,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asteasolutions/zod-to-openapi@npm:^7.1.0":
+"@asteasolutions/zod-to-openapi@npm:^7.3.0":
   version: 7.3.0
   resolution: "@asteasolutions/zod-to-openapi@npm:7.3.0"
   dependencies:
@@ -2363,7 +2363,7 @@ __metadata:
   resolution: "@hono/zod-openapi@workspace:packages/zod-openapi"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
-    "@asteasolutions/zod-to-openapi": "npm:^7.1.0"
+    "@asteasolutions/zod-to-openapi": "npm:^7.3.0"
     "@hono/zod-validator": "workspace:^"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"


### PR DESCRIPTION
Ran into some issues related to https://github.com/asteasolutions/zod-to-openapi/pull/281 in our codebase, where we implemented format string schemas using `z.custom`. In Zod 4 we will migrate to the new format literals, but in the meanwhile opening this PR to bump the dependency minor version to include this bug fix.

Please let me know if I should add a test!

- [ ] Add tests (?)
- [x] ~~Run tests~~
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
