### PR TITLE
fix(valibot-validator): import valibot from jsr

### DIFF
--- a/.changeset/four-flowers-guess.md
+++ b/.changeset/four-flowers-guess.md
@@ -1,0 +1,5 @@
+---
+'@hono/valibot-validator': patch
+---
+
+Import `jsr:@valibot/valibot`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "version": "yarn version:npm && yarn version:jsr",
     "version:npm": "changeset version",
     "version:jsr": "yarn workspaces foreach --all --no-private --parallel run version:jsr",
-    "version:set": "tmp=$(mktemp) && jq --arg version $0 '.version = $version' $INIT_CWD/deno.json > $tmp && mv $tmp $INIT_CWD/deno.json",
+    "version:set": "tmp=$(mktemp) && jq --arg version $0 '.version = $version' $INIT_CWD/deno.json > $tmp && mv $tmp $INIT_CWD/deno.json && prettier --write $INIT_CWD/deno.json",
     "typecheck": "yarn tsc --build",
     "typecheck:clean": "yarn tsc --build --clean",
     "typecheck:watch": "yarn tsc --build --watch",

--- a/packages/valibot-validator/deno.json
+++ b/packages/valibot-validator/deno.json
@@ -6,16 +6,11 @@
     ".": "./src/index.ts"
   },
   "imports": {
-    "hono": "jsr:@hono/hono@^4.8.3"
+    "hono": "jsr:@hono/hono@^4.8.3",
+    "valibot": "jsr:@valibot/valibot@^1.1.0"
   },
   "publish": {
-    "include": [
-      "deno.json",
-      "README.md",
-      "src/**/*.ts"
-    ],
-    "exclude": [
-      "src/**/*.test.ts"
-    ]
+    "include": ["deno.json", "README.md", "src/**/*.ts"],
+    "exclude": ["src/**/*.test.ts"]
   }
 }


### PR DESCRIPTION
I'd probably encourage everyone to use `@hono/standard-validator`, but this should still be useful

> I noticed that `jsr:@hono/valibot-validator` currently depends on `npm:valibot`. Would it be possible to switch the dependency to `jsr:@valibot/valibot` instead? In addition as changes of [PR 1277](https://github.com/honojs/middleware/pull/1277/files#diff-02cdcfb2199788f089f47ead4befb17cdf868b406375d9d0ac555ab5194772ef)?
>  

 _Originally posted by @imcotton in [#740](https://github.com/honojs/middleware/issues/740#issuecomment-3037495198)_