### PR TITLE
fix(node-ws): fix WebSocket not working with app.route()

### DIFF
--- a/.changeset/forty-results-speak.md
+++ b/.changeset/forty-results-speak.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': minor
+---
+
+Fix WebSocket connections failing when the endpoint is registered under `app.route()`.

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -103,7 +103,7 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
 
       const request = c.env.incoming as IncomingMessage
 
-      // request オブジェクト自体にマーク（c.env への代入ではなく）
+      // Instead of writing to c.env, use a WeakSet to track the request object directly
       upgradeAllowed.add(request)
       ;(async () => {
         const ws = await nodeUpgradeWebSocket(request)


### PR DESCRIPTION
## Summary

Fix WebSocket connections failing when the endpoint is registered under `app.route()`.

## Problem

When using `app.route()`, WebSocket connections fail with `400 Bad Request`.
```typescript
// ❌ This doesn't work
const subApp = new Hono()
subApp.get('/ws', upgradeWebSocket(() => ({ ... })))
app.route('/api', subApp)

// ✅ This works
app.get('/ws', upgradeWebSocket(() => ({ ... })))
```

## Cause

The original implementation stored a connection symbol in `c.env`:
```typescript
c.env[CONNECTION_SYMBOL_KEY] = connectionSymbol
```

However, this doesn't persist when the WebSocket endpoint is registered via `app.route()`. The exact reason is unclear, but it seems `c.env` reference changes in that case.

## Solution

Instead of writing to `c.env`, use a `WeakSet` to track the `request` object directly. Since `c.env.incoming` (the request object) remains the same reference even through `app.route()`, this approach works reliably.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
