### PR TITLE
chore(cr): publish all from main

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -11,8 +11,30 @@ concurrency:
   cancel-in-progress: true # Cancel in progress builds for the same PR
 
 jobs:
-  publish:
-    if: github.repository == 'honojs/middleware' && (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'cr-tracked'))
+  publish-all:
+    if: github.repository == 'honojs/middleware' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    name: 'Publish: pkg.pr.new'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn workspaces foreach --all --topological --parallel --no-private run build
+
+      - name: Publish to StackBlitz
+        run: yarn pkg-pr-new publish --compact --no-template './packages/*'
+
+  publish-changed:
+    if: github.repository == 'honojs/middleware' && contains(github.event.pull_request.labels.*.name, 'cr-tracked')
     runs-on: ubuntu-latest
     name: 'Publish: pkg.pr.new'
     steps:

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true # Cancel in progress builds for the same PR
 
 jobs:
-  publish-all:
-    if: github.repository == 'honojs/middleware' && github.ref == 'refs/heads/main'
+  publish:
+    if: github.repository == 'honojs/middleware' && (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'cr-tracked'))
     runs-on: ubuntu-latest
     name: 'Publish: pkg.pr.new'
     steps:
@@ -32,27 +32,3 @@ jobs:
 
       - name: Publish to StackBlitz
         run: yarn pkg-pr-new publish --compact --no-template './packages/*'
-
-  publish-changed:
-    if: github.repository == 'honojs/middleware' && contains(github.event.pull_request.labels.*.name, 'cr-tracked')
-    runs-on: ubuntu-latest
-    name: 'Publish: pkg.pr.new'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-
-      - name: Install Dependencies
-        run: yarn
-
-      - name: Build
-        run: yarn workspaces foreach --topological --parallel --since --no-private run build
-
-      - name: Publish to StackBlitz
-        run: |
-          changed=$(yarn workspaces list --json --since --no-private | jq -sr '[.[].location] | @sh')
-          yarn pkg-pr-new publish --compact --no-template ${changed}


### PR DESCRIPTION
Publish all packages from `main`

This feels a bit wasteful as it will end up publishing a lot of packages where nothing has changed. But I guess that is the point of `pkg.pr.new`, to make it easy to install any commit as a package