### PR TITLE
fix(release): publish tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "yarn workspaces foreach --all --topological --verbose run build",
     "publint": "yarn workspaces foreach --all --topological --verbose run publint",
-    "publish": "yarn workspaces foreach --all --no-private --topological --verbose npm publish --tolerate-republish",
+    "publish": "yarn workspaces foreach --all --no-private --topological --verbose npm publish --tolerate-republish && changeset tag",
     "typecheck": "yarn tsc --build",
     "typecheck:clean": "yarn tsc --build --clean",
     "typecheck:watch": "yarn tsc --build --watch",


### PR DESCRIPTION
Calling `changeset tag` after publishing packages _should_ trigger `changesets/actions` to add releases to GitHub

> It looks like `changesets/actions` uses the output of the publish command (`changesetPublishOutput`)
> 
> https://github.com/changesets/action/blob/ff7179cf129faeb3e444f56e6290adef5901f936/src/run.ts#L127-L131
> 
> to look for packages that were published, and pushes any matches to `releasedPackages`
> 
> https://github.com/changesets/action/blob/ff7179cf129faeb3e444f56e6290adef5901f936/src/run.ts#L142-L156
> 
> The output from `yarn npm publish` is a different format, so no release get added to GitHub 

 _Originally posted by @BarryThePenguin in [#1124](https://github.com/honojs/middleware/issues/1124#issuecomment-2796549220)_

The output of `changeset tag` is in the correct format to populate `releasedPackages`

```sh
❯ changeset tag
🦋  New tag:  @hono/arktype-validator@2.0.1
🦋  New tag:  @hono/bun-compress@0.1.0
🦋  New tag:  @hono/graphql-server@0.6.0
🦋  New tag:  @hono/node-ws@1.1.4
🦋  New tag:  @hono/otel@0.2.0
🦋  New tag:  @hono/react-renderer@1.0.1
🦋  New tag:  @hono/zod-openapi@0.19.6
🦋  New tag:  @hono/zod-validator@0.5.0
```

Note that the `changeset tag` command isn't documented
https://github.com/changesets/changesets/blob/main/packages/cli/src/commands/tag/index.ts

Fixes #1160