### PR TITLE
lint: array-type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dist
 node_modules
 *.tgz
 coverage
-
+.eslintcache
 .yarn/*
 !.yarn/cache
 !.yarn/patches

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,6 @@ export default defineConfig(globalIgnores(['.yarn', '**/coverage', '**/dist']), 
   },
 
   rules: {
-    '@typescript-eslint/array-type': 'off',
     '@typescript-eslint/await-thenable': 'off',
     '@typescript-eslint/consistent-indexed-object-style': 'off',
     '@typescript-eslint/consistent-type-definitions': 'off',

--- a/packages/event-emitter/src/index.ts
+++ b/packages/event-emitter/src/index.ts
@@ -145,7 +145,7 @@ export const createEmitter = <EPMap extends EventPayloadMap>(
       if (!handlers.has(key as EventKey)) {
         handlers.set(key as EventKey, [])
       }
-      const handlerArray = handlers.get(key as EventKey) as Array<EventHandler<EPMap[Key]>>
+      const handlerArray = handlers.get(key as EventKey) as EventHandler<EPMap[Key]>[]
       const limit = options?.maxHandlers ?? 10
       if (handlerArray.length >= limit) {
         throw new RangeError(

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -32,7 +32,7 @@ type Options<E extends Env = any, P extends string = any, I extends Input = {}> 
   schema: GraphQLSchema
   rootResolver?: RootResolver<E, P, I>
   pretty?: boolean
-  validationRules?: ReadonlyArray<ValidationRule>
+  validationRules?: readonly ValidationRule[]
   graphiql?: boolean
 }
 

--- a/packages/standard-validator/src/index.test.ts
+++ b/packages/standard-validator/src/index.test.ts
@@ -184,7 +184,7 @@ describe('Standard Schema Validation', () => {
           sValidator('json', schema, (result, c) => {
             if (!result.success) {
               type verify = Expect<
-                Equal<ReadonlyArray<StandardSchemaV1.Issue>, typeof result.error>
+                Equal<readonly StandardSchemaV1.Issue[], typeof result.error>
               >
               return c.text(`${result.data.id} is invalid!`, 400)
             }

--- a/packages/standard-validator/src/index.test.ts
+++ b/packages/standard-validator/src/index.test.ts
@@ -183,9 +183,7 @@ describe('Standard Schema Validation', () => {
           '/post',
           sValidator('json', schema, (result, c) => {
             if (!result.success) {
-              type verify = Expect<
-                Equal<readonly StandardSchemaV1.Issue[], typeof result.error>
-              >
+              type verify = Expect<Equal<readonly StandardSchemaV1.Issue[], typeof result.error>>
               return c.text(`${result.data.id} is invalid!`, 400)
             }
           }),

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -14,7 +14,7 @@ type Hook<
 > = (
   result: (
     | { success: true; data: T }
-    | { success: false; error: ReadonlyArray<StandardSchemaV1.Issue>; data: T }
+    | { success: false; error: readonly StandardSchemaV1.Issue[]; data: T }
   ) & {
     target: Target
   },

--- a/packages/typebox-validator/src/index.test.ts
+++ b/packages/typebox-validator/src/index.test.ts
@@ -313,7 +313,7 @@ describe('Remove non schema items', () => {
     })
 
     const res = await app.request(req)
-    const { message, success } = (await res.json()) as { success: boolean; message: Array<any> }
+    const { message, success } = (await res.json()) as { success: boolean; message: any[] }
     expect(res.status).toBe(200)
     expect(success).toBe(true)
     expect(message).toEqual([


### PR DESCRIPTION
While I had some time I thought I'd review some lint rules from #1098

This enables PR [`@typescript-eslint/array-type`](https://typescript-eslint.io/rules/array-type/), a stylistic rule that prefers
- `T[] or readonly T[]` ✅ 
- `Array<T>, ReadonlyArray<T>` ❌

There are also options to prefer [`"generic"`](https://typescript-eslint.io/rules/array-type/#generic) or [`"array-simple"`](https://typescript-eslint.io/rules/array-type/#array-simple)

Another option is to disable this rule entirely in `@hono/eslint-config`