### PR TITLE
fix(swagger-ui): set `<!doctype html>` when serving swagger-ui to avoid quirks mode

### DIFF
--- a/.changeset/curly-actors-sin.md
+++ b/.changeset/curly-actors-sin.md
@@ -1,0 +1,5 @@
+---
+'@hono/swagger-ui': patch
+---
+
+serve swagger-ui with `<!doctype html>`

--- a/packages/swagger-ui/src/index.ts
+++ b/packages/swagger-ui/src/index.ts
@@ -71,6 +71,7 @@ const middleware =
   async (c) => {
     const title = options?.title ?? 'SwaggerUI'
     return c.html(/* html */ `
+      <!doctype html>
       <html lang="en">
         <head>
           <meta charset="utf-8" />


### PR DESCRIPTION
this sets `<!doctype html>` when serving swagger-ui.