### PR TITLE
fix(swagger-ui): do not delete version and baseUrl from the passed swagger ui options ref

### DIFF
--- a/.changeset/warm-foxes-scream.md
+++ b/.changeset/warm-foxes-scream.md
@@ -1,0 +1,5 @@
+---
+'@hono/swagger-ui': patch
+---
+
+do not delete version and baseUrl from the passed swagger ui options ref

--- a/packages/swagger-ui/src/index.test.ts
+++ b/packages/swagger-ui/src/index.test.ts
@@ -143,4 +143,26 @@ describe('SwaggerUI Middleware', () => {
     expect(html).toContain('{"info":{"title":"Custom UI","version":"1.0.0"}}') // RENDER_TYPE.JSON_STRING
     expect(html).toContain('window.ui = SwaggerUIBundle({') // entry point of SwaggerUI
   })
+
+  it('should handle baseUrl correctly', async () => {
+    app.get(
+      '/',
+      swaggerUI({
+        url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+        baseUrl: '/docs',
+      })
+    )
+
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('/docs/swagger-ui-dist/swagger-ui.css') // CSS URL should be correct
+    expect(html).toContain('/docs/swagger-ui-dist/swagger-ui-bundle.js') // JS URL should be correct
+
+    const res2 = await app.request('/')
+    expect(res2.status).toBe(200)
+    const html2 = await res2.text()
+    expect(html2).toContain('/docs/swagger-ui-dist/swagger-ui.css') // CSS URL should be correct
+    expect(html2).toContain('/docs/swagger-ui-dist/swagger-ui-bundle.js') // JS URL should be correct
+  })
 })

--- a/packages/swagger-ui/src/index.ts
+++ b/packages/swagger-ui/src/index.ts
@@ -42,13 +42,11 @@ type OriginalSwaggerUIOptions = {
 
 type SwaggerUIOptions = OriginalSwaggerUIOptions & DistSwaggerUIOptions
 
-const SwaggerUI = (options: SwaggerUIOptions): string => {
+const SwaggerUI = ({ baseUrl, version, ...options }: SwaggerUIOptions): string => {
   const asset = remoteAssets({
-    baseUrl: options?.baseUrl,
-    version: options?.version,
+    baseUrl: baseUrl,
+    version: version,
   })
-  delete options.baseUrl
-  delete options.version
 
   if (options.manuallySwaggerUIHtml) {
     return options.manuallySwaggerUIHtml(asset)


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

Currently the @hono/swagger-ui middleware deletes the baseUrl and version from its passed options. This causes the next request serving the swagger-ui to fallback to the default baseUrl and version.