### PR TITLE
feat(otel): support custom time input for span startTime & endTime

### DIFF
--- a/.changeset/evil-rabbits-obey.md
+++ b/.changeset/evil-rabbits-obey.md
@@ -1,0 +1,5 @@
+---
+'@hono/otel': minor
+---
+
+Support custom time input for span startTime & endTime

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "@opentelemetry/core": "^2.0.1",
     "@opentelemetry/sdk-metrics": "^2.0.1",
     "@opentelemetry/sdk-trace-base": "^1.30.0",
     "@opentelemetry/sdk-trace-node": "^1.30.0",

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -69,7 +69,7 @@ export const otel = (options: OtelOptions = {}): MiddlewareHandler => {
           [ATTR_URL_FULL]: c.req.url,
           [ATTR_HTTP_ROUTE]: routePath,
         },
-        startTime: options.getTime?.()
+        startTime: options.getTime?.(),
       },
       activeContext,
       async (span) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2475,6 +2475,7 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.17.4"
     "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/core": "npm:^2.0.1"
     "@opentelemetry/sdk-metrics": "npm:^2.0.1"
     "@opentelemetry/sdk-trace-base": "npm:^1.30.0"
     "@opentelemetry/sdk-trace-node": "npm:^1.30.0"
@@ -3599,7 +3600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:2.0.1":
+"@opentelemetry/core@npm:2.0.1, @opentelemetry/core@npm:^2.0.1":
   version: 2.0.1
   resolution: "@opentelemetry/core@npm:2.0.1"
   dependencies:


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)



In some applications, when relatively small spans are produced, `startTime` & `endTime` may be required to have a higher precision than the default millisecond
This PR intends to support this by introducing a `getTime` option. When defined, this function is used for assigning `startTime` & `endTime` values to the spans