### PR TITLE
feat(otel): record uncaught expections

### DIFF
--- a/.changeset/rude-squids-shout.md
+++ b/.changeset/rude-squids-shout.md
@@ -1,0 +1,5 @@
+---
+'@hono/otel': patch
+---
+
+Record uncaught exceptions as events attached to the request span

--- a/packages/otel/src/index.test.ts
+++ b/packages/otel/src/index.test.ts
@@ -7,6 +7,9 @@ import {
   ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_URL_FULL,
   ATTR_HTTP_ROUTE,
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_TYPE,
+  ATTR_EXCEPTION_STACKTRACE,
 } from '@opentelemetry/semantic-conventions'
 import { Hono } from 'hono'
 import { otel } from '.'
@@ -65,6 +68,15 @@ describe('OpenTelemetry middleware', () => {
     expect(span.attributes[ATTR_HTTP_REQUEST_METHOD]).toBe('POST')
     expect(span.attributes[ATTR_URL_FULL]).toBe('http://localhost/error')
     expect(span.attributes[ATTR_HTTP_ROUTE]).toBe('/error')
+    expect(span.events.length).toBe(1)
+    const [event] = span.events
+    expect(event.attributes).toBeDefined()
+    const attributes = event.attributes!
+    expect(attributes[ATTR_EXCEPTION_TYPE]).toBe('Error')
+    expect(attributes[ATTR_EXCEPTION_MESSAGE]).toBe('error message')
+    expect(attributes[ATTR_EXCEPTION_STACKTRACE]).toEqual(
+      expect.stringMatching(/Error: error message\n.*at \S+\/src\/index.test.ts:\d+:\d+\n/)
+    )
   })
 
   it('Should update the active span', async () => {

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -75,9 +75,13 @@ export const otel = <E extends Env = any, P extends string = any, I extends Inpu
             span.setAttribute(ATTR_HTTP_RESPONSE_HEADER(name), value)
           }
           if (c.error) {
+            span.recordException(c.error)
             span.setStatus({ code: SpanStatusCode.ERROR, message: String(c.error) })
           }
         } catch (e) {
+          if (e instanceof Error) {
+            span.recordException(e)
+          }
           span.setStatus({ code: SpanStatusCode.ERROR, message: String(e) })
           throw e
         } finally {


### PR DESCRIPTION
## Description

This implements the [Otel spec for expections](https://opentelemetry.io/docs/specs/otel/trace/exceptions/), recording them as events on the span. The main goal is to be able to see the stacktrace of a span with an error. The status of the spec seems to be `Development`, so I'm not sure what's the stance for this middleware, but for instance this is how the express Otel integration handles exceptions as well.

I've set the change to be a patch one but I'm not sure about that.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
