### PR TITLE
chore: update hono version to 4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/ws": "^8.18.0",
     "@vitest/coverage-istanbul": "^3.2.4",
     "eslint": "^9.23.0",
-    "hono": "^4.7.11",
+    "hono": "^4.8.4",
     "pkg-pr-new": "^0.0.51",
     "prettier": "^3.5.3",
     "tsup": "^8.4.0",

--- a/packages/ajv-validator/package.json
+++ b/packages/ajv-validator/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "ajv": "^8.12.0",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/arktype-validator/package.json
+++ b/packages/arktype-validator/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "arktype": "^2.0.0",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/auth-js/package.json
+++ b/packages/auth-js/package.json
@@ -64,6 +64,7 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "@auth/core": "^0.35.3",
     "@types/react": "^18",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "react": "^18.2.0",
     "tsup": "^8.4.0",

--- a/packages/bun-compress/package.json
+++ b/packages/bun-compress/package.json
@@ -45,6 +45,7 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "@types/bun": "^1.2.12",
     "@types/node": "^22.15.15",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/bun-transpiler/package.json
+++ b/packages/bun-transpiler/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/casbin/package.json
+++ b/packages/casbin/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "casbin": "^5.30.0",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/class-validator/package.json
+++ b/packages/class-validator/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/clerk-auth/package.json
+++ b/packages/clerk-auth/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@types/react": "^18",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "react": "^18.2.0",
     "tsup": "^8.4.0",

--- a/packages/cloudflare-access/package.json
+++ b/packages/cloudflare-access/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/conform-validator/package.json
+++ b/packages/conform-validator/package.json
@@ -50,6 +50,7 @@
     "@conform-to/valibot": "^1.0.0",
     "@conform-to/yup": "^1.1.5",
     "@conform-to/zod": "^1.1.5",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/effect-validator/package.json
+++ b/packages/effect-validator/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "effect": "3.10.0",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/esbuild-transpiler/package.json
+++ b/packages/esbuild-transpiler/package.json
@@ -76,6 +76,7 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "esbuild": "^0.19.9",
     "esbuild-wasm": "^0.19.5",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -29,5 +29,8 @@
     "eslint-plugin-import-x": "^4.1.1",
     "eslint-plugin-n": "^17.10.2",
     "typescript-eslint": "^8.27.0"
+  },
+  "devDependencies": {
+    "hono": "^4.8.4"
   }
 }

--- a/packages/event-emitter/package.json
+++ b/packages/event-emitter/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/firebase-auth/package.json
+++ b/packages/firebase-auth/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "firebase-tools": "^13.29.1",
+    "hono": "^4.8.4",
     "miniflare": "^3.20240208.0",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/hello/package.json
+++ b/packages/hello/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/medley-router/package.json
+++ b/packages/medley-router/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/node-ws/package.json
+++ b/packages/node-ws/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@hono/node-server": "^1.11.1",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/oauth-providers/package.json
+++ b/packages/oauth-providers/package.json
@@ -82,6 +82,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "msw": "^2.0.11",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",

--- a/packages/oidc-auth/package.json
+++ b/packages/oidc-auth/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@types/jsonwebtoken": "^9.0.5",
+    "hono": "^4.8.4",
     "jsonwebtoken": "^9.0.2",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -50,6 +50,7 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "@opentelemetry/sdk-trace-base": "^1.30.0",
     "@opentelemetry/sdk-trace-node": "^1.30.0",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/prometheus/package.json
+++ b/packages/prometheus/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "prom-client": "^15.0.0",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",

--- a/packages/qwik-city/package.json
+++ b/packages/qwik-city/package.json
@@ -46,6 +46,7 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "@builder.io/qwik": "^1.2.0",
     "@builder.io/qwik-city": "^1.2.0",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2"

--- a/packages/react-compat/package.json
+++ b/packages/react-compat/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2"

--- a/packages/react-renderer/package.json
+++ b/packages/react-renderer/package.json
@@ -49,6 +49,7 @@
     "@cloudflare/vitest-pool-workers": "^0.8.38",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.2",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@cloudflare/vitest-pool-workers": "^0.7.8",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/standard-validator/package.json
+++ b/packages/standard-validator/package.json
@@ -48,6 +48,7 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "@standard-schema/spec": "1.0.0",
     "arktype": "^2.0.0-rc.26",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/stytch-auth/package.json
+++ b/packages/stytch-auth/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "stytch": "^12.19.0",
     "tsup": "^8.4.0",

--- a/packages/swagger-editor/package.json
+++ b/packages/swagger-editor/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/swagger-ui/package.json
+++ b/packages/swagger-ui/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@types/swagger-ui-dist": "^3.30.5",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/trpc-server/package.json
+++ b/packages/trpc-server/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@trpc/server": "^11.0.0",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/tsyringe/package.json
+++ b/packages/tsyringe/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "reflect-metadata": "^0.2.2",
     "tsup": "^8.4.0",

--- a/packages/typebox-validator/package.json
+++ b/packages/typebox-validator/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@sinclair/typebox": "^0.31.15",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/typia-validator/package.json
+++ b/packages/typia-validator/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@ryoppippi/unplugin-typia": "^2.1.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/ua-blocker/package.json
+++ b/packages/ua-blocker/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@types/node": "^22.15.24",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/valibot-validator/package.json
+++ b/packages/valibot-validator/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "hono": "^4.8.4",
     "publint": "^0.3.9",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2051,6 +2051,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     ajv: "npm:^8.12.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2067,6 +2068,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     arktype: "npm:^2.0.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2084,6 +2086,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@auth/core": "npm:^0.35.3"
     "@types/react": "npm:^18"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     react: "npm:^18.2.0"
     tsup: "npm:^8.4.0"
@@ -2103,6 +2106,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@types/bun": "npm:^1.2.12"
     "@types/node": "npm:^22.15.15"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2117,6 +2121,7 @@ __metadata:
   resolution: "@hono/bun-transpiler@workspace:packages/bun-transpiler"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2132,6 +2137,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     casbin: "npm:^5.30.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2149,6 +2155,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     class-transformer: "npm:^0.5.1"
     class-validator: "npm:^0.14.1"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     reflect-metadata: "npm:^0.2.2"
     tsup: "npm:^8.4.0"
@@ -2167,6 +2174,7 @@ __metadata:
     "@clerk/backend": "npm:^2.2.0"
     "@clerk/types": "npm:^4.61.0"
     "@types/react": "npm:^18"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     react: "npm:^18.2.0"
     tsup: "npm:^8.4.0"
@@ -2182,6 +2190,7 @@ __metadata:
   resolution: "@hono/cloudflare-access@workspace:packages/cloudflare-access"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2200,6 +2209,7 @@ __metadata:
     "@conform-to/valibot": "npm:^1.0.0"
     "@conform-to/yup": "npm:^1.1.5"
     "@conform-to/zod": "npm:^1.1.5"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2219,6 +2229,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     effect: "npm:3.10.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2236,6 +2247,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     esbuild: "npm:^0.19.9"
     esbuild-wasm: "npm:^0.19.5"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2254,6 +2266,7 @@ __metadata:
     eslint-import-resolver-typescript: "npm:^4.2.2"
     eslint-plugin-import-x: "npm:^4.1.1"
     eslint-plugin-n: "npm:^17.10.2"
+    hono: "npm:^4.8.4"
     typescript-eslint: "npm:^8.27.0"
   peerDependencies:
     eslint: ^9.0.0
@@ -2266,6 +2279,7 @@ __metadata:
   resolution: "@hono/event-emitter@workspace:packages/event-emitter"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2282,6 +2296,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     firebase-auth-cloudflare-workers: "npm:^2.0.6"
     firebase-tools: "npm:^13.29.1"
+    hono: "npm:^4.8.4"
     miniflare: "npm:^3.20240208.0"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
@@ -2298,6 +2313,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     graphql: "npm:^16.5.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2312,6 +2328,7 @@ __metadata:
   resolution: "@hono/hello@workspace:packages/hello"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2327,6 +2344,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@modelcontextprotocol/sdk": "npm:^1.12.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2344,6 +2362,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@medley/router": "npm:^0.2.1"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2368,6 +2387,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@hono/node-server": "npm:^1.11.1"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2384,6 +2404,7 @@ __metadata:
   resolution: "@hono/oauth-providers@workspace:packages/oauth-providers"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     msw: "npm:^2.0.11"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
@@ -2400,6 +2421,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@types/jsonwebtoken": "npm:^9.0.5"
+    hono: "npm:^4.8.4"
     jsonwebtoken: "npm:^9.0.2"
     oauth4webapi: "npm:^2.6.0"
     publint: "npm:^0.3.9"
@@ -2420,6 +2442,7 @@ __metadata:
     "@opentelemetry/sdk-trace-base": "npm:^1.30.0"
     "@opentelemetry/sdk-trace-node": "npm:^1.30.0"
     "@opentelemetry/semantic-conventions": "npm:^1.28.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2434,6 +2457,7 @@ __metadata:
   resolution: "@hono/prometheus@workspace:packages/prometheus"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     prom-client: "npm:^15.0.0"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
@@ -2452,6 +2476,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@builder.io/qwik": "npm:^1.2.0"
     "@builder.io/qwik-city": "npm:^1.2.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2467,6 +2492,7 @@ __metadata:
   resolution: "@hono/react-compat@workspace:packages/react-compat"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2483,6 +2509,7 @@ __metadata:
     "@cloudflare/vitest-pool-workers": "npm:^0.8.38"
     "@types/react": "npm:^19.1.0"
     "@types/react-dom": "npm:^19.1.2"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
@@ -2501,6 +2528,7 @@ __metadata:
   resolution: "@hono/sentry@workspace:packages/sentry"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     toucan-js: "npm:^4.0.0"
     tsup: "npm:^8.4.0"
@@ -2517,6 +2545,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@cloudflare/vitest-pool-workers": "npm:^0.7.8"
+    hono: "npm:^4.8.4"
     jose: "npm:^6.0.11"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
@@ -2535,6 +2564,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@standard-schema/spec": "npm:1.0.0"
     arktype: "npm:^2.0.0-rc.26"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2552,6 +2582,7 @@ __metadata:
   resolution: "@hono/stytch-auth@workspace:packages/stytch-auth"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     stytch: "npm:^12.19.0"
     tsup: "npm:^8.4.0"
@@ -2568,6 +2599,7 @@ __metadata:
   resolution: "@hono/swagger-editor@workspace:packages/swagger-editor"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2583,6 +2615,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@types/swagger-ui-dist": "npm:^3.30.5"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2598,6 +2631,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@trpc/server": "npm:^11.0.0"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2614,6 +2648,7 @@ __metadata:
   resolution: "@hono/tsyringe@workspace:packages/tsyringe"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     reflect-metadata: "npm:^0.2.2"
     tsup: "npm:^8.4.0"
@@ -2632,6 +2667,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@sinclair/typebox": "npm:^0.31.15"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2648,6 +2684,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@ryoppippi/unplugin-typia": "npm:^2.1.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2665,6 +2702,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@types/node": "npm:^22.15.24"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2679,6 +2717,7 @@ __metadata:
   resolution: "@hono/valibot-validator@workspace:packages/valibot-validator"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"
@@ -2697,6 +2736,7 @@ __metadata:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@asteasolutions/zod-to-openapi": "npm:^7.3.0"
     "@hono/zod-validator": "workspace:^"
+    hono: "npm:^4.8.4"
     openapi3-ts: "npm:^4.5.0"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
@@ -2715,6 +2755,7 @@ __metadata:
   resolution: "@hono/zod-validator@workspace:packages/zod-validator"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
+    hono: "npm:^4.8.4"
     publint: "npm:^0.3.9"
     tsup: "npm:^8.4.0"
     typescript: "npm:^5.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9291,7 +9291,7 @@ __metadata:
     "@types/ws": "npm:^8.18.0"
     "@vitest/coverage-istanbul": "npm:^3.2.4"
     eslint: "npm:^9.23.0"
-    hono: "npm:^4.7.11"
+    hono: "npm:^4.8.4"
     pkg-pr-new: "npm:^0.0.51"
     prettier: "npm:^3.5.3"
     tsup: "npm:^8.4.0"
@@ -9300,10 +9300,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"hono@npm:^4.7.11":
-  version: 4.7.11
-  resolution: "hono@npm:4.7.11"
-  checksum: 10c0/2821471b09f2e9f7bab5ad7412e2e44df5f07b7098508d70dd6e368b933580f03a06c30e20dd764b53e0121e1b1ff2132ae98cffa7fd1b286e299f9054effd6a
+"hono@npm:^4.8.4":
+  version: 4.8.4
+  resolution: "hono@npm:4.8.4"
+  checksum: 10c0/3712bbb4f7d24b5f4f30d75730ae30111cafdb92132728c92e83c257008cfd64e234a6c0657807cb4dd7bc001e3e1daf2e4dd5eb0a73a32ef3a70eff0415d3b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I updated the hono dependency to prepare for accepting middleware related to features added in [v4.8.0](https://github.com/honojs/hono/releases/tag/v4.8.0).