### PR TITLE
fix(oauth-providers): pass missing state param to MSEntra AuthFlow

### DIFF
--- a/.changeset/brave-bags-talk.md
+++ b/.changeset/brave-bags-talk.md
@@ -1,5 +1,5 @@
 ---
-'@hono/oauth-providers': minor
+'@hono/oauth-providers': patch
 ---
 
 fix: enable CSRF protection for MSEntra ID authentication

--- a/.changeset/brave-bags-talk.md
+++ b/.changeset/brave-bags-talk.md
@@ -1,0 +1,7 @@
+---
+'@hono/oauth-providers': patch
+---
+
+fix: pass missing state param to MSEntra AuthFlow
+
+Fixed a bug where the state parameter was not being passed to the MSEntra AuthFlow constructor, which could cause CSRF protection to fail. The state parameter is now properly passed from the middleware options to the AuthFlow instance.

--- a/.changeset/brave-bags-talk.md
+++ b/.changeset/brave-bags-talk.md
@@ -1,7 +1,7 @@
 ---
-'@hono/oauth-providers': patch
+'@hono/oauth-providers': minor
 ---
 
-fix: pass missing state param to MSEntra AuthFlow
+fix: enable CSRF protection for MSEntra ID authentication
 
-Fixed a bug where the state parameter was not being passed to the MSEntra AuthFlow constructor, which could cause CSRF protection to fail. The state parameter is now properly passed from the middleware options to the AuthFlow instance.
+Fixed a bug where the state parameter was not being passed to the MSEntra AuthFlow constructor. As a result, CSRF protection now properly works for MSEntra ID authentication, ensuring that authentication requests are protected against Cross-Site Request Forgery attacks.

--- a/packages/oauth-providers/src/index.test.ts
+++ b/packages/oauth-providers/src/index.test.ts
@@ -448,6 +448,15 @@ describe('OAuth Middleware', () => {
       redirect_uri: 'http://localhost:3000/msentra',
     })(c, next)
   })
+  app.use('/msentra-custom-state', (c, next) => {
+    return msentraAuth({
+      client_id,
+      client_secret,
+      tenant_id: 'fake-tenant-id',
+      scope: ['openid', 'email', 'profile'],
+      state: 'test-state',
+    })(c, next)
+  })
   app.get('/msentra', (c) => {
     const user = c.get('user-msentra')
     const token = c.get('token')
@@ -1053,6 +1062,15 @@ describe('OAuth Middleware', () => {
         const redirectLocation = res.headers.get('location')!
         const redirectUrl = new URL(redirectLocation)
         expect(redirectUrl.searchParams.get('redirect_uri')).toBe('http://localhost:3000/msentra')
+      })
+
+      it('Should work with custom state', async () => {
+        const res = await app.request('/msentra-custom-state')
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(302)
+        const redirectLocation = res.headers.get('location')!
+        const redirectUrl = new URL(redirectLocation)
+        expect(redirectUrl.searchParams.get('state')).toBe('test-state')
       })
 
       it('Prevent CSRF attack', async () => {

--- a/packages/oauth-providers/src/providers/msentra/msentraAuth.ts
+++ b/packages/oauth-providers/src/providers/msentra/msentraAuth.ts
@@ -30,6 +30,7 @@ export function msentraAuth(options: {
         expires_in: Number(c.req.query('expires_in')) as number,
       },
       scope: options.scope,
+      state: newState,
     })
 
     // Redirect to login dialog


### PR DESCRIPTION
Fixed a bug where the state parameter was not being passed to the MSEntra AuthFlow constructor, which could cause CSRF protection to fail. The state parameter is now properly passed from the middleware options to the AuthFlow instance.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
