### PR TITLE
chore(capnweb): `@hono/node-ws` does not refer to workspace

### DIFF
--- a/packages/capnweb/package.json
+++ b/packages/capnweb/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.2",
-    "@hono/node-ws": "workspace:^",
+    "@hono/node-ws": "^1.2.0",
     "@types/ws": "^8.5.0",
     "capnweb": "^0.2.0",
     "hono": "^4.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,7 +1884,7 @@ __metadata:
   resolution: "@hono/capnweb@workspace:packages/capnweb"
   dependencies:
     "@hono/node-server": "npm:^1.19.2"
-    "@hono/node-ws": "workspace:^"
+    "@hono/node-ws": "npm:^1.2.0"
     "@types/ws": "npm:^8.5.0"
     capnweb: "npm:^0.2.0"
     hono: "npm:^4.10.1"
@@ -2128,7 +2128,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hono/node-ws@workspace:^, @hono/node-ws@workspace:packages/node-ws":
+"@hono/node-ws@npm:^1.2.0, @hono/node-ws@workspace:packages/node-ws":
   version: 0.0.0-use.local
   resolution: "@hono/node-ws@workspace:packages/node-ws"
   dependencies:


### PR DESCRIPTION
`@hono/capnweb` does not need `@hono/node-ws` in the workspace. To try to avoid [the error]( https://github.com/honojs/middleware/actions/runs/19985969956/job/57319951082), I will apply this change.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
