### PR TITLE
feat(zod-openapi): Add optional generator options parameter to doc middleware

### DIFF
--- a/.changeset/warm-emus-clap.md
+++ b/.changeset/warm-emus-clap.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Add optional generator options parameter to doc middleware

--- a/.changeset/warm-emus-clap.md
+++ b/.changeset/warm-emus-clap.md
@@ -1,5 +1,5 @@
 ---
-'@hono/zod-openapi': patch
+'@hono/zod-openapi': minor
 ---
 
 Add optional generator options parameter to doc middleware

--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -309,11 +309,18 @@ You can generate OpenAPI v3.1 spec using the following methods:
 
 ```ts
 app.doc31('/docs', { openapi: '3.1.0', info: { title: 'foo', version: '1' } }) // new endpoint
-app.getOpenAPI31Document({
-  openapi: '3.1.0',
-  info: { title: 'foo', version: '1' },
-}) // schema object
+app.getOpenAPI31Document(
+  {
+    openapi: '3.1.0',
+    info: { title: 'foo', version: '1' },
+  }, // OpenAPI object config
+  {
+    unionPreferredType: 'oneOf',
+  } // Generator options
+) // schema object
 ```
+
+The second parameter is optional and accepts generator options as supported by the `@asteasolutions/zod-to-openapi` library. Refer to their documentation for the complete list of available options and their usage.
 
 ### The Registry
 

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -54,7 +54,7 @@
     "zod": "^4.0.5"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^8.0.0",
+    "@asteasolutions/zod-to-openapi": "^8.1.0",
     "@hono/zod-validator": "workspace:^",
     "openapi3-ts": "^4.5.0"
   },

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -367,6 +367,12 @@ export type OpenAPIObjectConfigure<E extends Env, P extends string> =
   | OpenAPIObjectConfig
   | ((context: Context<E, P>) => OpenAPIObjectConfig)
 
+export type OpenAPIGeneratorOptions = ConstructorParameters<typeof OpenApiGeneratorV3>[1]
+
+export type OpenAPIGeneratorConfigure<E extends Env, P extends string> =
+  | OpenAPIGeneratorOptions
+  | ((context: Context<E, P>) => OpenAPIGeneratorOptions)
+
 export class OpenAPIHono<
   E extends Env = Env,
   S extends Schema = {},
@@ -558,28 +564,38 @@ export class OpenAPIHono<
     return this
   }
 
-  getOpenAPIDocument = (config: OpenAPIObjectConfig): OpenAPIObject => {
-    const generator = new OpenApiGeneratorV3(this.openAPIRegistry.definitions)
-    const document = generator.generateDocument(config)
+  getOpenAPIDocument = (
+    objectConfig: OpenAPIObjectConfig,
+    generatorConfig?: OpenAPIGeneratorOptions
+  ): OpenAPIObject => {
+    const generator = new OpenApiGeneratorV3(this.openAPIRegistry.definitions, generatorConfig)
+    const document = generator.generateDocument(objectConfig)
     // @ts-expect-error the _basePath is a private property
     return this._basePath ? addBasePathToDocument(document, this._basePath) : document
   }
 
-  getOpenAPI31Document = (config: OpenAPIObjectConfig): OpenAPIV31bject => {
-    const generator = new OpenApiGeneratorV31(this.openAPIRegistry.definitions)
-    const document = generator.generateDocument(config)
+  getOpenAPI31Document = (
+    objectConfig: OpenAPIObjectConfig,
+    generatorConfig?: OpenAPIGeneratorOptions
+  ): OpenAPIV31bject => {
+    const generator = new OpenApiGeneratorV31(this.openAPIRegistry.definitions, generatorConfig)
+    const document = generator.generateDocument(objectConfig)
     // @ts-expect-error the _basePath is a private property
     return this._basePath ? addBasePathToDocument(document, this._basePath) : document
   }
 
   doc = <P extends string>(
     path: P,
-    configure: OpenAPIObjectConfigure<E, P>
+    configureObject: OpenAPIObjectConfigure<E, P>,
+    configureGenerator?: OpenAPIGeneratorConfigure<E, P>
   ): OpenAPIHono<E, S & ToSchema<'get', P, {}, {}>, BasePath> => {
     return this.get(path, (c) => {
-      const config = typeof configure === 'function' ? configure(c) : configure
+      const objectConfig =
+        typeof configureObject === 'function' ? configureObject(c) : configureObject
+      const generatorConfig =
+        typeof configureGenerator === 'function' ? configureGenerator(c) : configureGenerator
       try {
-        const document = this.getOpenAPIDocument(config)
+        const document = this.getOpenAPIDocument(objectConfig, generatorConfig)
         return c.json(document)
       } catch (e: any) {
         return c.json(e, 500)
@@ -589,12 +605,16 @@ export class OpenAPIHono<
 
   doc31 = <P extends string>(
     path: P,
-    configure: OpenAPIObjectConfigure<E, P>
+    configureObject: OpenAPIObjectConfigure<E, P>,
+    configureGenerator?: OpenAPIGeneratorConfigure<E, P>
   ): OpenAPIHono<E, S & ToSchema<'get', P, {}, {}>, BasePath> => {
     return this.get(path, (c) => {
-      const config = typeof configure === 'function' ? configure(c) : configure
+      const objectConfig =
+        typeof configureObject === 'function' ? configureObject(c) : configureObject
+      const generatorConfig =
+        typeof configureGenerator === 'function' ? configureGenerator(c) : configureGenerator
       try {
-        const document = this.getOpenAPI31Document(config)
+        const document = this.getOpenAPI31Document(objectConfig, generatorConfig)
         return c.json(document)
       } catch (e: any) {
         return c.json(e, 500)

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,14 +99,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asteasolutions/zod-to-openapi@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@asteasolutions/zod-to-openapi@npm:8.0.0"
+"@asteasolutions/zod-to-openapi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@asteasolutions/zod-to-openapi@npm:8.1.0"
   dependencies:
     openapi3-ts: "npm:^4.1.2"
   peerDependencies:
     zod: ^4.0.0
-  checksum: 10c0/b522d074832fb137dca724c8bd4bb134c7b4d4cad12c247ed3c864f993923b3475fc06580e6e1cbc4fd8641cd361679bbe1dd87c9bb42e142bc056d96d59fbc8
+  checksum: 10c0/974a8b06bc3048406bc13f2cf2c00ce8bc2256af6d1e24b39f3b8b1c6fa6047d64b8a017da5b45e6b3f28ca89b159383f01dabc00a904a705a54ea87712dfda3
   languageName: node
   linkType: hard
 
@@ -2734,7 +2734,7 @@ __metadata:
   resolution: "@hono/zod-openapi@workspace:packages/zod-openapi"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
-    "@asteasolutions/zod-to-openapi": "npm:^8.0.0"
+    "@asteasolutions/zod-to-openapi": "npm:^8.1.0"
     "@hono/zod-validator": "workspace:^"
     hono: "npm:^4.8.4"
     openapi3-ts: "npm:^4.5.0"


### PR DESCRIPTION
fixes #1349

This PR adds support for passing generator options to the `doc` function in `@hono/zod-openapi`, allowing users to customize OpenAPI v3.1 document generation.

### API Changes
```ts
// Before
app.doc31('/docs', { openapi: '3.1.0', info: { title: 'My API' } })

// After (optional generator options with backward compatibility)
app.doc31('/docs', 
  { openapi: '3.1.0', info: { title: 'My API' } },
  { unionPreferredType: 'oneOf' }
)
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
