### PR TITLE
feat(node-ws): Add WebSocketServer instance return to createNodeWebSocket

### DIFF
--- a/.changeset/stale-insects-own.md
+++ b/.changeset/stale-insects-own.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': minor
+---
+
+Return the WebSocketServer instance used for createNodeWebSocket

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -297,7 +297,10 @@ describe('WebSocket helper', () => {
       })
     )
 
-    app.get('/', upgradeWebSocket(() => ({})))
+    app.get(
+      '/',
+      upgradeWebSocket(() => ({}))
+    )
     new WebSocket('ws://localhost:3030/')
 
     await mainPromise

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -13,10 +13,11 @@ describe('WebSocket helper', () => {
   let server: ServerType
   let injectWebSocket: ReturnType<typeof createNodeWebSocket>['injectWebSocket']
   let upgradeWebSocket: ReturnType<typeof createNodeWebSocket>['upgradeWebSocket']
+  let wss: ReturnType<typeof createNodeWebSocket>['wss']
 
   beforeEach(async () => {
     app = new Hono()
-    ;({ injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app }))
+    ;({ injectWebSocket, upgradeWebSocket, wss } = createNodeWebSocket({ app }))
 
     server = await new Promise<ServerType>((resolve) => {
       const server = serve({ fetch: app.fetch, port: 3030 }, () => resolve(server))
@@ -285,5 +286,23 @@ describe('WebSocket helper', () => {
     }
 
     expect(await mainPromise).toBe(true)
+  })
+
+  it('Should return the wss used for the websocket helper', async () => {
+    let clientWs: WebSocket | null = null
+    const mainPromise = new Promise<void>((resolve) =>
+      wss.on('connection', (ws) => {
+        clientWs = ws
+        resolve()
+      })
+    )
+
+    app.get('/', upgradeWebSocket(() => ({})))
+    new WebSocket('ws://localhost:3030/')
+
+    await mainPromise
+
+    expect(clientWs).toBeTruthy()
+    expect(wss.clients.size).toBe(1)
   })
 })

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -17,6 +17,7 @@ export interface NodeWebSocket {
     }
   >
   injectWebSocket(server: Server | Http2Server | Http2SecureServer): void
+  wss: WebSocketServer
 }
 export interface NodeWebSocketInit {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -56,6 +57,7 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
   }
 
   return {
+    wss,
     injectWebSocket(server) {
       server.on('upgrade', async (request, socket: Duplex, head) => {
         const url = new URL(request.url ?? '/', init.baseUrl ?? 'http://localhost')


### PR DESCRIPTION
This change introduces the return of the WebSocketServer instance from the createNodeWebSocket function, enhancing its usability by allowing consumers access to the WebSocketServer instance for additional operations.

e.g. now users can do the following:
```
import { createNodeWebSocket } from '@hono/node-ws'
import { Hono } from 'hono'
import { serve } from '@hono/node-server'

const app = new Hono()

const { injectWebSocket, upgradeWebSocket, wss } = createNodeWebSocket({ app })

app.get(
  '/ws',
  upgradeWebSocket((c) => ({
    // https://hono.dev/helpers/websocket
  }))
)

const server = serve(app)
injectWebSocket(server)

wss.on('connection', (ws) => {
  console.log('A new client connected!');
  // Implement pingpong or something.
});
```

- Updated tests to verify the returned WebSocketServer instance
- Added wss property to NodeWebSocket interface for type safety

I'm not sure if this repo uses semver: I called this a minor change but it could be a patch. Let me know and I can change it.

### The author should do the following, if applicable

- [ ✅ ] Add tests
- [ ✅ ] Run tests
- [ ✅ ] `yarn changeset` at the top of this repo and push the changeset
- [ ✅ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
