### PR TITLE
chore: update Zod/Valibot import examples to use namespace imports in docs and tests

### DIFF
--- a/packages/conform-validator/README.md
+++ b/packages/conform-validator/README.md
@@ -9,7 +9,7 @@ The validator middleware using [conform](https://conform.guide) for [Hono](https
 Zod:
 
 ```ts
-import { z } from 'zod'
+import * as z from 'zod'
 import { parseWithZod } from '@conform-to/zod'
 import { conformValidator } from '@hono/conform-validator'
 import { HTTPException } from 'hono/http-exception'
@@ -58,14 +58,14 @@ app.post(
 Valibot:
 
 ```ts
-import { object, string } from 'valibot'
+import * as v from 'valibot'
 import { parseWithValibot } from '@conform-to/valibot'
 import { conformValidator } from '@hono/conform-validator'
 import { HTTPException } from 'hono/http-exception'
 
-const schema = object({
-  name: string(),
-  age: string(),
+const schema = v.object({
+  name: v.string(),
+  age: v.string(),
 })
 
 app.post(

--- a/packages/conform-validator/src/common.test.ts
+++ b/packages/conform-validator/src/common.test.ts
@@ -1,6 +1,6 @@
 import { parseWithZod } from '@conform-to/zod/v4'
 import { Hono } from 'hono'
-import { z } from 'zod'
+import * as z from 'zod'
 import { conformValidator } from '.'
 
 describe('Validate common processing', () => {

--- a/packages/standard-validator/README.md
+++ b/packages/standard-validator/README.md
@@ -10,7 +10,7 @@ You can write a schema with any validation library supporting Standard Schema an
 ### Basic:
 
 ```ts
-import { z } from 'zod'
+import * as z from 'zod'
 import { sValidator } from '@hono/standard-validator'
 
 const schema = z.object({
@@ -46,12 +46,12 @@ app.post(
 Headers are internally transformed to lower-case in Hono. Hence, you will have to make them lower-cased in validation object.
 
 ```ts
-import { object, string } from 'valibot'
+import * as v from 'valibot'
 import { sValidator } from '@hono/standard-validator'
 
-const schema = object({
-  'content-type': string(),
-  'user-agent': string(),
+const schema = v.object({
+  'content-type': v.string(),
+  'user-agent': v.string(),
 })
 
 app.post('/author', sValidator('header', schema), (c) => {

--- a/packages/trpc-server/README.md
+++ b/packages/trpc-server/README.md
@@ -17,7 +17,7 @@ Router:
 
 ```ts
 import { initTRPC } from '@trpc/server'
-import { z } from 'zod'
+import * as z from 'zod'
 
 const t = initTRPC.create()
 
@@ -75,7 +75,7 @@ You can also access `c.env` from hono context from the trpc `ctx`. eg. here's an
 
 ```ts
 import { initTRPC } from '@trpc/server'
-import { z } from 'zod'
+import * as z from 'zod'
 
 type Env = {
   DB: D1Database

--- a/packages/trpc-server/src/index.test.ts
+++ b/packages/trpc-server/src/index.test.ts
@@ -1,6 +1,6 @@
 import { initTRPC } from '@trpc/server'
 import { Hono } from 'hono'
-import { z } from 'zod'
+import * as z from 'zod'
 import { trpcServer } from '.'
 
 describe('tRPC Adapter Middleware', () => {

--- a/packages/valibot-validator/README.md
+++ b/packages/valibot-validator/README.md
@@ -8,12 +8,12 @@ You can write a schema with Valibot and validate the incoming values.
 ## Usage
 
 ```ts
-import { number, object, string } from 'valibot'
+import * as v from 'valibot'
 import { vValidator } from '@hono/valibot-validator'
 
-const schema = object({
-  name: string(),
-  age: number(),
+const schema = v.object({
+  name: v.string(),
+  age: v.number(),
 })
 
 app.post('/author', vValidator('json', schema), (c) => {

--- a/packages/valibot-validator/src/index.test.ts
+++ b/packages/valibot-validator/src/index.test.ts
@@ -2,7 +2,7 @@ import type { TypedResponse } from 'hono'
 import { Hono } from 'hono'
 import type { Equal, Expect, UnionToIntersection } from 'hono/utils/types'
 import type { InferIssue, NumberIssue, ObjectIssue, StringIssue } from 'valibot'
-import { number, object, objectAsync, optional, optionalAsync, string } from 'valibot'
+import * as v from 'valibot'
 import type { FailedResponse } from '.'
 import { vValidator } from '.'
 
@@ -14,15 +14,15 @@ type MergeDiscriminatedUnion<U> =
 describe('Basic', () => {
   const app = new Hono()
 
-  const schema = object({
-    name: string(),
-    age: number(),
+  const schema = v.object({
+    name: v.string(),
+    age: v.number(),
   })
 
-  const querySchema = optional(
-    object({
-      search: optional(string()),
-      page: optional(number()),
+  const querySchema = v.optional(
+    v.object({
+      search: v.optional(v.string()),
+      page: v.optional(v.number()),
     })
   )
 
@@ -218,9 +218,9 @@ describe('Basic', () => {
 describe('With Hook', () => {
   const app = new Hono()
 
-  const schema = object({
-    id: number(),
-    title: string(),
+  const schema = v.object({
+    id: v.number(),
+    title: v.string(),
   })
 
   app.post(
@@ -278,15 +278,15 @@ describe('With Hook', () => {
 describe('Async', () => {
   const app = new Hono()
 
-  const schemaAsync = objectAsync({
-    name: string(),
-    age: number(),
+  const schemaAsync = v.objectAsync({
+    name: v.string(),
+    age: v.number(),
   })
 
-  const querySchemaAsync = optionalAsync(
-    objectAsync({
-      search: optionalAsync(string()),
-      page: optionalAsync(number()),
+  const querySchemaAsync = v.optionalAsync(
+    v.objectAsync({
+      search: v.optionalAsync(v.string()),
+      page: v.optionalAsync(v.number()),
     })
   )
 
@@ -461,9 +461,9 @@ describe('Async', () => {
 describe('With Hook Async', () => {
   const app = new Hono()
 
-  const schemaAsync = objectAsync({
-    id: number(),
-    title: string(),
+  const schemaAsync = v.objectAsync({
+    id: v.number(),
+    title: v.string(),
   })
 
   app.post(
@@ -526,8 +526,8 @@ describe('Test types', () => {
       '/',
       vValidator(
         'query',
-        object({
-          foo: string(),
+        v.object({
+          foo: v.string(),
         })
       ),
       (c) => {

--- a/packages/zod-validator/README.md
+++ b/packages/zod-validator/README.md
@@ -44,11 +44,11 @@ throw a zod validate error instead of directly returning an error response.
 
 ```ts
 // file: validator-wrapper.ts
-import { ZodSchema } from 'zod'
+import * as z from 'zod'
 import type { ValidationTargets } from 'hono'
 import { zValidator as zv } from '@hono/zod-validator'
 
-export const zValidator = <T extends ZodSchema, Target extends keyof ValidationTargets>(
+export const zValidator = <T extends z.ZodSchema, Target extends keyof ValidationTargets>(
   target: Target,
   schema: T
 ) =>


### PR DESCRIPTION
Update Zod and Valibot import examples to use namespace imports to align with the official documentation style.

- Zod: `import { z } from 'zod'` → `import * as z from 'zod'`
- Valibot: `import { object, string, ... } from 'valibot'` → `import * as v from 'valibot'`

## Changes

### Zod (README.md)
- `packages/trpc-server/README.md`: Update 2 import examples
- `packages/conform-validator/README.md`: Update 1 import example
- `packages/standard-validator/README.md`: Update 1 import example
- `packages/zod-validator/README.md`: `import { ZodSchema } from 'zod'` → `import * as z from 'zod'`, `ZodSchema` → `z.ZodSchema`

### Zod (test files)
- `packages/trpc-server/src/index.test.ts`: Update import
- `packages/conform-validator/src/common.test.ts`: Update import

### Valibot (README.md)
- `packages/valibot-validator/README.md`: Update to namespace import with `v.` prefix
- `packages/conform-validator/README.md`: Update Valibot section to namespace import with `v.` prefix
- `packages/standard-validator/README.md`: Update Valibot section to namespace import with `v.` prefix

### Valibot (test files)
- `packages/valibot-validator/src/index.test.ts`: Update to namespace import, prefix all calls with `v.`

## Related

- honojs/hono#4715
- #1738

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset (not needed: docs/test only)
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)