### PR TITLE
fix(oauth-providers): github oauth

### DIFF
--- a/.changeset/gentle-bugs-peel.md
+++ b/.changeset/gentle-bugs-peel.md
@@ -1,0 +1,5 @@
+---
+'@hono/oauth-providers': major
+---
+
+fixed github email request content-type

--- a/.changeset/gentle-bugs-peel.md
+++ b/.changeset/gentle-bugs-peel.md
@@ -1,5 +1,5 @@
 ---
-'@hono/oauth-providers': major
+'@hono/oauth-providers': patch
 ---
 
 fixed github email request content-type

--- a/packages/oauth-providers/src/providers/github/authFlow.ts
+++ b/packages/oauth-providers/src/providers/github/authFlow.ts
@@ -100,7 +100,7 @@ export class AuthFlow {
         Authorization: `Bearer ${this.token?.token}`,
         'User-Agent': userAgent,
         Accept: 'application/json',
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json'
       },
     }).then((res) => res.json())) as GitHubEmailResponse[] | GitHubErrorResponse
 

--- a/packages/oauth-providers/src/providers/github/authFlow.ts
+++ b/packages/oauth-providers/src/providers/github/authFlow.ts
@@ -100,7 +100,7 @@ export class AuthFlow {
         Authorization: `Bearer ${this.token?.token}`,
         'User-Agent': userAgent,
         Accept: 'application/json',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
     }).then((res) => res.json())) as GitHubEmailResponse[] | GitHubErrorResponse
 

--- a/packages/oauth-providers/src/providers/github/authFlow.ts
+++ b/packages/oauth-providers/src/providers/github/authFlow.ts
@@ -24,7 +24,7 @@ type Token = {
 
 const userAgent = 'Hono-Auth-App'
 
-export class AuthFlow {
+export class AuthFlow {π
   client_id: string
   client_secret: string
   scope: GitHubScope[] | undefined
@@ -99,6 +99,8 @@ export class AuthFlow {
       headers: {
         Authorization: `Bearer ${this.token?.token}`,
         'User-Agent': userAgent,
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
       },
     }).then((res) => res.json())) as GitHubEmailResponse[] | GitHubErrorResponse
 

--- a/packages/oauth-providers/src/providers/github/authFlow.ts
+++ b/packages/oauth-providers/src/providers/github/authFlow.ts
@@ -24,7 +24,7 @@ type Token = {
 
 const userAgent = 'Hono-Auth-App'
 
-export class AuthFlow {π
+export class AuthFlow {
   client_id: string
   client_secret: string
   scope: GitHubScope[] | undefined


### PR DESCRIPTION
hi, after github oauth, the framework attempted to obtain the email, but the contentType was missing. This request would report a 400 error. This PR supplemented this contentType