### PR TITLE
fix(oidc-auth): ensure revokeSession clears domain-scoped cookies with Domain attribute (closes #1490)

### DIFF
--- a/.changeset/eager-papers-pick.md
+++ b/.changeset/eager-papers-pick.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': patch
+---
+
+fix(oidc-auth): ensure revokeSession clears domain-scoped cookies with Domain attribute

--- a/packages/oidc-auth/src/index.test.ts
+++ b/packages/oidc-auth/src/index.test.ts
@@ -611,6 +611,28 @@ describe('RevokeSession()', () => {
       new RegExp(`oidc-auth=; Max-Age=0; Path=${MOCK_COOKIE_PATH}($|,)`)
     )
   })
+  test('Should revoke domain-scoped session cookie with Domain attribute', async () => {
+    const MOCK_COOKIE_DOMAIN = 'example.com'
+    process.env.OIDC_COOKIE_DOMAIN = MOCK_COOKIE_DOMAIN
+
+    const req = new Request('http://localhost/logout', {
+      method: 'GET',
+      headers: { cookie: `oidc-auth=${MOCK_JWT_ACTIVE_SESSION}` },
+    })
+
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+
+    const setCookieHeader = res.headers.get('set-cookie')
+    expect(setCookieHeader).toBeDefined()
+
+    const cookieStrings = setCookieHeader?.split(', ')
+    const domainCookie = cookieStrings?.find((c) => c.includes(`Domain=${MOCK_COOKIE_DOMAIN}`))
+
+    expect(domainCookie).toBeDefined()
+    expect(domainCookie).toContain('Max-Age=0')
+    expect(domainCookie).toContain('Path=/')
+  })
 })
 describe('initOidcAuthMiddleware()', () => {
   test('Should error if not called first in context', async () => {

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -290,7 +290,15 @@ export const revokeSession = async (c: Context): Promise<void> => {
   const env = getOidcAuthEnv(c)
   const session_jwt = getCookie(c, env.OIDC_COOKIE_NAME)
   if (session_jwt !== undefined) {
+    // Always delete host-only cookie
     deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
+    // If domain is set, also delete domain-scoped cookie
+    if (env.OIDC_COOKIE_DOMAIN) {
+      deleteCookie(c, env.OIDC_COOKIE_NAME, {
+        path: env.OIDC_COOKIE_PATH,
+        domain: env.OIDC_COOKIE_DOMAIN,
+      })
+    }
     const auth = (await verify(session_jwt, env.OIDC_AUTH_SECRET)) as OidcAuth
     if (auth.rtk !== undefined && auth.rtk !== '') {
       // revoke refresh token


### PR DESCRIPTION
This PR fixes the issue https://github.com/honojs/middleware/issues/1490 where revokeSession did not clear domain-scoped cookies when OIDC_COOKIE_DOMAIN is set. Now, the cookie is deleted with both path and domain 