### PR TITLE
refactor(zod-openai): enable isolated declarations

### DIFF
--- a/.changeset/petite-masks-melt.md
+++ b/.changeset/petite-masks-melt.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Add explicit return types

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -53,7 +53,8 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.0",
-    "@hono/zod-validator": "workspace:^"
+    "@hono/zod-validator": "workspace:^",
+    "openapi3-ts": "^4.5.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -36,6 +36,8 @@ import type {
 } from 'hono/utils/http-status'
 import type { JSONParsed, JSONValue, RemoveBlankRecord, SimplifyDeepArray } from 'hono/utils/types'
 import { mergePath } from 'hono/utils/url'
+import type { OpenAPIObject } from 'openapi3-ts/oas30'
+import type { OpenAPIObject as OpenAPIV31bject } from 'openapi3-ts/oas31'
 import type { ZodError, ZodSchema } from 'zod'
 import { ZodType, z } from 'zod'
 
@@ -555,18 +557,14 @@ export class OpenAPIHono<
     return this
   }
 
-  getOpenAPIDocument = (
-    config: OpenAPIObjectConfig
-  ): ReturnType<typeof generator.generateDocument> => {
+  getOpenAPIDocument = (config: OpenAPIObjectConfig): OpenAPIObject => {
     const generator = new OpenApiGeneratorV3(this.openAPIRegistry.definitions)
     const document = generator.generateDocument(config)
     // @ts-expect-error the _basePath is a private property
     return this._basePath ? addBasePathToDocument(document, this._basePath) : document
   }
 
-  getOpenAPI31Document = (
-    config: OpenAPIObjectConfig
-  ): ReturnType<typeof generator.generateDocument> => {
+  getOpenAPI31Document = (config: OpenAPIObjectConfig): OpenAPIV31bject => {
     const generator = new OpenApiGeneratorV31(this.openAPIRegistry.definitions)
     const document = generator.generateDocument(config)
     // @ts-expect-error the _basePath is a private property
@@ -690,7 +688,9 @@ type RoutingPath<P extends string> = P extends `${infer Head}/{${infer Param}}${
 
 export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'> & { path: P }>(
   routeConfig: R
-) => {
+): R & {
+  getRoutingPath(): RoutingPath<R['path']>
+} => {
   const route = {
     ...routeConfig,
     getRoutingPath(): RoutingPath<R['path']> {

--- a/packages/zod-openapi/tsconfig.build.json
+++ b/packages/zod-openapi/tsconfig.build.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.build.json",
-  "compilerOptions": {
-    "isolatedDeclarations": false
-  },
+  "compilerOptions": {},
   "references": [{ "path": "../zod-validator/tsconfig.build.json" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,6 +2697,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@asteasolutions/zod-to-openapi": "npm:^7.3.0"
     "@hono/zod-validator": "workspace:^"
+    openapi3-ts: "npm:^4.5.0"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -12039,6 +12040,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"openapi3-ts@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "openapi3-ts@npm:4.5.0"
+  dependencies:
+    yaml: "npm:^2.8.0"
+  checksum: 10c0/97de2d24e9ceffb89e1388e137e4a6e17ee57a02dce0c938a5e98b1338ac72b31e8b2ce8dd28945ad43fae8bee2a145892cb548ba5ae60b0930f1b6b79b0747d
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
@@ -16601,6 +16611,15 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/b4a9dea34265f000402c909144ac310be42c4526dfd16dff1aee2b04a0d94051713651c0cd2b0a3d8109266997422120f16a7934629d12f22dc215839ebbeccf
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "yaml@npm:2.8.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/f6f7310cf7264a8107e72c1376f4de37389945d2fb4656f8060eca83f01d2d703f9d1b925dd8f39852a57034fafefde6225409ddd9f22aebfda16c6141b71858
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is the last package to enable `isolatedDeclarations`

There is one issue where two methods use `ReturnType<typeof generator.generateDocument>`, which is too dynamic for JSR

https://github.com/honojs/middleware/blob/a7ee664c98b3a3089ac2f8c0df8c2b6f5470c64a/packages/zod-openapi/src/index.ts#L558-L574

Two solutions I can think of
1. Add `openapi3-ts` as a dependency and import the types directly
2. Update `@asteasolutions/zod-to-openapi` so it re-exports the necessary types from `openapi3-ts`