### PR TITLE
docs(otel): Updates README.md

### DIFF
--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -31,33 +31,37 @@ export default app
 ```
 
 ## Configuration
+
 The middleware allows further customization of several aspects of the instrumentation using the [`HttpInstrumentationConfig`](./src/types.ts#L4) type:
 
 ### Service name and version
+
 `serviceName`, `serviceVersion`.
 These are the name and version of the service that is being instrumented. They are used to create the `Resource` object that is passed to the `Tracer` and `Meter` instances.
 There are no default values for these properties so if you want to set these attributes on spans you will need to pass them in the config.
 
-### Capturing request/response headers 
+### Capturing request/response headers
+
 `captureRequestHeaders`, `captureResponseHeaders`.
 This is an array of header names that should be captured as part of the span. By default, no headers are captured. The captured headers are represented as span attributes under the `http.request.header` key, `http.request.header.x-forwarded-for=["1.2.3.4", "1.2.3.5"]`.
 
 ## Advanced options
 
 ### `tracerProvider`, `meterProvider`, `tracer`
+
 These are the OpenTelemetry SDK components that are used to create the `Tracer` and `Meter` instances. If you want to use a custom `Tracer` or `Meter` instance, you can pass them in here.
 
-
 ### `getTime`
+
 The getTime function is used to get the current time for a span. The middleware uses it to set the start and end times for the span. By default this function is managed by the OpenTelemetry API, and is currently implemented as `Date.now()`.
 
 ### spanNameFactory
+
 `spanNameFactory: (c: HonoContext) => string`
 If you want to customize the name of the spans, you can pass a `spanNameFactory` function in the config.
 This function will be called with the `HonoContext` object as an argument, and should return a string that will be used as the name of the span.
 
 Be mindful that span names are actually defined by OpenTelemetry semantic conventions, and carry expactations about the format of the name.
-
 
 ## Usage on Cloudflare Workers
 


### PR DESCRIPTION
# Why
This PR updates the README for our new `otel` middleware to give more guidance to new users.

#What
Adds more in-depth information regarding configuration of the middleware and advanced options that could be used.

## Note
I've ignored pushing a changeset for this change, as it is a pure docs update. If you disagree with this - just ping and I'll push a patch change!