### PR TITLE
fix(ci): release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # Used by changests to create releases
       id-token: write # The OIDC ID token is used for authentication with JSR.
+      pull-requests: write # Used by changesets to create a pull request for the release
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Add the [necessary permissions](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) for the release job to create pull requests and releases

To provide some extra context, we're using the "Version Packages" PR created by changesets to also

1. sync the `deno.json` version field of a package. 
2. publish to JSR, and npm

To do this we introduced `jobs.release.permissions.id-token` to the workflow to authenticate with JSR. This appears to have also affected the permissions required for changesets to work. Hopefully adding these additional permissions should help