### PR TITLE
chore(ua-blocker): add changeset and format in `robots.json` sync PR

### DIFF
--- a/.github/workflows/ci-ua-blocker-sync.yml
+++ b/.github/workflows/ci-ua-blocker-sync.yml
@@ -3,12 +3,15 @@ name: Sync robots.json
 on:
   schedule:
     # Runs every day at midnight
-    - cron: '0 0 * * *'
+    - cron: '15 0 */3 * *'
   workflow_dispatch:
 
 jobs:
   sync-and-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,11 +30,20 @@ jobs:
       - name: Generate data
         run: yarn workspace @hono/ua-blocker prebuild
 
-      - name: Generate changeset
+      - name: Check for changes
+        id: changes
         run: |
-          # Generate a unique changeset filename
-          CHANGESET_ID=$(date +%s | sha256sum | head -c 8)
-          CHANGESET_FILE=".changeset/${CHANGESET_ID}-sync-robots.md"
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate changeset
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          # Use a static changeset filename to avoid duplicates
+          CHANGESET_FILE=".changeset/auto-sync-robots.md"
 
           # Create the changeset file
           cat << EOF > "$CHANGESET_FILE"
@@ -46,6 +58,7 @@ jobs:
         run: yarn prettier --write . !packages packages/ua-blocker
 
       - name: Create Pull Request if changes exist
+        if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds format and Changeset to `robots.json` sync PR

As mentioned in #1229 


The workflow directly creates the changeset file instead of trying to automate the CLI