### PR TITLE
fix(session): types for SessionOptions cookie methods

### DIFF
--- a/.changeset/six-candles-repeat.md
+++ b/.changeset/six-candles-repeat.md
@@ -1,0 +1,5 @@
+---
+'@hono/session': patch
+---
+
+Fix types for `SessionOptions` cookie methods

--- a/packages/session/deno.json
+++ b/packages/session/deno.json
@@ -1,0 +1,18 @@
+{
+  "name": "@hono/session",
+  "version": "0.1.0",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./cookies": "./src/cookies.ts",
+    "./testing": "./src/helper/testing/index.ts"
+  },
+  "imports": {
+    "hono": "jsr:@hono/hono@^4.8.3",
+    "jose": "jsr:@panva/jose@^6.0.11"
+  },
+  "publish": {
+    "include": ["deno.json", "README.md", "src/**/*.ts"],
+    "exclude": ["src/**/*.test.ts"]
+  }
+}

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -37,9 +37,9 @@ export interface SessionOptions<Data> extends SessionEvents<Data> {
    */
   secret?: string | EncryptionKey
 
-  deleteCookie?: typeof cookie.deleteCookie
-  getCookie?: typeof cookie.getCookie
-  setCookie?: typeof cookie.setCookie
+  deleteCookie?: (c: Context, name: string, opt?: CookieOptions) => void
+  getCookie?: (c: Context, name: string) => string | undefined
+  setCookie?: (c: Context, name: string, value: string, opt?: CookieOptions) => void
 }
 
 export type SessionEnv<Data = SessionData> = Env & {


### PR DESCRIPTION
Changes the types for the `deleteCookie`, `getCookie`, and `setCookie` methods to match their usage