### PR TITLE
feat(auth-js): Support async ConfigHandler

### DIFF
--- a/.changeset/good-otters-press.md
+++ b/.changeset/good-otters-press.md
@@ -1,0 +1,5 @@
+---
+'@hono/auth-js': minor
+---
+
+Allow async authjs Config

--- a/packages/auth-js/src/index.test.ts
+++ b/packages/auth-js/src/index.test.ts
@@ -54,7 +54,7 @@ describe('Config', () => {
     app.use(
       '/*',
       initAuthConfig(async () => {
-        await new Promise(resolve => setTimeout(resolve, 1));
+        await new Promise((resolve) => setTimeout(resolve, 1))
         return {
           basePath: '/api/auth',
           providers: [],

--- a/packages/auth-js/src/index.test.ts
+++ b/packages/auth-js/src/index.test.ts
@@ -47,6 +47,27 @@ describe('Config', () => {
     expect(res.status).toBe(200)
   })
 
+  it('Should allow async ConfigHandler', async () => {
+    globalThis.process.env = { AUTH_SECRET: 'secret' }
+    const app = new Hono()
+
+    app.use(
+      '/*',
+      initAuthConfig(async () => {
+        await new Promise(resolve => setTimeout(resolve, 1));
+        return {
+          basePath: '/api/auth',
+          providers: [],
+        }
+      })
+    )
+
+    app.use('/api/auth/*', authHandler())
+    const req = new Request('http://localhost/api/auth/signin')
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+  })
+
   it('Should return 401 is if auth cookie is invalid or missing', async () => {
     const app = new Hono()
 

--- a/packages/auth-js/src/index.ts
+++ b/packages/auth-js/src/index.ts
@@ -29,7 +29,7 @@ export type AuthUser = {
 
 export interface AuthConfig extends Omit<AuthConfigCore, 'raw'> {}
 
-export type ConfigHandler = (c: Context) => AuthConfig
+export type ConfigHandler = (c: Context) => AuthConfig | Promise<AuthConfig>
 
 export function setEnvDefaults(env: AuthEnv, config: AuthConfig): void {
   config.secret ??= env.AUTH_SECRET
@@ -118,7 +118,7 @@ export function verifyAuth(): MiddlewareHandler {
 
 export function initAuthConfig(cb: ConfigHandler): MiddlewareHandler {
   return async (c, next) => {
-    const config = cb(c)
+    const config = await cb(c)
     c.set('authConfig', config)
     await next()
   }


### PR DESCRIPTION
This allows the config file to be generated async. 

Rationale / need: See (for example) the [split config](https://authjs.dev/guides/edge-compatibility#split-config) described in auth-js docs, where a database is used but not in all environments or not for all paths. Allowing an async config enables you to import the config that does / doesn't use the database based on whatever conditions you desire.

It also allows you to use things like cloudflare's [secret store](https://developers.cloudflare.com/secrets-store/integrations/workers/#call-get-on-the-binding-variable)(the api for which is exclusively async) for configuration variables.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
