### PR TITLE
ci(ua-blocker): restrict PR creation to only upstream repository

### DIFF
--- a/.github/workflows/ci-ua-blocker-sync.yml
+++ b/.github/workflows/ci-ua-blocker-sync.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   sync-and-pr:
+    if: ${{ !github.event.repository.fork }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -58,7 +59,7 @@ jobs:
           EOF
 
       - name: Create Pull Request if changes exist
-        if: steps.changes.outputs.has_changes == 'true' && !github.event.repository.fork
+        if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In `.github/workflows/ci-ua-blocker-sync.yml`, the `peter-evans/create-pull-request` action specifies reviewers. However, in forked repositories, reviewers are not collaborators, causing the action to fail.

Since this workflow is triggered by a cron schedule, failure notifications are sent periodically. To address this, PR creation has been restricted to only the upstream repository.

Additional note: Even in the upstream repository, the specified reviewers are not collaborators, which appears to cause the same error[^1]. Removing the `reviewers` field altogether could also be considered.  
It seems that in the initial PRs, reviewers were assigned correctly[^2], so perhaps there has been a change in the GitHub API specification?

```plaintext
Create or update the pull request
  Attempting creation of pull request
  Created pull request #1526 (honojs:chore/sync-robots-json => main)
  Applying labels 'robots.json'
  Applying assignees 'finxol'
  Requesting reviewers 'finxol'
  Error: Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the honojs/middleware repository. - https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
```

[^1]: https://github.com/honojs/middleware/actions/runs/18796556639/job/53637301727
[^2]: https://github.com/honojs/middleware/pull/1229