### PR TITLE
chore: expand hono peer dependency

### DIFF
--- a/.changeset/happy-groups-decide.md
+++ b/.changeset/happy-groups-decide.md
@@ -1,0 +1,29 @@
+---
+'@hono/arktype-validator': patch
+'@hono/cloudflare-access': patch
+'@hono/oauth-providers': patch
+'@hono/bun-transpiler': patch
+'@hono/react-renderer': patch
+'@hono/swagger-editor': patch
+'@hono/event-emitter': patch
+'@hono/firebase-auth': patch
+'@hono/bun-compress': patch
+'@hono/react-compat': patch
+'@hono/stytch-auth': patch
+'@hono/trpc-server': patch
+'@hono/zod-openapi': patch
+'@hono/clerk-auth': patch
+'@hono/prometheus': patch
+'@hono/swagger-ui': patch
+'@hono/ua-blocker': patch
+'@hono/oidc-auth': patch
+'@hono/tsyringe': patch
+'@hono/auth-js': patch
+'@hono/session': patch
+'@hono/sentry': patch
+'@hono/hello': patch
+'@hono/otel': patch
+'@hono/mcp': patch
+---
+
+Expand `hono` peer dependency

--- a/packages/arktype-validator/package.json
+++ b/packages/arktype-validator/package.json
@@ -41,12 +41,12 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "arktype": "^2.0.0-dev.14",
-    "hono": "*"
+    "arktype": ">=2.0.0-dev",
+    "hono": ">=3.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
-    "arktype": "^2.0.0-dev.14",
+    "arktype": "^2.0.0",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/auth-js/package.json
+++ b/packages/auth-js/package.json
@@ -56,8 +56,8 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "@auth/core": "0.*",
-    "hono": ">=3.*",
+    "@auth/core": ">=0.35.0",
+    "hono": ">=3.0.0",
     "react": "^18 || ^19 || ^19.0.0-rc"
   },
   "devDependencies": {

--- a/packages/bun-compress/package.json
+++ b/packages/bun-compress/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/bun-transpiler/package.json
+++ b/packages/bun-transpiler/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/clerk-auth/package.json
+++ b/packages/clerk-auth/package.json
@@ -45,7 +45,7 @@
     "@clerk/types": "^4.61.0"
   },
   "peerDependencies": {
-    "hono": ">=3.*"
+    "hono": ">=3.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/cloudflare-access/package.json
+++ b/packages/cloudflare-access/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/event-emitter/package.json
+++ b/packages/event-emitter/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/honojs/middleware",
   "author": "David Havl <contact@davidhavl.com> (https://github.com/DavidHavl)",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/firebase-auth/package.json
+++ b/packages/firebase-auth/package.json
@@ -46,7 +46,7 @@
     "firebase-auth-cloudflare-workers": "^2.0.6"
   },
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/hello/package.json
+++ b/packages/hello/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/oauth-providers/package.json
+++ b/packages/oauth-providers/package.json
@@ -78,7 +78,7 @@
     }
   },
   "peerDependencies": {
-    "hono": ">=3.*"
+    "hono": ">=3.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/oidc-auth/package.json
+++ b/packages/oidc-auth/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": ">=3.*"
+    "hono": ">=3.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/prometheus/package.json
+++ b/packages/prometheus/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": ">=3.*",
+    "hono": ">=3.0.0",
     "prom-client": "^15.0.0"
   },
   "devDependencies": {

--- a/packages/react-compat/package.json
+++ b/packages/react-compat/package.json
@@ -35,7 +35,7 @@
     }
   },
   "peerDependencies": {
-    "hono": ">=4.5.*"
+    "hono": ">=4.5.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/react-renderer/package.json
+++ b/packages/react-renderer/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*",
+    "hono": ">=4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -41,7 +41,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "hono": ">=3.*"
+    "hono": ">=3.0.0"
   },
   "dependencies": {
     "toucan-js": "^4.0.0"

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -59,7 +59,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "dependencies": {
     "jose": "^6.0.11"

--- a/packages/stytch-auth/package.json
+++ b/packages/stytch-auth/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": ">=3.*",
+    "hono": ">=3.0.0",
     "stytch": "^12.19.0"
   },
   "devDependencies": {

--- a/packages/swagger-editor/package.json
+++ b/packages/swagger-editor/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/swagger-ui/package.json
+++ b/packages/swagger-ui/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/trpc-server/package.json
+++ b/packages/trpc-server/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://honojs.dev",
   "peerDependencies": {
     "@trpc/server": "^10.10.0 || >11.0.0-rc",
-    "hono": ">=4.*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/tsyringe/package.json
+++ b/packages/tsyringe/package.json
@@ -40,8 +40,8 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": ">=4.*",
-    "tsyringe": ">=4.*"
+    "hono": ">=4.0.0",
+    "tsyringe": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/ua-blocker/package.json
+++ b/packages/ua-blocker/package.json
@@ -51,7 +51,7 @@
   },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
-    "hono": "*"
+    "hono": ">=4.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=4.3.6",
-    "zod": "3.*"
+    "zod": ">=3.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,12 +76,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ark/schema@npm:0.45.2":
-  version: 0.45.2
-  resolution: "@ark/schema@npm:0.45.2"
+"@ark/schema@npm:0.46.0":
+  version: 0.46.0
+  resolution: "@ark/schema@npm:0.46.0"
   dependencies:
-    "@ark/util": "npm:0.45.2"
-  checksum: 10c0/e2dbac994f9fc9e10ee85fda8dd78bbcac044a8b874ed7fa8664b572d7b33d0aae7bf66071fa5b6222a9da295c84ac4cecf1552992b57bf38da444fc315d6d85
+    "@ark/util": "npm:0.46.0"
+  checksum: 10c0/5f9b0256689daa8c39868328ee57c4d091917376cba0b4b0607982d0dcd4f8b9dd840caf5877bf766af8ecc81756f780718077860f0e030c024fc75972e4d041
   languageName: node
   linkType: hard
 
@@ -92,10 +92,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ark/util@npm:0.45.2":
-  version: 0.45.2
-  resolution: "@ark/util@npm:0.45.2"
-  checksum: 10c0/9785dc9e4e467797256d14510655881f78762e07ed9be5738679b4e2090b7defcbbaab20fc70d3cc7b0f6ef26056fafc6d02f4666542c23dd003d2a5b87bb891
+"@ark/util@npm:0.46.0":
+  version: 0.46.0
+  resolution: "@ark/util@npm:0.46.0"
+  checksum: 10c0/18fb146510856191ba1924f8ee50aa650b2f8795de7df85301cdd068b4bb9bd6f1548d6f3a8f99e75c3d9036d4c4b6ca245c964ceb4d3fa431ea53653faa2aa8
   languageName: node
   linkType: hard
 
@@ -2066,14 +2066,14 @@ __metadata:
   resolution: "@hono/arktype-validator@workspace:packages/arktype-validator"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
-    arktype: "npm:^2.0.0-dev.14"
+    arktype: "npm:^2.0.0"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    arktype: ^2.0.0-dev.14
-    hono: "*"
+    arktype: ">=2.0.0-dev"
+    hono: ">=3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2090,8 +2090,8 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    "@auth/core": 0.*
-    hono: ">=3.*"
+    "@auth/core": ">=0.35.0"
+    hono: ">=3.0.0"
     react: ^18 || ^19 || ^19.0.0-rc
   languageName: unknown
   linkType: soft
@@ -2108,7 +2108,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2122,7 +2122,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2173,7 +2173,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: ">=3.*"
+    hono: ">=3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2187,7 +2187,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2271,7 +2271,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2288,7 +2288,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2317,7 +2317,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2334,7 +2334,7 @@ __metadata:
     zod: "npm:^3.25.34"
   peerDependencies:
     "@modelcontextprotocol/sdk": ^1.12.0
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2390,7 +2390,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: ">=3.*"
+    hono: ">=3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2407,7 +2407,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: ">=3.*"
+    hono: ">=3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2425,7 +2425,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2440,7 +2440,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: ">=3.*"
+    hono: ">=3.0.0"
     prom-client: ^15.0.0
   languageName: unknown
   linkType: soft
@@ -2471,7 +2471,7 @@ __metadata:
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
   peerDependencies:
-    hono: ">=4.5.*"
+    hono: ">=4.5.0"
   languageName: unknown
   linkType: soft
 
@@ -2490,7 +2490,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
     react: ^19.0.0
     react-dom: ^19.0.0
   languageName: unknown
@@ -2507,7 +2507,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: ">=3.*"
+    hono: ">=3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2524,7 +2524,7 @@ __metadata:
     unstorage: "npm:^1.16.0"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2558,7 +2558,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: ">=3.*"
+    hono: ">=3.0.0"
     stytch: ^12.19.0
   languageName: unknown
   linkType: soft
@@ -2573,7 +2573,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2588,7 +2588,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2605,7 +2605,7 @@ __metadata:
     zod: "npm:^3.20.2"
   peerDependencies:
     "@trpc/server": ^10.10.0 || >11.0.0-rc
-    hono: ">=4.*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2621,8 +2621,8 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: ">=4.*"
-    tsyringe: ">=4.*"
+    hono: ">=4.0.0"
+    tsyringe: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2670,7 +2670,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    hono: "*"
+    hono: ">=4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2706,7 +2706,7 @@ __metadata:
     zod: "npm:^3.22.1"
   peerDependencies:
     hono: ">=4.3.6"
-    zod: 3.*
+    zod: ">=3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5333,13 +5333,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arktype@npm:^2.0.0-dev.14":
-  version: 2.1.12
-  resolution: "arktype@npm:2.1.12"
+"arktype@npm:^2.0.0":
+  version: 2.1.20
+  resolution: "arktype@npm:2.1.20"
   dependencies:
-    "@ark/schema": "npm:0.45.2"
-    "@ark/util": "npm:0.45.2"
-  checksum: 10c0/e515e8ea9069a46c222360703e2a54ca9b92ae1f8897aa4ff55af97748e238d186dab4ba249535ced0e4d360cf486923f235f0dc8998a808243fa3678e392ed7
+    "@ark/schema": "npm:0.46.0"
+    "@ark/util": "npm:0.46.0"
+  checksum: 10c0/9200a94616fac1a703ab0c7834fd15ba6f683fd8d909e12c48e5f321ac302c276ce0d6c2736063ca7fda0ff6ded00f1bda08b1155ae20fab0d178ec1238ffcae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces usage of `"hono": "*"` as a peer dependency with a range that should be compatible with Deno