### PR TITLE
chore: consolidate tool versions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version-file: .tool-versions
       - run: yarn install
       - run: yarn format:fix
       - run: yarn lint:fix

--- a/.github/workflows/ci-bun-transpiler.yml
+++ b/.github/workflows/ci-bun-transpiler.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.32
+          bun-version-file: .tool-versions
       - run: yarn workspaces focus hono-middleware @hono/bun-transpiler
       - run: yarn workspace @hono/bun-transpiler build
       - run: yarn workspace @hono/bun-transpiler publint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version-file: .tool-versions
       - name: Get changed packages
         id: set-packages
         run: |
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version-file: .tool-versions
       - run: yarn workspaces focus hono-middleware @hono/${{ matrix.package }}
       - run: yarn workspaces foreach --topological --recursive --from @hono/${{ matrix.package }} run publint
       - run: yarn workspace @hono/${{ matrix.package }} typecheck
@@ -54,7 +54,7 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: v2.3.7
+          deno-version-file: .tool-versions
       - run: deno install --no-lock
       - run: deno publish --dry-run
 
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version-file: .tool-versions
       - run: yarn workspaces focus hono-middleware @hono/${{ matrix.package }}
       - run: yarn workspaces foreach --topological --recursive --from @hono/${{ matrix.package }} run build
       - run: yarn test --coverage --project @hono/${{ matrix.package }}

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version-file: .tool-versions
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,12 @@ jobs:
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version-file: .tool-versions
 
       - uses: denoland/setup-deno@v2
         with:
           cache: true
-          # TODO: Update to v2.x when https://github.com/jsr-io/jsr-npm/issues/129 is resolved
-          deno-version: v2.3.7
+          deno-version-file: .tool-versions
       - name: Install Dependencies
         run: yarn
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+bun 1.1.32
+# TODO: Update to v2.x when https://github.com/jsr-io/jsr-npm/issues/129 is resolved
+deno 2.3.7
+node 20.19.4


### PR DESCRIPTION
This consolidates the tool versions from different CI workflows into a single `.tool-versions` file

I noticed in #1357 that [`oven-sh/setup-bun@v2`](https://github.com/oven-sh/setup-bun) has an option for `bun-version-file: .tool-versions`. Both [`denoland/setup-deno@v2`](https://github.com/denoland/setup-deno) and [`actions/setup-node@v4`](https://github.com/actions/setup-node) have similar options too.

I think the `.tool-versions` concept originated in the [asdf](https://asdf-vm.com/manage/configuration.html#tool-versions) version manages, but has since been adopted by other tools too.

Including a `.tool-versions` should only affect CI, and if contributor already knows about `.tool-versions` files, it will ensure they have the correct tools installed. I personally use https://mise.jdx.dev/