### PR TITLE
chore(what-changed): no-emit

### DIFF
--- a/.github/actions/what-changed/tsconfig.json
+++ b/.github/actions/what-changed/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
     "module": "nodenext",
     "moduleResolution": "node16",
+    "noEmit": true,
     "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
Make sure TypeScript doesn't emit a `main.js` file during build 🙈 

Which caused prettier to fail https://github.com/honojs/middleware/actions/runs/16962240688/job/48077603902