### PR TITLE
feature(eslint-config): add types

### DIFF
--- a/.changeset/hot-singers-smell.md
+++ b/.changeset/hot-singers-smell.md
@@ -1,0 +1,5 @@
+---
+'@hono/eslint-config': patch
+---
+
+Add type declaration

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -4,6 +4,9 @@ import importX from 'eslint-plugin-import-x'
 import nodePlugin from 'eslint-plugin-n'
 import tseslint from 'typescript-eslint'
 
+/**
+ * @type {import("eslint").Linter.Config[]}
+ */
 export default [
   js.configs.recommended,
   nodePlugin.configs['flat/recommended'],


### PR DESCRIPTION
Adds a `@type` declaration for the default export of `@hono/eslint-config `

fixes #1157
