### PR TITLE
feat(mcp): relax Accept header validation with opt-in strict mode

### DIFF
--- a/.changeset/relax-accept-header.md
+++ b/.changeset/relax-accept-header.md
@@ -1,0 +1,5 @@
+---
+'@hono/mcp': patch
+---
+
+relax Accept header validation to accept `application/json`, `text/event-stream`, or `*/*` individually, improving compatibility with Gemini CLI, Java MCP SDK, Open WebUI, and curl. Add `strictAcceptHeader` option for strict MCP spec compliance.

--- a/.changeset/relax-accept-header.md
+++ b/.changeset/relax-accept-header.md
@@ -1,5 +1,5 @@
 ---
-'@hono/mcp': patch
+'@hono/mcp': minor
 ---
 
 relax Accept header validation to accept `application/json`, `text/event-stream`, or `*/*` individually, improving compatibility with Gemini CLI, Java MCP SDK, Open WebUI, and curl. Add `strictAcceptHeader` option for strict MCP spec compliance.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -32,6 +32,20 @@ app.all('/mcp', async (c) => {
 export default app
 ```
 
+### Options
+
+The `StreamableHTTPTransport` constructor accepts all options from the MCP SDK's `StreamableHTTPServerTransportOptions`, plus:
+
+- **`strictAcceptHeader`** (default: `false`) — When `false` (the default), the transport accepts POST requests where the `Accept` header contains `application/json`, `text/event-stream`, or `*/*`. This improves compatibility with clients like Gemini CLI, Java MCP SDK, Open WebUI, and curl. When `true`, the transport enforces strict MCP spec compliance, requiring both `application/json` and `text/event-stream` in the `Accept` header.
+
+```ts
+// Permissive mode (default) — works with most HTTP clients
+const transport = new StreamableHTTPTransport()
+
+// Strict mode — requires fully spec-compliant Accept header
+const transport = new StreamableHTTPTransport({ strictAcceptHeader: true })
+```
+
 ## Auth
 
 The simplest way to setup MCP Auth when using 3rd party auth providers.

--- a/packages/mcp/eslint-suppressions.json
+++ b/packages/mcp/eslint-suppressions.json
@@ -157,7 +157,7 @@
       "count": 1
     },
     "@typescript-eslint/no-unsafe-assignment": {
-      "count": 41
+      "count": 42
     },
     "@typescript-eslint/no-unsafe-call": {
       "count": 2

--- a/packages/mcp/src/streamable-http.test.ts
+++ b/packages/mcp/src/streamable-http.test.ts
@@ -22,6 +22,7 @@ interface TestServerConfig {
   eventStore?: EventStore
   onsessioninitialized?: (sessionId: string) => void | Promise<void>
   onsessionclosed?: (sessionId: string) => void
+  strictAcceptHeader?: boolean
 }
 
 /**
@@ -54,6 +55,7 @@ async function createTestServer(
     eventStore: config.eventStore,
     onsessioninitialized: config.onsessioninitialized,
     onsessionclosed: config.onsessionclosed,
+    strictAcceptHeader: config.strictAcceptHeader,
   })
 
   await mcpServer.connect(transport)
@@ -115,6 +117,7 @@ async function createTestAuthServer(
     eventStore: config.eventStore,
     onsessioninitialized: config.onsessioninitialized,
     onsessionclosed: config.onsessionclosed,
+    strictAcceptHeader: config.strictAcceptHeader,
   })
 
   await mcpServer.connect(transport)
@@ -590,10 +593,10 @@ describe('MCP helper', () => {
     expectErrorResponse(errorData, -32000, /Only one SSE stream is allowed per session/)
   })
 
-  it('should reject GET requests without Accept: text/event-stream header', async () => {
+  it('should reject GET requests without acceptable Accept header', async () => {
     sessionId = await initializeServer()
 
-    // Try GET without proper Accept header
+    // Try GET with Accept that doesn't include text/event-stream or */*
     const response = await server.request('/', {
       method: 'GET',
       headers: {
@@ -608,15 +611,94 @@ describe('MCP helper', () => {
     expectErrorResponse(errorData, -32000, /Client must accept text\/event-stream/)
   })
 
-  it('should reject POST requests without proper Accept header', async () => {
+  it('should accept GET requests with Accept: */*', async () => {
     sessionId = await initializeServer()
 
-    // Try POST without Accept: text/event-stream
+    const response = await server.request('/', {
+      method: 'GET',
+      headers: {
+        Accept: '*/*',
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': '2025-03-26',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/event-stream')
+  })
+
+  it('should accept POST requests with Accept: application/json only (permissive default)', async () => {
+    sessionId = await initializeServer()
+
     const response = await server.request('/', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Accept: 'application/json', // Missing text/event-stream
+        Accept: 'application/json',
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': '2025-03-26',
+      },
+      body: JSON.stringify(TEST_MESSAGES.toolsList),
+    })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('should accept POST requests with Accept: text/event-stream only (permissive default)', async () => {
+    sessionId = await initializeServer()
+
+    const response = await server.request('/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': '2025-03-26',
+      },
+      body: JSON.stringify(TEST_MESSAGES.toolsList),
+    })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('should accept POST requests with Accept: */* (permissive default)', async () => {
+    sessionId = await initializeServer()
+
+    const response = await server.request('/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': '2025-03-26',
+      },
+      body: JSON.stringify(TEST_MESSAGES.toolsList),
+    })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('should accept POST requests with no Accept header (permissive default)', async () => {
+    // No Accept header defaults to */* internally
+    const response = await server.request('/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(TEST_MESSAGES.initialize),
+    })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('should reject POST requests with unacceptable Accept header (permissive default)', async () => {
+    sessionId = await initializeServer()
+
+    const response = await server.request('/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/html',
         'mcp-session-id': sessionId,
         'mcp-protocol-version': '2025-03-26',
       },
@@ -628,7 +710,7 @@ describe('MCP helper', () => {
     expectErrorResponse(
       errorData,
       -32000,
-      /Client must accept both application\/json and text\/event-stream/
+      /Client must accept application\/json or text\/event-stream/
     )
   })
 
@@ -2160,6 +2242,61 @@ describe('StreamableHTTPServerTransport DNS rebinding protection', () => {
 
       expect(response2.status).toBe(200)
     })
+  })
+})
+
+describe('strictAcceptHeader option', () => {
+  let server: Hono
+  let transport: StreamableHTTPTransport
+
+  afterEach(async () => {
+    await stopTestServer({ transport })
+  })
+
+  it('should reject POST with Accept: application/json only when strict mode is enabled', async () => {
+    const result = await createTestServer({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      strictAcceptHeader: true,
+    })
+    server = result.server
+    transport = result.transport
+
+    // Initialize first (with both Accept types)
+    const initResponse = await sendPostRequest(server, TEST_MESSAGES.initialize)
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers.get('mcp-session-id') as string
+
+    // Try POST with only application/json
+    const response = await server.request('/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': '2025-03-26',
+      },
+      body: JSON.stringify(TEST_MESSAGES.toolsList),
+    })
+
+    expect(response.status).toBe(406)
+    const errorData = await response.json()
+    expectErrorResponse(
+      errorData,
+      -32000,
+      /Client must accept both application\/json and text\/event-stream/
+    )
+  })
+
+  it('should accept POST with both Accept types when strict mode is enabled', async () => {
+    const result = await createTestServer({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      strictAcceptHeader: true,
+    })
+    server = result.server
+    transport = result.transport
+
+    const response = await sendPostRequest(server, TEST_MESSAGES.initialize)
+    expect(response.status).toBe(200)
   })
 })
 

--- a/packages/mcp/src/streamable-http.ts
+++ b/packages/mcp/src/streamable-http.ts
@@ -54,13 +54,24 @@ export class StreamableHTTPTransport implements Transport {
   #allowedHosts?: string[]
   #allowedOrigins?: string[]
   #enableDnsRebindingProtection: boolean
+  #strictAcceptHeader: boolean
 
   sessionId?: string
   onclose?: () => void
   onerror?: (error: Error) => void
   onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void
 
-  constructor(options?: StreamableHTTPServerTransportOptions) {
+  constructor(
+    options?: StreamableHTTPServerTransportOptions & {
+      /**
+       * When `true`, strictly requires both `application/json` and `text/event-stream`
+       * in the `Accept` header per the MCP spec. When `false` (the default), accepts
+       * any of `application/json`, `text/event-stream`, or `*\/\*`, improving
+       * compatibility with clients like Gemini CLI, Java MCP SDK, curl, and Open WebUI.
+       */
+      strictAcceptHeader?: boolean
+    }
+  ) {
     this.#sessionIdGenerator = options?.sessionIdGenerator
     this.#enableJsonResponse = options?.enableJsonResponse ?? false
     this.#eventStore = options?.eventStore
@@ -69,6 +80,7 @@ export class StreamableHTTPTransport implements Transport {
     this.#allowedHosts = options?.allowedHosts
     this.#allowedOrigins = options?.allowedOrigins
     this.#enableDnsRebindingProtection = options?.enableDnsRebindingProtection ?? false
+    this.#strictAcceptHeader = options?.strictAcceptHeader ?? false
   }
 
   /**
@@ -148,8 +160,8 @@ export class StreamableHTTPTransport implements Transport {
   private async handleGetRequest(ctx: Context) {
     try {
       // The client MUST include an Accept header, listing text/event-stream as a supported content type.
-      const acceptHeader = ctx.req.header('Accept')
-      if (!acceptHeader?.includes('text/event-stream')) {
+      const getAcceptHeader = ctx.req.header('Accept') ?? '*/*'
+      if (!getAcceptHeader.includes('text/event-stream') && !getAcceptHeader.includes('*/*')) {
         throw new HTTPException(406, {
           res: Response.json({
             jsonrpc: '2.0',
@@ -275,19 +287,23 @@ export class StreamableHTTPTransport implements Transport {
   private async handlePostRequest(ctx: Context, parsedBody?: unknown) {
     try {
       // Validate the Accept header
-      const acceptHeader = ctx.req.header('Accept')
-      // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
-      if (
-        !acceptHeader?.includes('application/json') ||
-        !acceptHeader.includes('text/event-stream')
-      ) {
+      const acceptHeader = ctx.req.header('Accept') ?? '*/*'
+
+      const isAcceptable = this.#strictAcceptHeader
+        ? acceptHeader.includes('application/json') && acceptHeader.includes('text/event-stream')
+        : acceptHeader.includes('application/json') ||
+          acceptHeader.includes('text/event-stream') ||
+          acceptHeader.includes('*/*')
+
+      if (!isAcceptable) {
         throw new HTTPException(406, {
           res: Response.json({
             jsonrpc: '2.0',
             error: {
               code: ErrorCode.ConnectionClosed,
-              message:
-                'Not Acceptable: Client must accept both application/json and text/event-stream',
+              message: this.#strictAcceptHeader
+                ? 'Not Acceptable: Client must accept both application/json and text/event-stream'
+                : 'Not Acceptable: Client must accept application/json or text/event-stream',
             },
             id: null,
           }),


### PR DESCRIPTION
## Summary

- Default to permissive `Accept` header validation in the Streamable HTTP transport — accept `application/json`, `text/event-stream`, or `*/*` individually (and treat missing `Accept` as `*/*`)
- Add `strictAcceptHeader` option to opt in to the original strict behavior (requiring both `application/json` and `text/event-stream`)
- Also accept `*/*` in the GET handler for consistency

## Motivation

The current strict requirement for both `application/json` **and** `text/event-stream` in the `Accept` header breaks compatibility with Gemini CLI, Java MCP SDK, Open WebUI, curl, and any standard HTTP client that doesn't send both. The server already knows whether it's responding with JSON or SSE — pre-rejecting based on `Accept` is unnecessarily strict.

This matches the approach taken in the upstream MCP TypeScript SDK ([modelcontextprotocol/typescript-sdk#551](https://github.com/modelcontextprotocol/typescript-sdk/pull/551)).

Closes #1773

## Test plan

- POST with `Accept: application/json` only → 200
- POST with `Accept: text/event-stream` only → 200
- POST with `Accept: */*` → 200
- POST with no `Accept` header → 200 (defaults to `*/*`)
- POST with `Accept: text/html` only → 406
- POST with `Accept: application/json, text/event-stream` → 200 (fully compliant)
- POST with `strictAcceptHeader: true` and `Accept: application/json` only → 406
- GET with `Accept: */*` → 200 (SSE stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)