### PR TITLE
[arktype-validator] Don't return restricted fields in error responses

### DIFF
--- a/.changeset/silent-worms-mate.md
+++ b/.changeset/silent-worms-mate.md
@@ -1,0 +1,5 @@
+---
+'@hono/arktype-validator': patch
+---
+
+Don't return restricted data fields on error responses

--- a/packages/arktype-validator/src/index.test.ts
+++ b/packages/arktype-validator/src/index.test.ts
@@ -123,7 +123,6 @@ describe('Basic', () => {
     expect(res.status).toBe(400)
     const data = (await res.json()) as { succcess: false; errors: type.errors }
     expect(data.errors).toHaveLength(1)
-    console.log(data.errors)
     expect(data.errors[0].data).not.toHaveProperty('cookie')
   })
 })

--- a/packages/arktype-validator/src/index.ts
+++ b/packages/arktype-validator/src/index.ts
@@ -23,7 +23,7 @@ export const arktypeValidator = <
   } = {
     in: HasUndefined<I> extends true ? { [K in Target]?: I } : { [K in Target]: I }
     out: { [K in Target]: O }
-  }
+  },
 >(
   target: Target,
   schema: T,


### PR DESCRIPTION
## Summary

Now `arktype-validator` doesn't return certain fields (for now, only `Cookie` in `header` validation) in its error repsponses (`data` field).

Fixes #1135 

### Details

In the [`ArkError class`](https://github.com/arktypeio/arktype/blob/049bc4dcede23a620cd0fc43176ce7b5aaaf2f48/ark/schema/shared/errors.ts#L134), when converting the error to JSON, the `data` property always includes the full input passed to the schema. 

I've implemented a simple check for the validation target and restricted fields that manually `delete`s the fields from the `data` property.

In future the list of restricted fields can be expanded.

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
