### PR TITLE
feat(session): enable accessing sid via `c.var.session.id`

### DIFF
--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -104,6 +104,9 @@ export const useSession = <Data extends SessionData>(
       get data() {
         return session.data
       },
+      get id() {
+        return session.id
+      },
       delete() {
         session.delete()
       },

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -27,6 +27,11 @@ export interface Session<Data> {
   readonly data: Data | null
 
   /**
+   * Current session ID.
+   */
+  readonly id: string | null
+
+  /**
    * Delete the current session, removing the session cookie and data from storage.
    */
   delete: () => void
@@ -121,6 +126,17 @@ export function getSession<Data extends SessionData>({
       }
 
       return session.data ?? null
+    },
+    get id() {
+      if (!session) {
+        throw new Error('Session not initialised. Call get() or update() first.')
+      }
+
+      if (session.action === 'destroy') {
+        throw new Error('Session has been destroyed.')
+      }
+
+      return session.payload?.sid ?? null
     },
     delete() {
       if (session) {


### PR DESCRIPTION
With this PR, you can get the current session id via `c.var.session.id`. I am also thinking the name is `c.var.session.sid` but simply `c.var.session.id`.

The original idea is by @craigsdennis

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
