### PR TITLE
fix(publish): set access public

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ nmHoistingLimits: workspaces
 
 nodeLinker: node-modules
 
+npmPublishAccess: public
+
 npmPublishProvenance: true
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs


### PR DESCRIPTION
It took me a while to understand what the error in CI meant

```
[@hono/capnweb]: ➤ YN0000: Generating provenance statement because `npmPublishProvenance` setting is set.
[@hono/capnweb]: ➤ YN0033: No authentication configured for request
[@hono/capnweb]: ➤ YN0000: Failed with errors in 1s 614ms
```

Creating a new package in the npm registry defaults to private access, you need to specify if you want it to be public. Which is why the error mentions "No authentication configured for request" because it's attempting to create a private package.

From [Publishing packages with provenance via GitHub Actions](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions)

> If you are publishing a package for the first time you will also need to explicitly set access to public:
> ```sh
> npm publish --provenance --access public
> ```