### PR TITLE
fix(eslint-config): less strict no base to string

### DIFF
--- a/.changeset/moody-actors-share.md
+++ b/.changeset/moody-actors-share.md
@@ -1,0 +1,6 @@
+---
+'@hono/eslint-config': patch
+---
+
+Make `@typescript-eslint/no-base-to-string` less strict,
+allowing `toString()` to be used with `["Error","RegExp","URL","URLSearchParams"]`

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -91,7 +91,14 @@ const config = [
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-unused-vars': 'warn',
       '@typescript-eslint/no-var-requires': 'off',
-      
+
+      '@typescript-eslint/no-base-to-string': [
+        'error',
+        {
+          ignoredTypeNames: ['Error', 'RegExp', 'URL', 'URLSearchParams'],
+        },
+      ],
+
       '@typescript-eslint/restrict-template-expressions': [
         'error',
         {


### PR DESCRIPTION
Make [`@typescript-eslint/no-base-to-string`](https://typescript-eslint.io/rules/no-base-to-string/) less strict, eg; allowing `new URL().toString()`, `new Error().toString()`, etc

Similar to #1681