### PR TITLE
fix: Modify scope to always include profile for Google OAuth

### DIFF
--- a/packages/oauth-providers/src/providers/google/googleAuth.ts
+++ b/packages/oauth-providers/src/providers/google/googleAuth.ts
@@ -26,7 +26,8 @@ export function googleAuth(options: {
       login_hint: options.login_hint,
       prompt: options.prompt,
       access_type: options.access_type,
-      scope: options.scope,
+      // profile scope is always mandatory because https://www.googleapis.com/oauth2/v2/userinfo needs it
+      scope: options.includes("profile") ? options.scope : ["profile", ...options.scope],
       state: newState,
       code: c.req.query('code'),
       token: {


### PR DESCRIPTION
Ensure profile scope is included in Google OAuth options.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
