### PR TITLE
chore: pin Deno to 2.3.7 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: v2.x
+          # TODO: Update to v2.x when https://github.com/jsr-io/jsr-npm/issues/129 is resolved
+          deno-version: v2.3.7
       - name: Install Dependencies
         run: yarn
 


### PR DESCRIPTION
The latest Deno (2.4.0) seems to have an issue with module resolution. Let's try to use 2.3.7 for releasing for now.

related:
- https://github.com/jsr-io/jsr-npm/issues/129
- https://github.com/jsr-io/jsr-npm/pull/130