### PR TITLE
fix(zod-validator): correct fallback behavior when using `coerce`

### DIFF
--- a/.changeset/wise-masks-say.md
+++ b/.changeset/wise-masks-say.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': patch
+---
+
+fix: correct fallback behavior when using `coerce`

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -42,12 +42,20 @@ export const zValidator = <
       ? {
           [K in Target]?: In extends ValidationTargets[K]
             ? In
-            : { [K2 in keyof In]?: ValidationTargets[K][K2] }
+            : {
+                [K2 in keyof In]?: In[K2] extends ValidationTargets[K][K2]
+                  ? In[K2]
+                  : ValidationTargets[K][K2]
+              }
         }
       : {
           [K in Target]: In extends ValidationTargets[K]
             ? In
-            : { [K2 in keyof In]: ValidationTargets[K][K2] }
+            : {
+                [K2 in keyof In]: In[K2] extends ValidationTargets[K][K2]
+                  ? In[K2]
+                  : ValidationTargets[K][K2]
+              }
         }
     out: { [K in Target]: Out }
   },

--- a/packages/zod-validator/src/v3.test.ts
+++ b/packages/zod-validator/src/v3.test.ts
@@ -55,7 +55,7 @@ describe('Basic', () => {
             | undefined
         }
         output: {
-          success: boolean
+          success: true
           message: string
           queryName: string | undefined
         }
@@ -148,6 +148,49 @@ describe('coerce', () => {
     expect(await res.json()).toEqual({
       page: 123,
     })
+  })
+
+  it('Should correctly infer literal types for enum and fallback for coerce schemas', () => {
+    // Related to issue #1370: Type inference for coerce and enum schemas
+    const mixedRoute = new Hono().get(
+      '/mixed',
+      zValidator(
+        'query',
+        z.object({
+          tenant: z.enum(['abba', 'baab']), // Should infer as literal union type
+          page: z.coerce.number(), // Should fallback to string | string[]
+        })
+      ),
+      (c) => {
+        const query = c.req.valid('query')
+        return c.json({ query })
+      }
+    )
+
+    type MixedActual = ExtractSchema<typeof mixedRoute>
+    type MixedExpected = {
+      '/mixed': {
+        $get: {
+          input: {
+            query: {
+              tenant: 'abba' | 'baab' // Literal type preserved
+              page: string | string[] // Coerce fallback type
+            }
+          }
+          output: {
+            query: {
+              tenant: 'abba' | 'baab' // Output uses inferred type
+              page: number // Coerce output type
+            }
+          }
+          outputFormat: 'json'
+          status: ContentfulStatusCode
+        }
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type verifyMixed = Expect<Equal<MixedExpected, MixedActual>>
   })
 })
 

--- a/packages/zod-validator/src/v3.test.ts
+++ b/packages/zod-validator/src/v3.test.ts
@@ -55,7 +55,7 @@ describe('Basic', () => {
             | undefined
         }
         output: {
-          success: true
+          success: boolean
           message: string
           queryName: string | undefined
         }

--- a/packages/zod-validator/src/v4.test.ts
+++ b/packages/zod-validator/src/v4.test.ts
@@ -56,7 +56,7 @@ describe('Basic', () => {
             | undefined
         }
         output: {
-          success: true
+          success: boolean
           message: string
           queryName: string | undefined
         }

--- a/packages/zod-validator/src/v4.test.ts
+++ b/packages/zod-validator/src/v4.test.ts
@@ -56,7 +56,7 @@ describe('Basic', () => {
             | undefined
         }
         output: {
-          success: boolean
+          success: true
           message: string
           queryName: string | undefined
         }
@@ -149,6 +149,49 @@ describe('coerce', () => {
     expect(await res.json()).toEqual({
       page: 123,
     })
+  })
+
+  it('Should correctly infer literal types for enum and fallback for coerce schemas', () => {
+    // Related to issue #1370: Type inference for coerce and enum schemas
+    const mixedRoute = new Hono().get(
+      '/mixed',
+      zValidator(
+        'query',
+        z.object({
+          tenant: z.enum(['abba', 'baab']), // Should infer as literal union type
+          page: z.coerce.number(), // Should fallback to string | string[]
+        })
+      ),
+      (c) => {
+        const query = c.req.valid('query')
+        return c.json({ query })
+      }
+    )
+
+    type MixedActual = ExtractSchema<typeof mixedRoute>
+    type MixedExpected = {
+      '/mixed': {
+        $get: {
+          input: {
+            query: {
+              tenant: 'abba' | 'baab' // Literal type preserved
+              page: string | string[] // Coerce fallback type
+            }
+          }
+          output: {
+            query: {
+              tenant: 'abba' | 'baab' // Output uses inferred type
+              page: number // Coerce output type
+            }
+          }
+          outputFormat: 'json'
+          status: ContentfulStatusCode
+        }
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type verifyMixed = Expect<Equal<MixedExpected, MixedActual>>
   })
 })
 


### PR DESCRIPTION
Fixes #1370

This PR enables preventing enum types from falling back to `string | string[]` when `coerce` is used.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
