### PR TITLE
fix(valibot-validator, standard-validator): Fix undefined response

### DIFF
--- a/.changeset/witty-dolls-move.md
+++ b/.changeset/witty-dolls-move.md
@@ -1,0 +1,6 @@
+---
+'@hono/standard-validator': patch
+'@hono/valibot-validator': patch
+---
+
+Fix undefined Response type

--- a/packages/valibot-validator/src/index.test.ts
+++ b/packages/valibot-validator/src/index.test.ts
@@ -1,11 +1,15 @@
+import type { TypedResponse } from 'hono'
 import { Hono } from 'hono'
-import type { Equal, Expect } from 'hono/utils/types'
-import type { InferIssue } from 'valibot'
+import type { Equal, Expect, UnionToIntersection } from 'hono/utils/types'
+import type { InferIssue, NumberIssue, ObjectIssue, StringIssue } from 'valibot'
 import { number, object, objectAsync, optional, optionalAsync, string } from 'valibot'
+import type { FailedResponse } from '.'
 import { vValidator } from '.'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ExtractSchema<T> = T extends Hono<infer _, infer S> ? S : never
+type MergeDiscriminatedUnion<U> =
+  UnionToIntersection<U> extends infer O ? { [K in keyof O]: O[K] } : never
 
 describe('Basic', () => {
   const app = new Hono()
@@ -22,11 +26,8 @@ describe('Basic', () => {
     })
   )
 
-  const route = app.post(
-    '/author',
-    vValidator('json', schema),
-    vValidator('query', querySchema),
-    (c) => {
+  const route = app
+    .post('/author', vValidator('json', schema), vValidator('query', querySchema), (c) => {
       const data = c.req.valid('json')
       const query = c.req.valid('query')
 
@@ -37,113 +38,141 @@ describe('Basic', () => {
         },
         200
       )
-    }
-  )
+    })
+    .post(
+      '/with-hook',
+      vValidator('query', querySchema, (result, c) => {
+        if (!result.success) {
+          return c.text('Invalid query', 400)
+        }
+      }),
+      vValidator('json', schema, (result, c) => {
+        if (!result.success) {
+          if (!result.typed) return c.text('Invalid data', 400)
+          else
+            return undefined as unknown as FailedResponse<typeof schema> &
+              TypedResponse<{ typed: true }, 400, 'json'>
+        }
+      }),
+      (c) => {
+        const data = c.req.valid('json')
+        return c.json(data, 200)
+      }
+    )
 
   type Actual = ExtractSchema<typeof route>
-  type Expected = {
-    '/author': {
-      $post:
-        | {
-            input: {
-              json: {
-                name: string
-                age: number
-              }
-            } & {
-              query?:
-                | {
-                    search?: string | string[] | undefined
-                    page?: string | string[] | undefined
-                  }
-                | undefined
+  type withoutHook_verifyInput = Expect<
+    Equal<
+      {
+        json: {
+          name: string
+          age: number
+        }
+        query?:
+          | {
+              search?: string | string[] | undefined
+              page?: string | string[] | undefined
             }
-            output: {
-              success: boolean
-              message: string
-            }
-            outputFormat: 'json'
-            status: 200
+          | undefined
+      },
+      MergeDiscriminatedUnion<(Actual['/author']['$post'] & { status: 200 })['input']>
+    >
+  >
+  type withoutHook_verifySuccessOutput = Expect<
+    Equal<
+      {
+        success: boolean
+        message: string
+      },
+      MergeDiscriminatedUnion<(Actual['/author']['$post'] & { status: 200 })['output']>
+    >
+  >
+  type withoutHook_verifyErrorOutput = Expect<
+    Equal<
+      | {
+          readonly typed: true
+          readonly success: false
+          readonly output: {
+            name: string
+            age: number
           }
-        | {
-            input: {
-              json: {
-                name: string
-                age: number
+          readonly issues: [
+            StringIssue | NumberIssue | ObjectIssue,
+            ...(StringIssue | NumberIssue | ObjectIssue)[],
+          ]
+        }
+      | {
+          readonly typed: false
+          readonly success: false
+          readonly output: unknown
+          readonly issues: [
+            StringIssue | NumberIssue | ObjectIssue,
+            ...(StringIssue | NumberIssue | ObjectIssue)[],
+          ]
+        }
+      | {
+          readonly typed: true
+          readonly success: false
+          readonly output:
+            | {
+                search?: string | undefined
+                page?: number | undefined
               }
-            } & {
-              query?:
-                | {
-                    search?: string | string[] | undefined
-                    page?: string | string[] | undefined
-                  }
-                | undefined
-            }
-            output:
-              | {
-                  readonly typed: true
-                  readonly success: false
-                  readonly output: {
-                    name: string
-                    age: number
-                  }
-                  readonly issues: [InferIssue<typeof schema>, ...InferIssue<typeof schema>[]]
-                }
-              | {
-                  readonly typed: false
-                  readonly success: false
-                  readonly output: unknown
-                  readonly issues: [InferIssue<typeof schema>, ...InferIssue<typeof schema>[]]
-                }
-            outputFormat: 'json'
-            status: 400
-          }
-        | {
-            input: {
-              json: {
-                name: string
-                age: number
-              }
-            } & {
-              query?:
-                | {
-                    search?: string | string[] | undefined
-                    page?: string | string[] | undefined
-                  }
-                | undefined
-            }
-            output:
-              | {
-                  readonly typed: true
-                  readonly success: false
-                  readonly output:
-                    | {
-                        search?: string | undefined
-                        page?: number | undefined
-                      }
-                    | undefined
-                  readonly issues: [
-                    InferIssue<typeof querySchema>,
-                    ...InferIssue<typeof querySchema>[],
-                  ]
-                }
-              | {
-                  readonly typed: false
-                  readonly success: false
-                  readonly output: unknown
-                  readonly issues: [
-                    InferIssue<typeof querySchema>,
-                    ...InferIssue<typeof querySchema>[],
-                  ]
-                }
-            outputFormat: 'json'
-            status: 400
-          }
-    }
-  }
+            | undefined
+          readonly issues: [
+            StringIssue | NumberIssue | ObjectIssue,
+            ...(StringIssue | NumberIssue | ObjectIssue)[],
+          ]
+        },
+      (Actual['/author']['$post'] & { status: 400 })['output']
+    >
+  >
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  type verify = Expect<Equal<Expected, Actual>>
+  type withHook_verifyInput = Expect<
+    Equal<
+      {
+        json: {
+          name: string
+          age: number
+        }
+        query?:
+          | {
+              search?: string | string[] | undefined
+              page?: string | string[] | undefined
+            }
+          | undefined
+      },
+      MergeDiscriminatedUnion<(Actual['/with-hook']['$post'] & { status: 200 })['input']>
+    >
+  >
+  type withHook_verifySuccessOutput = Expect<
+    Equal<
+      {
+        name: string
+        age: number
+      },
+      MergeDiscriminatedUnion<(Actual['/with-hook']['$post'] & { status: 200 })['output']>
+    >
+  >
+  type withHook_verifyErrorOutput = Expect<
+    Equal<
+      | ({
+          readonly typed: true
+          readonly success: false
+          readonly output: {
+            name: string
+            age: number
+          }
+          readonly issues: [
+            StringIssue | NumberIssue | ObjectIssue,
+            ...(StringIssue | NumberIssue | ObjectIssue)[],
+          ]
+        } & { typed: true })
+      | 'Invalid query'
+      | 'Invalid data',
+      (Actual['/with-hook']['$post'] & { status: 400 })['output']
+    >
+  >
 
   it('Should return 200 response', async () => {
     const req = new Request('http://localhost/author?search=hello', {


### PR DESCRIPTION
### Summary

I would like to apologize for mistakenly treating undefined as a Response in the previous PR.

Typically, it's `({ success: true }) => undefined`, `({ success: false }) => Response`, and undefined should be ignored. This PR will simply remove the undefined.

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
