### PR TITLE
[standard-validator]: Fix arktype leaking headers 

### DIFF
--- a/.changeset/rotten-cats-live.md
+++ b/.changeset/rotten-cats-live.md
@@ -1,0 +1,5 @@
+---
+'@hono/standard-validator': patch
+---
+
+Fix cookies output for arktype in standard schema validator

--- a/packages/standard-validator/__schemas__/arktype.ts
+++ b/packages/standard-validator/__schemas__/arktype.ts
@@ -26,7 +26,12 @@ const querySortSchema = type({
   order: "'asc'|'desc'",
 })
 
+const headerSchema = type({
+  'User-Agent': 'string',
+})
+
 export {
+  headerSchema,
   idJSONSchema,
   personJSONSchema,
   postJSONSchema,

--- a/packages/standard-validator/__schemas__/valibot.ts
+++ b/packages/standard-validator/__schemas__/valibot.ts
@@ -28,7 +28,12 @@ const querySortSchema = object({
   order: picklist(['asc', 'desc']),
 })
 
+const headerSchema = object({
+  'User-Agent': string(),
+})
+
 export {
+  headerSchema,
   idJSONSchema,
   personJSONSchema,
   postJSONSchema,

--- a/packages/standard-validator/__schemas__/zod.ts
+++ b/packages/standard-validator/__schemas__/zod.ts
@@ -28,7 +28,12 @@ const querySortSchema = z.object({
   order: z.enum(['asc', 'desc']),
 })
 
+const headerSchema = z.object({
+  'User-Agent': z.string(),
+})
+
 export {
+  headerSchema,
   idJSONSchema,
   personJSONSchema,
   postJSONSchema,

--- a/packages/standard-validator/src/index.test.ts
+++ b/packages/standard-validator/src/index.test.ts
@@ -359,10 +359,8 @@ describe('Standard Schema Validation', () => {
 
           const schema = schemas.headerSchema
 
-          app.get(
-            '/headers',
-            sValidator('header', schema),
-            (c) => c.json({ success: true, userAgent: c.req.header('User-Agent') })
+          app.get('/headers', sValidator('header', schema), (c) =>
+            c.json({ success: true, userAgent: c.req.header('User-Agent') })
           )
 
           const req = new Request('http://localhost/headers', {

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -76,11 +76,12 @@ const sValidator = <
 
     if (result.issues) {
       let processedIssues = result.issues
-      
+
       // Strip sensitive data for arktype schemas
       if (schema['~standard'].vendor === 'arktype' && target in RESTRICTED_DATA_FIELDS) {
-        const restrictedFields = RESTRICTED_DATA_FIELDS[target as keyof typeof RESTRICTED_DATA_FIELDS] || []
-        
+        const restrictedFields =
+          RESTRICTED_DATA_FIELDS[target as keyof typeof RESTRICTED_DATA_FIELDS] || []
+
         processedIssues = result.issues.map((issue) => {
           if (
             issue &&
@@ -99,7 +100,7 @@ const sValidator = <
           return issue
         }) as readonly StandardSchemaV1.Issue[]
       }
-      
+
       return c.json({ data: value, error: processedIssues, success: false }, 400)
     }
 


### PR DESCRIPTION
## Overview

As discussed #1241 and #1135, this PR fixes arktype headers leak in `standard-validator`. This is a step toward deprecating arktype-specific validator and relying solely on standard schema validator.

### Checks

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
