### PR TITLE
chore: remove overlapping dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,6 @@ updates:
 
   - package-ecosystem: npm
     allow:
-      - dependency-type: production
-    directory: /
-    schedule:
-      interval: weekly
-    versioning-strategy: widen
-
-  - package-ecosystem: npm
-    allow:
       - dependency-type: development
     directory: /
     schedule:


### PR DESCRIPTION
Looks like there was an issue with the initial configuration 😩 

https://github.com/honojs/middleware/runs/47402472825

```
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories.
```

It should now only update `devDependencies`