### PR TITLE
feat(graphql-server): upgrade to GraphiQL 5

### DIFF
--- a/.changeset/hot-bobcats-sing.md
+++ b/.changeset/hot-bobcats-sing.md
@@ -1,0 +1,5 @@
+---
+'@hono/graphql-server': minor
+---
+
+feat: upgrade GraphiQL

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -235,9 +235,9 @@ export const errorMessages = (
 }
 
 export const respondWithGraphiQL = (c: Context): Response => {
-  // https://github.com/graphql/graphiql/blob/03171d5614c61fb345763636d120da2b536d54a0/examples/graphiql-cdn/index.html
+  // https://github.com/graphql/graphiql/blob/fd3f9e6a91be728a69a136ad8680f6e3c7241198/examples/graphiql-cdn/index.html
   return c.html(`<!--
- *  Copyright (c) 2021 GraphQL Contributors
+ *  Copyright (c) 2025 GraphQL Contributors
  *  All rights reserved.
  *
  *  This source code is licensed under the license found in the
@@ -252,7 +252,6 @@ export const respondWithGraphiQL = (c: Context): Response => {
     <style>
       body {
         margin: 0;
-        overflow: hidden; /* in Firefox */
       }
 
       #graphiql {
@@ -267,51 +266,49 @@ export const respondWithGraphiQL = (c: Context): Response => {
         font-size: 4rem;
       }
     </style>
+    <link rel="stylesheet" href="https://esm.sh/graphiql/dist/style.css" />
     <link
       rel="stylesheet"
-      href="https://esm.sh/graphiql@4.0.0/dist/style.css"
+      href="https://esm.sh/@graphiql/plugin-explorer/dist/style.css"
     />
-    <link
-      rel="stylesheet"
-      href="https://esm.sh/@graphiql/plugin-explorer@4.0.0/dist/style.css"
-    />
-    <!-- Note: the ?standalone flag bundles the module along with all of its \`dependencies\`, excluding \`peerDependencies\`, into a single JavaScript file. -->
     <script type="importmap">
       {
         "imports": {
           "react": "https://esm.sh/react@19.1.0",
-          "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime",
+          "react/": "https://esm.sh/react@19.1.0/",
 
           "react-dom": "https://esm.sh/react-dom@19.1.0",
-          "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
+          "react-dom/": "https://esm.sh/react-dom@19.1.0/",
 
-          "graphiql": "https://esm.sh/graphiql@4.0.0?standalone&external=react,react/jsx-runtime,react-dom,@graphiql/react",
-          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer@4.0.0?standalone&external=react,react/jsx-runtime,react-dom,@graphiql/react,graphql",
-          "@graphiql/react": "https://esm.sh/@graphiql/react@0.30.0?standalone&external=react,react/jsx-runtime,react-dom,graphql,@graphiql/toolkit",
+          "graphiql": "https://esm.sh/graphiql?standalone&external=react,react-dom,@graphiql/react,graphql",
+          "graphiql/": "https://esm.sh/graphiql/",
+          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer?standalone&external=react,@graphiql/react,graphql",
+          "@graphiql/react": "https://esm.sh/@graphiql/react?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid",
 
-          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit@0.11.2?standalone&external=graphql",
-          "graphql": "https://esm.sh/graphql@16.11.0"
+          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit?standalone&external=graphql",
+          "graphql": "https://esm.sh/graphql@16.11.0",
+          "@emotion/is-prop-valid": "data:text/javascript,"
         }
       }
     </script>
     <script type="module">
-      // Import React and ReactDOM
       import React from 'react';
       import ReactDOM from 'react-dom/client';
-      // Import GraphiQL and the Explorer plugin
-      import { GraphiQL } from 'graphiql';
+      import { GraphiQL, HISTORY_PLUGIN } from 'graphiql';
       import { createGraphiQLFetcher } from '@graphiql/toolkit';
       import { explorerPlugin } from '@graphiql/plugin-explorer';
+      import 'graphiql/setup-workers/esm.sh';
 
       const fetcher = createGraphiQLFetcher({
         url: '${c.req.path}',
       });
-      const explorer = explorerPlugin();
+      const plugins = [HISTORY_PLUGIN, explorerPlugin()];
 
       function App() {
         return React.createElement(GraphiQL, {
           fetcher,
-          plugins: [explorer],
+          plugins,
+          defaultEditorToolsVisibility: true,
         });
       }
 


### PR DESCRIPTION
This PR proposes an upgrade from GraphiQL v4 to v5. This follows the official example provided in the `graphql/graphiql` repository:
https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
