### PR TITLE
fix(eslint-config): diable `quotes` and `semi` rules

### DIFF
--- a/.changeset/nasty-pears-sit.md
+++ b/.changeset/nasty-pears-sit.md
@@ -1,0 +1,5 @@
+---
+'@hono/eslint-config': patch
+---
+
+fix: diable `quotes` and `semi` rules

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -31,8 +31,6 @@ export default [
 
     rules: {
       curly: ['error', 'all'],
-      quotes: ['error', 'single'],
-      semi: ['error', 'never'],
       'no-debugger': ['error'],
 
       'no-empty': [


### PR DESCRIPTION
I think these formatting things should be done with a formatter like prettier, not ESLint. This resolves the conflict between prettier and eslint.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
