### PR TITLE
fix(zod-openapi): Run validators before route middleware

### DIFF
--- a/.changeset/some-friends-tie.md
+++ b/.changeset/some-friends-tie.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Run validators before route middleware.

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -550,8 +550,8 @@ export class OpenAPIHono<
     this.on(
       [route.method],
       route.path.replaceAll(/\/{(.+?)}/g, '/:$1'),
-      ...middleware,
       ...validators,
+      ...middleware,
       handler
     )
     return this


### PR DESCRIPTION
We're using `zod-openapi` and found that route middleware runs before the validators. As a result, we don't have access to validated input (like `c.req.valid('param')`) inside route middleware, which was somewhat surprising to us.

I can imagine special use cases where one might want route middleware to run first (e.g. when dynamically adding parameters) but i would imagine that to be less common. If we really want we could make this configurable.