### PR TITLE
fix(oidc-auth): Add sub and email values back to OidcAuth

### DIFF
--- a/.changeset/all-readers-wink.md
+++ b/.changeset/all-readers-wink.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': patch
+---
+
+Add sub and email values back to OidcAuth

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -23,6 +23,8 @@ export type OidcClaimsHook = (
 
 declare module 'hono' {
   export interface OidcAuthClaims {
+    email?: string
+    sub?: string
     readonly [claim: string]: oauth2.JsonValue | undefined
   }
   interface ContextVariableMap {


### PR DESCRIPTION
Hello maintainers. I am a new contributor but I have done some research before creating this pull request. Please let me know if there's any dispute.

## The Problem

In the README for `@hono/oidc-auth`, it states that this is possible.
```ts
app.get('/', async (c) => {
  const auth = await getAuth(c)
  return c.text(`Hello <${auth?.email}>!`)
})
```

But TypeScript says it doesn't exist, even though this code is valid.
<img width="1308" height="244" alt="image-1" src="https://github.com/user-attachments/assets/35cdafc2-782d-4394-a384-4cfe1e69efda" />


## Points to be made

- `email` and `sub` are stated as a standard claim according to [this website](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims)
- It seems like the key values were lost during a change because of [this pull request](https://github.com/honojs/middleware/pull/711/changes#diff-f8453ba25971e142b0ad63136b93a6dbe1b0fa54843c1b914a6fcac8d9e1b3d4L28)
- `JWTAccessTokenClaims` from `oauth4webapi` does not work as `email` is not provided

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
