### PR TITLE
feat(otel): Support selective HTTP header capture

### DIFF
--- a/.changeset/shiny-views-grin.md
+++ b/.changeset/shiny-views-grin.md
@@ -1,0 +1,5 @@
+---
+'@hono/otel': patch
+---
+
+Add `captureRequestHeaders` and `captureResponseHeaders` options for selective header collection.

--- a/packages/otel/src/index.test.ts
+++ b/packages/otel/src/index.test.ts
@@ -2,6 +2,7 @@ import { SpanKind, SpanStatusCode } from '@opentelemetry/api'
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import {
+  ATTR_HTTP_REQUEST_HEADER,
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_RESPONSE_HEADER,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
@@ -50,8 +51,8 @@ describe('OpenTelemetry middleware', () => {
     expect(span.attributes[ATTR_URL_FULL]).toBe('http://localhost/foo')
     expect(span.attributes[ATTR_HTTP_ROUTE]).toBe('/foo')
     expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toBe(200)
-    for (const [name, value] of response.headers.entries()) {
-      expect(span.attributes[ATTR_HTTP_RESPONSE_HEADER(name)]).toBe(value)
+    for (const [name] of response.headers.entries()) {
+      expect(span.attributes[ATTR_HTTP_RESPONSE_HEADER(name)]).toBeUndefined()
     }
   })
 
@@ -98,5 +99,56 @@ describe('OpenTelemetry middleware', () => {
     const spans = memoryExporter.getFinishedSpans()
     const [span] = spans
     expect(span.name).toBe('GET /subapp/hello')
+  })
+
+  // Issue #1326
+  it('Should capture specified request headers', async () => {
+    const app = new Hono()
+    app.use(
+      otel({
+        tracerProvider,
+        captureRequestHeaders: ['content-type', 'x-custom-header'],
+      })
+    )
+    app.get('/foo', (c) => c.text('foo'))
+
+    memoryExporter.reset()
+    await app.request('http://localhost/foo', {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom-Header': 'custom-value',
+        Authorization: 'Bearer secret-token',
+      },
+    })
+
+    const spans = memoryExporter.getFinishedSpans()
+    const [span] = spans
+    expect(span.attributes[ATTR_HTTP_REQUEST_HEADER('content-type')]).toBe('application/json')
+    expect(span.attributes[ATTR_HTTP_REQUEST_HEADER('x-custom-header')]).toBe('custom-value')
+    expect(span.attributes[ATTR_HTTP_REQUEST_HEADER('authorization')]).toBeUndefined()
+  })
+
+  it('Should capture specified response headers', async () => {
+    const app = new Hono()
+    app.use(
+      otel({
+        tracerProvider,
+        captureResponseHeaders: ['content-type', 'x-response-header'],
+      })
+    )
+    app.get('/foo', (c) => {
+      c.header('X-Response-Header', 'response-value')
+      c.header('Set-Cookie', 'session=secret')
+      return c.json({ message: 'test' })
+    })
+
+    memoryExporter.reset()
+    await app.request('http://localhost/foo')
+
+    const spans = memoryExporter.getFinishedSpans()
+    const [span] = spans
+    expect(span.attributes[ATTR_HTTP_RESPONSE_HEADER('content-type')]).toBe('application/json')
+    expect(span.attributes[ATTR_HTTP_RESPONSE_HEADER('x-response-header')]).toBe('response-value')
+    expect(span.attributes[ATTR_HTTP_RESPONSE_HEADER('set-cookie')]).toBeUndefined()
   })
 })

--- a/packages/otel/src/index.test.ts
+++ b/packages/otel/src/index.test.ts
@@ -26,7 +26,7 @@ describe('OpenTelemetry middleware', () => {
 
   app.use(otel({ tracerProvider }))
   app.get('/foo', (c) => c.text('foo'))
-  app.post('/error', (_) => {
+  app.post('/error', () => {
     throw new Error('error message')
   })
 

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -64,8 +64,9 @@ export const otel = (options: OtelOptions = {}): MiddlewareHandler => {
       activeContext,
       async (span) => {
         options.captureRequestHeaders?.push('Traceparent', 'Tracestate')
+        const captureRequestHeaders = options.captureRequestHeaders?.map((h) => h.toLowerCase())
         for (const [name, value] of Object.entries(c.req.header())) {
-          if (options.captureRequestHeaders?.includes(name)) {
+          if (captureRequestHeaders?.includes(name)) {
             span.setAttribute(ATTR_HTTP_REQUEST_HEADER(name), value)
           }
         }
@@ -76,8 +77,9 @@ export const otel = (options: OtelOptions = {}): MiddlewareHandler => {
           span.updateName(`${c.req.method} ${c.req.routePath}`)
           span.setAttribute(ATTR_HTTP_ROUTE, c.req.routePath)
           span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, c.res.status)
+          const captureResponseHeaders = options.captureResponseHeaders?.map((h) => h.toLowerCase())
           for (const [name, value] of c.res.headers.entries()) {
-            if (options.captureResponseHeaders?.includes(name)) {
+            if (captureResponseHeaders?.includes(name)) {
               span.setAttribute(ATTR_HTTP_RESPONSE_HEADER(name), value)
             }
           }

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -9,8 +9,8 @@ import {
   ATTR_HTTP_ROUTE,
 } from '@opentelemetry/semantic-conventions'
 import type { MiddlewareHandler } from 'hono'
-import type { RequestHeader, ResponseHeader } from 'hono/utils/headers'
 import { createMiddleware } from 'hono/factory'
+import type { RequestHeader, ResponseHeader } from 'hono/utils/headers'
 import metadata from '../package.json' with { type: 'json' }
 
 const PACKAGE_NAME = metadata.name


### PR DESCRIPTION
## Summary

  - Add `captureRequestHeaders` and `captureResponseHeaders` options to control which HTTP
  headers are collected in OpenTelemetry spans
  - Prevent sensitive information (cookies, authorization tokens) from being logged by default
  - The 'Traceparent' and 'Tracestate' headers are always captured from requests

## Changes

  - Added `captureRequestHeaders?: string[]` option to specify which request headers to capture
  - Added `captureResponseHeaders?: string[]` option to specify which response headers to capture

  - Modified header collection logic to only capture explicitly specified headers
  - Added comprehensive test coverage for the new functionality

## Breaking Changes

  **⚠️ Breaking Change**: By default, no headers are captured anymore. Previously, all headers
  were captured automatically.

  To maintain the previous behavior, explicitly specify the headers you want to capture:

  ```typescript
  app.use(otel({
    captureRequestHeaders: ['content-type', 'user-agent'],
    captureResponseHeaders: ['content-type', 'cache-control']
  }))
```

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
