### PR TITLE
docs(hono-mcp): fix variable name mismatch in Streamable HTTP example

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -21,9 +21,9 @@ const mcpServer = new McpServer({
 const transport = new StreamableHTTPTransport()
 
 app.all('/mcp', async (c) => {
-  if (!mcp.isConnected()) {
+  if (!mcpServer.isConnected()) {
     // Connect the mcp with the transport
-    await mcp.connect(transport)
+    await mcpServer.connect(transport)
   }
 
   return transport.handleRequest(c)


### PR DESCRIPTION
### What changed

Fixes a variable name mismatch in the Hono MCP documentation where
`mcp` was referenced instead of the declared `mcpServer`.

### Why

The example does not work when copied as-is. Updating the variable
name makes the snippet runnable out of the box.
