### PR TITLE
chore(dependabot): add @opentelemetry group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     allow:
       - dependency-type: development
     directory: /
+    groups:
+      otel:
+        patterns:
+          - '@opentelemetry/*'
     schedule:
       interval: weekly
     versioning-strategy: increase


### PR DESCRIPTION
[Group](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--) dependabot pull requests for `@opentelemetry/*` dependencies

eg; #1378 would include `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-trace-base`, and `@opentelemetry/sdk-trace-node`

