### PR TITLE
ci: add typia to root workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "tsup": "^8.5.0",
     "turbo": "^2.5.6",
     "typescript": "^5.8.2",
+    "typia": "^9.7.2",
     "vitest": "^3.2.4"
   },
   "packageManager": "yarn@4.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9037,6 +9037,7 @@ __metadata:
     tsup: "npm:^8.5.0"
     turbo: "npm:^2.5.6"
     typescript: "npm:^5.8.2"
+    typia: "npm:^9.7.2"
     vitest: "npm:^3.2.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Add `typia` to root workspace

It looks like `@ryoppippi/unplugin-typia` and `typia` are imported when `vitest` is resolving `project` configuration

https://github.com/honojs/middleware/blob/06073bcf0379e5c56be4378a68542664515e2a25/packages/typia-validator/vitest.config.ts#L1

There is no issue when both dependencies are installed, for example, when the CI workflow for `@hono/typia-validator` is run.

But it is an issue for other workspaces when the packages aren't installed 😭 `@ryoppippi/unplugin-typia` was already included in the root workspace, we just need to include `typia` too.