### PR TITLE
chore(ua-blocker): remove `@typescript-eslint/restrict-plus-operands` from lint suppressions

### DIFF
--- a/packages/ua-blocker/eslint-suppressions.json
+++ b/packages/ua-blocker/eslint-suppressions.json
@@ -8,10 +8,5 @@
     "@typescript-eslint/require-await": {
       "count": 1
     }
-  },
-  "src/escape.ts": {
-    "@typescript-eslint/restrict-plus-operands": {
-      "count": 1
-    }
   }
 }


### PR DESCRIPTION
The config is not needed now. It prevents the CI error:
https://github.com/honojs/middleware/actions/runs/20775288737/job/59659525125

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
