### PR TITLE
feat(otel): Added support for W3C Trace Context format

### DIFF
--- a/.changeset/salty-bags-shop.md
+++ b/.changeset/salty-bags-shop.md
@@ -1,0 +1,5 @@
+---
+'@hono/otel': minor
+---
+
+Added support for W3C Trace Context format

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -8,7 +8,7 @@ import {
   ATTR_URL_FULL,
   ATTR_HTTP_ROUTE,
 } from '@opentelemetry/semantic-conventions'
-import type { Env, HonoRequest, Input } from 'hono'
+import type { Env, Input } from 'hono'
 import { createMiddleware } from 'hono/factory'
 import metadata from '../package.json' with { type: 'json' }
 


### PR DESCRIPTION
One of Open Telemetry's main feature is the ability to trace across micro services, this updates the `@hono/otel` package to check if `traceparent` is set and if so then set the context for the span to match accordingly.