### PR TITLE
refactor(bun-transpiler): enable isolated declarations

### DIFF
--- a/.changeset/easy-wombats-help.md
+++ b/.changeset/easy-wombats-help.md
@@ -1,0 +1,5 @@
+---
+'@hono/bun-transpiler': patch
+---
+
+Add explicit `MiddlewareHandler` return type

--- a/packages/bun-transpiler/src/index.ts
+++ b/packages/bun-transpiler/src/index.ts
@@ -1,4 +1,5 @@
 import Bun from 'bun'
+import type { MiddlewareHandler } from 'hono'
 import { createMiddleware } from 'hono/factory'
 
 type BunTranspilerOptions = {
@@ -16,7 +17,7 @@ export const defaultOptions: Required<BunTranspilerOptions> = {
   },
 }
 
-export const bunTranspiler = (options?: BunTranspilerOptions) => {
+export const bunTranspiler = (options?: BunTranspilerOptions): MiddlewareHandler => {
   return createMiddleware(async (c, next) => {
     await next()
     const url = new URL(c.req.url)

--- a/packages/bun-transpiler/tsconfig.build.json
+++ b/packages/bun-transpiler/tsconfig.build.json
@@ -4,7 +4,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.build.tsbuildinfo",
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "isolatedDeclarations": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.test.ts"],


### PR DESCRIPTION
As part of #740, I'm enabling [`isolatedDeclarations`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations) to solve [JSR "slow types"](https://jsr.io/docs/about-slow-types)