### PR TITLE
feat(zod-validator): Optional passthrough param

### DIFF
--- a/.changeset/hot-symbols-thank.md
+++ b/.changeset/hot-symbols-thank.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': minor
+---
+
+Added optional opt field for passthrough and might further editions, passthrough and tests to it

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -65,7 +65,7 @@ export const zValidator = <
     }
 
     let result: z.infer<T>;
-    if (opt && "passthrough" in opt) {
+    if (opt && "passthroughObject" in opt) {
       result = await schema.passthrough().safeParseAsync(validatorValue)
     } else {
       result = await schema.safeParseAsync(validatorValue)


### PR DESCRIPTION
I think it's great to have optional parameter for objects that gives ability to freely go different objects through parser. It's flexible and handy.

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
