### PR TITLE
chore(ci): fix positional argument

### DIFF
--- a/.github/actions/what-changed/action.yml
+++ b/.github/actions/what-changed/action.yml
@@ -28,5 +28,5 @@ runs:
           "hono-middleware"
           "@hono/bun-transpiler"
         );
-        changed=$(yarn workspaces list --json --since ${{ inputs.since }}| jq -nc '[inputs.name | select(any(.; inside($ARGS.positional[])) | not) | sub("@hono/"; "")]' --args "${exclude[@]}")
+        changed=$(yarn workspaces list --json --since=${{ inputs.since }} | jq -nc '[inputs.name | select(any(.; inside($ARGS.positional[])) | not) | sub("@hono/"; "")]' --args "${exclude[@]}")
         echo "packages=${changed}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
From #1382, there's an issue with the `--since` argument

```sh
❯ yarn workspaces list --json --since b319d978f034143b8065f2a156392dc8a1eea1f1
Unknown Syntax Error: Extraneous positional argument ("b319d978f034143b8065f2a156392dc8a1eea1f1").

$ yarn workspaces list [--since] [-R,--recursive] [--no-private] [-v,--verbose] [--json]
```

While the following should work

```sh
❯ yarn workspaces list --json --since=b319d978f034143b8065f2a156392dc8a1eea1f1
{"location":".","name":"hono-middleware"}
```

