### PR TITLE
fix(zod-openapi): use a type-guard for zod to avoid issues with esbuild

### DIFF
--- a/.changeset/giant-cups-grab.md
+++ b/.changeset/giant-cups-grab.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Use a typeguard for zod to avoid issues when bundling with esbuild.

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -39,8 +39,9 @@ import type { JSONParsed, JSONValue, RemoveBlankRecord, SimplifyDeepArray } from
 import { mergePath } from 'hono/utils/url'
 import type { OpenAPIObject } from 'openapi3-ts/oas30'
 import type { OpenAPIObject as OpenAPIV31bject } from 'openapi3-ts/oas31'
-import { ZodType, z } from 'zod'
-import type { ZodError } from 'zod'
+import type { ZodType, ZodError  } from 'zod'
+import { z } from 'zod'
+import { isZod } from './zod-typeguard'
 
 type MaybePromise<T> = Promise<T> | T
 
@@ -506,7 +507,7 @@ export class OpenAPIHono<
           continue
         }
         const schema = (bodyContent[mediaType] as ZodMediaTypeObject)['schema']
-        if (!(schema instanceof ZodType)) {
+        if (!isZod(schema)) {
           continue
         }
         if (isJSONContentType(mediaType)) {

--- a/packages/zod-openapi/src/zod-typeguard.ts
+++ b/packages/zod-openapi/src/zod-typeguard.ts
@@ -1,0 +1,12 @@
+import type { ZodType as ZodTypeV3 } from 'zod/v3'
+import type { ZodType as ZodTypeV4 } from 'zod/v4'
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null
+}
+
+export function isZod(x: unknown): x is ZodTypeV3 | ZodTypeV4 {
+  if (!x) return false
+  if (!isObject(x)) return false
+  return typeof x.parse === 'function' && typeof x.safeParse === 'function' && typeof x.parseAsync === 'function' && typeof x.safeParseAsync === 'function'
+}

--- a/packages/zod-openapi/src/zod-typeguart.test.ts
+++ b/packages/zod-openapi/src/zod-typeguart.test.ts
@@ -1,0 +1,36 @@
+
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+import { z as z3 } from 'zod/v3'
+import { z as z4 } from 'zod/v4'
+import { z as z4m } from 'zod/v4-mini'
+import { isZod } from './zod-typeguard'
+
+describe('zod-type-guard', () => {
+
+  it('should return true for Zod 3 schema', () => {
+    const v3_schema = z3.string()
+    expect(isZod(v3_schema)).toBeTruthy()
+  })
+
+  it('should return true for Zod 4 schema', () => {
+    const v4_schema = z4.string()
+    expect(isZod(v4_schema)).toBeTruthy()
+  })
+
+  it('should return true for Zod 4 mini', () => {
+    const v4m_schema = z4m.string()
+    expect(isZod(v4m_schema)).toBeTruthy()
+  })
+
+  it('should return false for non-Zod schema', () => {
+    expect(isZod(undefined)).toBeFalsy()
+    expect(isZod(null)).toBeFalsy()
+    expect(isZod("string")).toBeFalsy()
+    expect(isZod(123)).toBeFalsy()
+    expect(isZod(123n)).toBeFalsy()
+    expect(isZod(new Date())).toBeFalsy()
+    expect(isZod(Symbol())).toBeFalsy()
+    expect(isZod({})).toBeFalsy()
+    expect(isZod(() => {})).toBeFalsy()
+  })
+})


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
