### PR TITLE
chore(ci): narrow prettier scope in ua-blocker sync workflow

### DIFF
--- a/.github/workflows/ci-ua-blocker-sync.yml
+++ b/.github/workflows/ci-ua-blocker-sync.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn workspace @hono/ua-blocker prebuild
 
       - name: Format
-        run: yarn prettier --write . !packages packages/ua-blocker
+        run: yarn prettier --write "packages/ua-blocker"
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
### Problem

 The previous prettier command (`yarn prettier --write . !packages packages/ua-blocker`) targeted the entire repository, 
which caused unintended formatting changes to files outside of `packages/ua-blocker`, including `.github/workflows/cr.yml`.

###  Fix
 
Scoped the prettier command to only `packages/ua-blocker`, since that is the only directory modified by this workflow.

 ```diff
  - run: yarn prettier --write . !packages packages/ua-blocker
  + run: yarn prettier --write "packages/ua-blocker"
```

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
