### PR TITLE
feat(cloudflare-access): Add audience (aud) validation and harden JWT verification

### DIFF
--- a/.changeset/small-socks-stare.md
+++ b/.changeset/small-socks-stare.md
@@ -1,0 +1,5 @@
+---
+'@hono/cloudflare-access': minor
+---
+
+Add audience (aud) validation and harden JWT verification

--- a/packages/cloudflare-access/README.md
+++ b/packages/cloudflare-access/README.md
@@ -53,7 +53,7 @@ app.use('*', cloudflareAccess('my-access-team-name'))
 app.get('/', (c) => {
   const payload = c.get('accessPayload')
 
-  return c.text(`You just authenticated with the email ${payload.email}`)
+  return c.text(payload.email ? `Hello, ${payload.email}` : 'Hello, authenticated user')
 })
 
 export default app

--- a/packages/cloudflare-access/README.md
+++ b/packages/cloudflare-access/README.md
@@ -70,7 +70,7 @@ export default app
 | Authentication error: Malformed token payload                                  | 401       |
 | Authentication error: Token is expired                                         | 401       |
 | Authentication error: Token is not yet valid                                   | 401       |
-| Authentication error: Invalid token                                            | 401       |
+| Authentication error: Invalid Token                                            | 401       |
 | Authentication error: Invalid team name                                        | 401       |
 | Authentication error: Invalid token audience                                   | 401       |
 | Invalid accessTeamName: must contain only alphanumeric characters and hyphens  | (throws)  |

--- a/packages/cloudflare-access/README.md
+++ b/packages/cloudflare-access/README.md
@@ -25,6 +25,16 @@ app.get('/', (c) => c.text('foo'))
 export default app
 ```
 
+The `aud` parameter accepts a single string or an array of strings for workers serving multiple Access applications:
+
+```ts
+// Single audience
+app.use('*', cloudflareAccess('my-team', 'aud-tag-1'))
+
+// Multiple audiences (e.g. during application migration)
+app.use('*', cloudflareAccess('my-team', ['aud-tag-1', 'aud-tag-2']))
+```
+
 The `aud` parameter is optional for backwards compatibility, but omitting it is discouraged in production.
 
 ## Access JWT payload

--- a/packages/cloudflare-access/README.md
+++ b/packages/cloudflare-access/README.md
@@ -51,16 +51,20 @@ export default app
 
 ## Errors throw by the middleware
 
-| Error                                                                                                  | HTTP Code |
-| ------------------------------------------------------------------------------------------------------ | --------- |
-| Authentication error: Missing bearer token                                                             | 401       |
-| Authentication error: Unable to decode Bearer token                                                    | 401       |
-| Authentication error: Token is expired                                                                 | 401       |
-| Authentication error: Expected team name {your-team-name}, but received ${different-team-signed-token} | 401       |
-| Authentication error: Invalid Token                                                                    | 401       |
-| Authentication error: Invalid token audience                                                           | 401       |
-| Authentication error: The Access Organization 'my-team-name' does not exist                            | 500       |
-| Authentication error: Received unexpected HTTP code 500 from Cloudflare Access                         | 500       |
+| Error                                                                          | HTTP Code |
+| ------------------------------------------------------------------------------ | --------- |
+| Authentication error: Missing bearer token                                     | 401       |
+| Authentication error: Unable to decode bearer token                            | 401       |
+| Authentication error: Invalid token algorithm                                  | 401       |
+| Authentication error: Malformed token payload                                  | 401       |
+| Authentication error: Token is expired                                         | 401       |
+| Authentication error: Token is not yet valid                                   | 401       |
+| Authentication error: Invalid token                                            | 401       |
+| Authentication error: Invalid team name                                        | 401       |
+| Authentication error: Invalid token audience                                   | 401       |
+| Invalid accessTeamName: must contain only alphanumeric characters and hyphens  | (throws)  |
+| Authentication error: The Access Organization 'my-team-name' does not exist    | 500       |
+| Authentication error: Received unexpected HTTP code 500 from Cloudflare Access | 500       |
 
 ## Author
 

--- a/packages/cloudflare-access/README.md
+++ b/packages/cloudflare-access/README.md
@@ -9,7 +9,7 @@ This middleware can be used to validate that your application is being served be
 JWT received, User details from the JWT are also available inside the request context.
 
 This middleware will also ensure the Access policy serving the application is from a
-specific [Access Team](https://developers.cloudflare.com/cloudflare-one/faq/getting-started-faq/#whats-a-team-domainteam-name).
+specific [Access Team](https://developers.cloudflare.com/cloudflare-one/faq/getting-started-faq/#whats-a-team-domainteam-name). It is strongly recommended to pass your [Application Audience (AUD) Tag](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json/#get-your-aud-tag) to validate that the JWT was intended for your specific application to prevent cross-application token reuse.
 
 ## Usage
 
@@ -19,11 +19,13 @@ import { Hono } from 'hono'
 
 const app = new Hono()
 
-app.use('*', cloudflareAccess('my-access-team-name'))
+app.use('*', cloudflareAccess('my-access-team-name', 'my-application-aud-tag'))
 app.get('/', (c) => c.text('foo'))
 
 export default app
 ```
+
+The `aud` parameter is optional for backwards compatibility, but omitting it is discouraged in production.
 
 ## Access JWT payload
 
@@ -56,6 +58,7 @@ export default app
 | Authentication error: Token is expired                                                                 | 401       |
 | Authentication error: Expected team name {your-team-name}, but received ${different-team-signed-token} | 401       |
 | Authentication error: Invalid Token                                                                    | 401       |
+| Authentication error: Invalid token audience                                                           | 401       |
 | Authentication error: The Access Organization 'my-team-name' does not exist                            | 500       |
 | Authentication error: Received unexpected HTTP code 500 from Cloudflare Access                         | 500       |
 

--- a/packages/cloudflare-access/README.md
+++ b/packages/cloudflare-access/README.md
@@ -31,7 +31,7 @@ The `aud` parameter accepts a single string or an array of strings for workers s
 // Single audience
 app.use('*', cloudflareAccess('my-team', 'aud-tag-1'))
 
-// Multiple audiences (e.g. during application migration)
+// Multiple audiences (e.g. production and preview applications)
 app.use('*', cloudflareAccess('my-team', ['aud-tag-1', 'aud-tag-2']))
 ```
 
@@ -64,7 +64,7 @@ export default app
 | Error                                                                          | HTTP Code |
 | ------------------------------------------------------------------------------ | --------- |
 | Authentication error: Missing bearer token                                     | 401       |
-| Authentication error: Unable to decode bearer token                            | 401       |
+| Authentication error: Unable to decode Bearer token                            | 401       |
 | Authentication error: Invalid token algorithm                                  | 401       |
 | Authentication error: Unsupported critical extension                           | 401       |
 | Authentication error: Malformed token payload                                  | 401       |

--- a/packages/cloudflare-access/README.md
+++ b/packages/cloudflare-access/README.md
@@ -66,6 +66,7 @@ export default app
 | Authentication error: Missing bearer token                                     | 401       |
 | Authentication error: Unable to decode bearer token                            | 401       |
 | Authentication error: Invalid token algorithm                                  | 401       |
+| Authentication error: Unsupported critical extension                           | 401       |
 | Authentication error: Malformed token payload                                  | 401       |
 | Authentication error: Token is expired                                         | 401       |
 | Authentication error: Token is not yet valid                                   | 401       |

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -109,34 +109,7 @@ function generateJWT(
   payload: Record<string, unknown>,
   expiresIn: number = 3600
 ): string {
-  // Create header
-  const header = {
-    alg: 'RS256',
-    typ: 'JWT',
-  }
-
-  // Add expiration to payload
-  const now = Math.floor(Date.now() / 1000)
-  const fullPayload = {
-    ...payload,
-    iat: now,
-    exp: now + expiresIn,
-  }
-
-  // Encode header and payload
-  const encodedHeader = base64URLEncode(JSON.stringify(header))
-  const encodedPayload = base64URLEncode(JSON.stringify(fullPayload))
-
-  // Create signature
-  const signatureInput = `${encodedHeader}.${encodedPayload}`
-  const signer = crypto.createSign('RSA-SHA256')
-  signer.update(signatureInput)
-  const signature = signer.sign(privateKey)
-  // @ts-expect-error signature is not typed correctly
-  const encodedSignature = base64URLEncode(signature)
-
-  // Combine all parts
-  return `${encodedHeader}.${encodedPayload}.${encodedSignature}`
+  return generateJWTWithHeader(privateKey, { alg: 'RS256', typ: 'JWT' }, payload, expiresIn)
 }
 
 describe('Cloudflare Access middleware', async () => {
@@ -145,7 +118,7 @@ describe('Cloudflare Access middleware', async () => {
   const keyPair3 = await generateJWTKeyPair()
 
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.restoreAllMocks()
     vi.stubGlobal('fetch', () => {
       return Response.json({
         keys: [publicKeyToJWK(keyPair1.publicKey), publicKeyToJWK(keyPair2.publicKey)],
@@ -175,7 +148,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Missing bearer token')
   })
 
-  it('Should throw Unable to decode Bearer token when sending garbage', async () => {
+  it('Should throw unable to decode bearer token when sending garbage', async () => {
     const res = await app.request('http://localhost/hello-behind-access', {
       headers: {
         'cf-access-jwt-assertion': 'asdasdasda',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -607,6 +607,102 @@ describe('Cloudflare Access middleware', async () => {
     vi.useRealTimers()
   })
 
+  it('Should re-fetch JWKS when token has unknown kid (key rotation)', async () => {
+    vi.useFakeTimers()
+
+    const jwk1 = publicKeyToJWK(keyPair1.publicKey)
+    const jwk3 = publicKeyToJWK(keyPair3.publicKey)
+
+    // Initially only serve keyPair1
+    let fetchCount = 0
+    const fetchSpy = vi.fn(() => {
+      fetchCount++
+      // After first fetch, also serve keyPair3 (simulating key rotation)
+      const keys = fetchCount === 1 ? [jwk1] : [jwk1, jwk3]
+      return Promise.resolve(Response.json({ keys }))
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    // First request with keyPair1 — fetches keys
+    const token1 = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+    const res1 = await freshApp.request('http://localhost/hello-behind-access', {
+      headers: { 'cf-access-jwt-assertion': token1 },
+    })
+    expect(res1.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    // Advance past the re-fetch rate limit (60s)
+    vi.advanceTimersByTime(61 * 1000)
+
+    // Request with keyPair3 and its kid — should trigger re-fetch since kid is unknown
+    const token3 = generateJWTWithHeader(
+      keyPair3.privateKey,
+      { alg: 'RS256', typ: 'JWT', kid: jwk3.kid },
+      {
+        sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      }
+    )
+    const res3 = await freshApp.request('http://localhost/hello-behind-access', {
+      headers: { 'cf-access-jwt-assertion': token3 },
+    })
+    expect(res3.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+
+    vi.useRealTimers()
+  })
+
+  it('Should rate-limit JWKS re-fetches on unknown kid to prevent DoS', async () => {
+    vi.useFakeTimers()
+
+    const jwk1 = publicKeyToJWK(keyPair1.publicKey)
+    const fetchSpy = vi.fn(() =>
+      Promise.resolve(Response.json({ keys: [jwk1] }))
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    // First request fetches keys
+    const token1 = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+    await freshApp.request('http://localhost/hello-behind-access', {
+      headers: { 'cf-access-jwt-assertion': token1 },
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    // Immediately send tokens with forged kids — should NOT trigger re-fetches
+    for (let i = 0; i < 5; i++) {
+      const forgedToken = generateJWTWithHeader(
+        keyPair3.privateKey,
+        { alg: 'RS256', typ: 'JWT', kid: `forged-kid-${i}` },
+        {
+          sub: '1234567890',
+          iss: 'https://my-cool-team-name.cloudflareaccess.com',
+        }
+      )
+      await freshApp.request('http://localhost/hello-behind-access', {
+        headers: { 'cf-access-jwt-assertion': forgedToken },
+      })
+    }
+
+    // Should still be 1 — rate limiter prevents re-fetches within 60s
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
+
   it('Should throw when accessTeamName contains invalid characters', () => {
     expect(() => cloudflareAccess('my team/name')).toThrow(
       'Invalid accessTeamName: must contain only alphanumeric characters and hyphens'

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -84,6 +84,7 @@ function generateJWTWithHeader(
   payload: Record<string, unknown>,
   expiresIn: number = 3600
 ): string {
+  // Add expiration to payload
   const now = Math.floor(Date.now() / 1000)
   const fullPayload = {
     ...payload,
@@ -91,9 +92,11 @@ function generateJWTWithHeader(
     exp: now + expiresIn,
   }
 
+  // Encode header and payload
   const encodedHeader = base64URLEncode(JSON.stringify(header))
   const encodedPayload = base64URLEncode(JSON.stringify(fullPayload))
 
+  // Create signature
   const signatureInput = `${encodedHeader}.${encodedPayload}`
   const signer = crypto.createSign('RSA-SHA256')
   signer.update(signatureInput)
@@ -101,6 +104,7 @@ function generateJWTWithHeader(
   // @ts-expect-error signature is not typed correctly
   const encodedSignature = base64URLEncode(signature)
 
+  // Combine all parts
   return `${encodedHeader}.${encodedPayload}.${encodedSignature}`
 }
 

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -261,6 +261,65 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('foo')
   })
 
+  it('Should reject token with wrong audience when aud is configured', async () => {
+    const appWithAud = new Hono()
+    appWithAud.use('/*', cloudflareAccess('my-cool-team-name', 'expected-aud-tag'))
+    appWithAud.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      aud: ['wrong-aud-tag'],
+    })
+
+    const res = await appWithAud.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Invalid token audience')
+  })
+
+  it('Should accept token with correct audience when aud is configured', async () => {
+    const appWithAud = new Hono()
+    appWithAud.use('/*', cloudflareAccess('my-cool-team-name', 'expected-aud-tag'))
+    appWithAud.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      aud: ['expected-aud-tag'],
+    })
+
+    const res = await appWithAud.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
+  it('Should skip audience check when aud is not configured', async () => {
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      aud: ['any-aud-tag'],
+    })
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
   it('Should be able to retrieve the JWT payload from Hono context', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: '1234567890',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -165,6 +165,7 @@ describe('Cloudflare Access middleware', async () => {
       keyPair1.privateKey,
       {
         sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
       },
       -3600
     )

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -1042,6 +1042,25 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Unable to decode Bearer token')
   })
 
+  it('Should reject tokens with invalid base64url characters in the signature segment', async () => {
+    const validToken = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+    const parts = validToken.split('.')
+    // Replace signature with characters invalid in base64url (e.g. '!@#')
+    const corruptedToken = `${parts[0]}.${parts[1]}.!@#$`
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': corruptedToken,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Unable to decode Bearer token')
+  })
+
   it('Should correctly decode tokens with base64url characters in payload', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: 'user+test/special_chars',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -1062,7 +1062,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    const payload = await res.json()
+    const payload = await res.json() as { sub: string }
     expect(payload.sub).toBe('user+test/special_chars')
   })
 })

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -344,6 +344,48 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Invalid token audience')
   })
 
+  it('Should accept token matching one of multiple configured audiences', async () => {
+    const appWithAuds = new Hono()
+    appWithAuds.use('/*', cloudflareAccess('my-cool-team-name', ['aud-one', 'aud-two']))
+    appWithAuds.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      aud: ['aud-two'],
+    })
+
+    const res = await appWithAuds.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
+  it('Should reject token matching none of multiple configured audiences', async () => {
+    const appWithAuds = new Hono()
+    appWithAuds.use('/*', cloudflareAccess('my-cool-team-name', ['aud-one', 'aud-two']))
+    appWithAuds.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      aud: ['aud-three'],
+    })
+
+    const res = await appWithAuds.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Invalid token audience')
+  })
+
   it('Should skip audience check when aud is not configured', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: '1234567890',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -346,7 +346,13 @@ describe('Cloudflare Access middleware', async () => {
       return Response.json({ success: false }, { status: 404 })
     })
 
-    const res = await app.request('http://localhost/hello-behind-access', {
+    // Use a fresh app so the middleware has no cached keys
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+    freshApp.onError((err, c) => c.json({ err: err.toString() }, 500))
+
+    const res = await freshApp.request('http://localhost/hello-behind-access', {
       headers: {
         'cf-access-jwt-assertion': 'asdads',
       },
@@ -363,7 +369,13 @@ describe('Cloudflare Access middleware', async () => {
       return Response.json({ success: false }, { status: 500 })
     })
 
-    const res = await app.request('http://localhost/hello-behind-access', {
+    // Use a fresh app so the middleware has no cached keys
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+    freshApp.onError((err, c) => c.json({ err: err.toString() }, 500))
+
+    const res = await freshApp.request('http://localhost/hello-behind-access', {
       headers: {
         'cf-access-jwt-assertion': 'asdads',
       },

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -516,6 +516,45 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('foo')
   })
 
+  it('Should reject token expired beyond clock skew leeway (30s)', async () => {
+    // Token that expired 31 seconds ago — outside 30s leeway
+    const token = generateJWT(
+      keyPair1.privateKey,
+      {
+        sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      },
+      -31
+    )
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Token is expired')
+  })
+
+  it('Should reject token with nbf beyond clock skew leeway (30s)', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      nbf: now + 31, // 31 seconds in the future, outside 30s leeway
+    })
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Token is not yet valid')
+  })
+
   it('Should accept token with nbf slightly in the future within clock skew leeway', async () => {
     const now = Math.floor(Date.now() / 1000)
     const token = generateJWT(keyPair1.privateKey, {

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -565,6 +565,167 @@ describe('Cloudflare Access middleware', async () => {
     expect(text).not.toContain('my-cool-team-name')
   })
 
+  it('Should reject tokens with more than 3 dot-separated parts (JWE format)', async () => {
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+    // Append extra parts to simulate a JWE-like token
+    const jweToken = `${token}.extrapart.anotherpart`
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': jweToken,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
+  })
+
+  it('Should reject tokens with fewer than 3 dot-separated parts', async () => {
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': 'part1.part2',
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
+  })
+
+  it('Should reject tokens with crit header parameter', async () => {
+    const token = generateJWTWithHeader(
+      keyPair1.privateKey,
+      { alg: 'RS256', typ: 'JWT', crit: ['exp'] },
+      {
+        sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      }
+    )
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Unsupported critical extension')
+  })
+
+  it('Should use kid header to select the correct key for verification', async () => {
+    const jwk1 = publicKeyToJWK(keyPair1.publicKey)
+    const jwk2 = publicKeyToJWK(keyPair2.publicKey)
+
+    const fetchSpy = vi.fn(() =>
+      Promise.resolve(Response.json({ keys: [jwk1, jwk2] }))
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    // Generate token with kid matching keyPair2
+    const token = generateJWTWithHeader(
+      keyPair2.privateKey,
+      { alg: 'RS256', typ: 'JWT', kid: jwk2.kid },
+      {
+        sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      }
+    )
+
+    const res = await freshApp.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
+  it('Should reject token when kid does not match any known key and signature is invalid', async () => {
+    const token = generateJWTWithHeader(
+      keyPair3.privateKey,
+      { alg: 'RS256', typ: 'JWT', kid: 'nonexistent-kid' },
+      {
+        sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      }
+    )
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Invalid token')
+  })
+
+  it('Should skip non-RSA keys from JWKS response', async () => {
+    const jwk1 = publicKeyToJWK(keyPair1.publicKey)
+    vi.stubGlobal('fetch', () =>
+      Response.json({
+        keys: [
+          { kid: 'ec-key', kty: 'EC', use: 'sig', crv: 'P-256', x: 'abc', y: 'def' },
+          jwk1,
+        ],
+      })
+    )
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+
+    const res = await freshApp.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
+  it('Should skip keys with use != sig from JWKS response', async () => {
+    const jwk1 = publicKeyToJWK(keyPair1.publicKey)
+    const encKey = { ...publicKeyToJWK(keyPair2.publicKey), use: 'enc' }
+    vi.stubGlobal('fetch', () =>
+      Response.json({
+        keys: [encKey, jwk1],
+      })
+    )
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    // Token signed with keyPair2 (whose public key has use='enc') should fail
+    const token = generateJWT(keyPair2.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+
+    const res = await freshApp.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Invalid token')
+  })
+
   it('Should correctly decode tokens with base64url characters in payload', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: 'user+test/special_chars',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -521,9 +521,7 @@ describe('Cloudflare Access middleware', async () => {
   it('Should warn when aud is omitted', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     cloudflareAccess('my-cool-team-name')
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('No aud parameter provided')
-    )
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No aud parameter provided'))
     warnSpy.mockRestore()
   })
 

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -157,7 +157,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Unable to decode Bearer token')
+    expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
   })
 
   it('Should be throw Token is expired when sending expired token', async () => {
@@ -209,7 +209,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Invalid Token')
+    expect(await res.text()).toBe('Authentication error: Invalid token')
   })
 
   it('Should work when sending everything correctly', async () => {

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -78,6 +78,32 @@ function base64URLEncode(str: string): string {
     .replace(/=/g, '')
 }
 
+function generateJWTWithHeader(
+  privateKey: string,
+  header: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  expiresIn: number = 3600
+): string {
+  const now = Math.floor(Date.now() / 1000)
+  const fullPayload = {
+    ...payload,
+    iat: now,
+    exp: now + expiresIn,
+  }
+
+  const encodedHeader = base64URLEncode(JSON.stringify(header))
+  const encodedPayload = base64URLEncode(JSON.stringify(fullPayload))
+
+  const signatureInput = `${encodedHeader}.${encodedPayload}`
+  const signer = crypto.createSign('RSA-SHA256')
+  signer.update(signatureInput)
+  const signature = signer.sign(privateKey)
+  // @ts-expect-error signature is not typed correctly
+  const encodedSignature = base64URLEncode(signature)
+
+  return `${encodedHeader}.${encodedPayload}.${encodedSignature}`
+}
+
 function generateJWT(
   privateKey: string,
   payload: Record<string, unknown>,
@@ -384,5 +410,161 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.json()).toEqual({
       err: 'Error: Authentication error: Received unexpected HTTP code 500 from Cloudflare Access',
     })
+  })
+
+  it('Should reject token with future nbf', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      nbf: now + 3600, // 1 hour in the future
+    })
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Token is not yet valid')
+  })
+
+  it('Should reject token with non-RS256 algorithm', async () => {
+    const token = generateJWTWithHeader(
+      keyPair1.privateKey,
+      { alg: 'HS256', typ: 'JWT' },
+      {
+        sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      }
+    )
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Invalid token algorithm')
+  })
+
+  it('Should reject token with missing exp', async () => {
+    // Manually construct a token without exp
+    const header = base64URLEncode(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+    const payload = base64URLEncode(
+      JSON.stringify({
+        sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
+        iat: Math.floor(Date.now() / 1000),
+      })
+    )
+    const signatureInput = `${header}.${payload}`
+    const signer = crypto.createSign('RSA-SHA256')
+    signer.update(signatureInput)
+    const signature = signer.sign(keyPair1.privateKey)
+    // @ts-expect-error signature is not typed correctly
+    const encodedSignature = base64URLEncode(signature)
+    const token = `${header}.${payload}.${encodedSignature}`
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Malformed token payload')
+  })
+
+  it('Should re-fetch keys after cache expiration', async () => {
+    const fetchSpy = vi.fn(() =>
+      Promise.resolve(
+        Response.json({
+          keys: [publicKeyToJWK(keyPair1.publicKey), publicKeyToJWK(keyPair2.publicKey)],
+        })
+      )
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+
+    // First request fetches keys
+    await freshApp.request('http://localhost/hello-behind-access', {
+      headers: { 'cf-access-jwt-assertion': token },
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    // Second request uses cache
+    await freshApp.request('http://localhost/hello-behind-access', {
+      headers: { 'cf-access-jwt-assertion': token },
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('Should throw when accessTeamName contains invalid characters', () => {
+    expect(() => cloudflareAccess('my team/name')).toThrow(
+      'Invalid accessTeamName: must contain only alphanumeric characters and hyphens'
+    )
+    expect(() => cloudflareAccess('team.name')).toThrow()
+    expect(() => cloudflareAccess('')).toThrow()
+  })
+
+  it('Should warn when aud is omitted', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    cloudflareAccess('my-cool-team-name')
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No aud parameter provided')
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('Should not warn when aud is provided', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    cloudflareAccess('my-cool-team-name', 'my-aud-tag')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('Should return generic error for issuer mismatch without leaking details', async () => {
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://attacker-team.cloudflareaccess.com',
+    })
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    const text = await res.text()
+    expect(text).toBe('Authentication error: Invalid team name')
+    expect(text).not.toContain('attacker-team')
+    expect(text).not.toContain('my-cool-team-name')
+  })
+
+  it('Should correctly decode tokens with base64url characters in payload', async () => {
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: 'user+test/special_chars',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+
+    const res = await app.request('http://localhost/access-payload', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    const payload = await res.json()
+    expect(payload.sub).toBe('user+test/special_chars')
   })
 })

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import crypto from 'crypto'
 import { promisify } from 'util'
@@ -142,14 +142,14 @@ describe('Cloudflare Access middleware', async () => {
     )
   })
 
-  it('Should be throw Missing bearer token when nothing is sent', async () => {
+  it('Should throw Missing bearer token when nothing is sent', async () => {
     const res = await app.request('http://localhost/hello-behind-access')
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
     expect(await res.text()).toBe('Authentication error: Missing bearer token')
   })
 
-  it('Should be throw Unable to decode Bearer token when sending garbage', async () => {
+  it('Should throw Unable to decode Bearer token when sending garbage', async () => {
     const res = await app.request('http://localhost/hello-behind-access', {
       headers: {
         'cf-access-jwt-assertion': 'asdasdasda',
@@ -160,7 +160,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
   })
 
-  it('Should be throw Token is expired when sending expired token', async () => {
+  it('Should throw Token is expired when sending expired token', async () => {
     const token = generateJWT(
       keyPair1.privateKey,
       {
@@ -196,7 +196,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Invalid team name')
   })
 
-  it('Should be throw Invalid token when sending token signed with private key not in the allowed list', async () => {
+  it('Should throw Invalid token when sending token signed with private key not in the allowed list', async () => {
     const token = generateJWT(keyPair3.privateKey, {
       sub: '1234567890',
       iss: 'https://my-cool-team-name.cloudflareaccess.com',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -141,14 +141,14 @@ describe('Cloudflare Access middleware', async () => {
     )
   })
 
-  it('Should throw Missing bearer token when nothing is sent', async () => {
+  it('Should be throw Missing bearer token when nothing is sent', async () => {
     const res = await app.request('http://localhost/hello-behind-access')
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
     expect(await res.text()).toBe('Authentication error: Missing bearer token')
   })
 
-  it('Should throw Unable to decode Bearer token when sending garbage', async () => {
+  it('Should be throw Unable to decode Bearer token when sending garbage', async () => {
     const res = await app.request('http://localhost/hello-behind-access', {
       headers: {
         'cf-access-jwt-assertion': 'asdasdasda',
@@ -159,7 +159,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Unable to decode Bearer token')
   })
 
-  it('Should throw Token is expired when sending expired token', async () => {
+  it('Should be throw Token is expired when sending expired token', async () => {
     const token = generateJWT(
       keyPair1.privateKey,
       {
@@ -179,7 +179,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Token is expired')
   })
 
-  it('Should throw Invalid team name when sending invalid iss', async () => {
+  it('Should be throw Invalid team name when sending invalid iss', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: '1234567890',
       iss: 'https://different-team.cloudflareaccess.com',
@@ -195,7 +195,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Invalid team name')
   })
 
-  it('Should throw Invalid token when sending token signed with private key not in the allowed list', async () => {
+  it('Should be throw Invalid token when sending token signed with private key not in the allowed list', async () => {
     const token = generateJWT(keyPair3.privateKey, {
       sub: '1234567890',
       iss: 'https://my-cool-team-name.cloudflareaccess.com',
@@ -208,7 +208,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Invalid token')
+    expect(await res.text()).toBe('Authentication error: Invalid Token')
   })
 
   it('Should work when sending everything correctly', async () => {
@@ -833,7 +833,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Invalid token')
+    expect(await res.text()).toBe('Authentication error: Invalid Token')
   })
 
   it('Should skip non-RSA keys from JWKS response', async () => {
@@ -889,7 +889,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Invalid token')
+    expect(await res.text()).toBe('Authentication error: Invalid Token')
   })
 
   it('Should skip keys with key_ops that does not include verify', async () => {
@@ -919,7 +919,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Invalid token')
+    expect(await res.text()).toBe('Authentication error: Invalid Token')
   })
 
   it('Should accept keys with key_ops that includes verify', async () => {
@@ -976,7 +976,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Invalid token')
+    expect(await res.text()).toBe('Authentication error: Invalid Token')
   })
 
   it('Should reject tokens with whitespace or invalid characters in base64url segments', async () => {

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -1016,7 +1016,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(200)
-    const payload = await res.json() as { sub: string }
+    const payload = (await res.json()) as { sub: string }
     expect(payload.sub).toBe('user+test/special_chars')
   })
 })

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -180,7 +180,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Token is expired')
   })
 
-  it('Should be throw Expected team name x, but received y when sending invalid iss', async () => {
+  it('Should throw Invalid team name when sending invalid iss', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: '1234567890',
       iss: 'https://different-team.cloudflareaccess.com',
@@ -193,9 +193,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe(
-      'Authentication error: Expected team name https://my-cool-team-name.cloudflareaccess.com, but received https://different-team.cloudflareaccess.com'
-    )
+    expect(await res.text()).toBe('Authentication error: Invalid team name')
   })
 
   it('Should be throw Invalid token when sending token signed with private key not in the allowed list', async () => {

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -726,6 +726,93 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Invalid token')
   })
 
+  it('Should skip keys with key_ops that does not include verify', async () => {
+    const jwk1 = publicKeyToJWK(keyPair1.publicKey)
+    // Key with key_ops that doesn't include 'verify' — should be skipped
+    const encryptOnlyKey = { ...publicKeyToJWK(keyPair2.publicKey), key_ops: ['encrypt'] }
+    vi.stubGlobal('fetch', () =>
+      Response.json({
+        keys: [encryptOnlyKey, jwk1],
+      })
+    )
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    // Token signed with keyPair2 (whose public key has key_ops=['encrypt']) should fail
+    const token = generateJWT(keyPair2.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+
+    const res = await freshApp.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Invalid token')
+  })
+
+  it('Should accept keys with key_ops that includes verify', async () => {
+    const jwk1 = { ...publicKeyToJWK(keyPair1.publicKey), key_ops: ['verify'] }
+    vi.stubGlobal('fetch', () =>
+      Response.json({
+        keys: [jwk1],
+      })
+    )
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+
+    const res = await freshApp.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
+  it('Should skip keys without a kid field', async () => {
+    const jwk1 = publicKeyToJWK(keyPair1.publicKey)
+    // Key without kid — should be skipped
+    const { kid: _kid, ...noKidKey } = publicKeyToJWK(keyPair2.publicKey)
+    vi.stubGlobal('fetch', () =>
+      Response.json({
+        keys: [noKidKey, jwk1],
+      })
+    )
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    // Token signed with keyPair2 (whose public key has no kid) should fail
+    const token = generateJWT(keyPair2.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+
+    const res = await freshApp.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Invalid token')
+  })
+
   it('Should correctly decode tokens with base64url characters in payload', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: 'user+test/special_chars',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -148,7 +148,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Missing bearer token')
   })
 
-  it('Should throw unable to decode bearer token when sending garbage', async () => {
+  it('Should throw Unable to decode Bearer token when sending garbage', async () => {
     const res = await app.request('http://localhost/hello-behind-access', {
       headers: {
         'cf-access-jwt-assertion': 'asdasdasda',
@@ -156,7 +156,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
+    expect(await res.text()).toBe('Authentication error: Unable to decode Bearer token')
   })
 
   it('Should throw Token is expired when sending expired token', async () => {
@@ -654,16 +654,13 @@ describe('Cloudflare Access middleware', async () => {
   })
 
   it('Should re-fetch JWKS when token has unknown kid (key rotation)', async () => {
-    vi.useFakeTimers()
-
     const jwk1 = publicKeyToJWK(keyPair1.publicKey)
     const jwk3 = publicKeyToJWK(keyPair3.publicKey)
 
-    // Initially only serve keyPair1
+    // Initially only serve keyPair1; after first fetch, also serve keyPair3 (simulating key rotation)
     let fetchCount = 0
     const fetchSpy = vi.fn(() => {
       fetchCount++
-      // After first fetch, also serve keyPair3 (simulating key rotation)
       const keys = fetchCount === 1 ? [jwk1] : [jwk1, jwk3]
       return Promise.resolve(Response.json({ keys }))
     })
@@ -684,9 +681,6 @@ describe('Cloudflare Access middleware', async () => {
     expect(res1.status).toBe(200)
     expect(fetchSpy).toHaveBeenCalledTimes(1)
 
-    // Advance past the re-fetch rate limit (60s)
-    vi.advanceTimersByTime(61 * 1000)
-
     // Request with keyPair3 and its kid — should trigger re-fetch since kid is unknown
     const token3 = generateJWTWithHeader(
       keyPair3.privateKey,
@@ -701,50 +695,6 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res3.status).toBe(200)
     expect(fetchSpy).toHaveBeenCalledTimes(2)
-
-    vi.useRealTimers()
-  })
-
-  it('Should rate-limit JWKS re-fetches on unknown kid to prevent DoS', async () => {
-    vi.useFakeTimers()
-
-    const jwk1 = publicKeyToJWK(keyPair1.publicKey)
-    const fetchSpy = vi.fn(() => Promise.resolve(Response.json({ keys: [jwk1] })))
-    vi.stubGlobal('fetch', fetchSpy)
-
-    const freshApp = new Hono()
-    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
-    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
-
-    // First request fetches keys
-    const token1 = generateJWT(keyPair1.privateKey, {
-      sub: '1234567890',
-      iss: 'https://my-cool-team-name.cloudflareaccess.com',
-    })
-    await freshApp.request('http://localhost/hello-behind-access', {
-      headers: { 'cf-access-jwt-assertion': token1 },
-    })
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
-
-    // Immediately send tokens with forged kids — should NOT trigger re-fetches
-    for (let i = 0; i < 5; i++) {
-      const forgedToken = generateJWTWithHeader(
-        keyPair3.privateKey,
-        { alg: 'RS256', typ: 'JWT', kid: `forged-kid-${i}` },
-        {
-          sub: '1234567890',
-          iss: 'https://my-cool-team-name.cloudflareaccess.com',
-        }
-      )
-      await freshApp.request('http://localhost/hello-behind-access', {
-        headers: { 'cf-access-jwt-assertion': forgedToken },
-      })
-    }
-
-    // Should still be 1 — rate limiter prevents re-fetches within 60s
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
-
-    vi.useRealTimers()
   })
 
   it('Should throw when accessTeamName contains invalid characters', () => {
@@ -801,7 +751,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
+    expect(await res.text()).toBe('Authentication error: Unable to decode Bearer token')
   })
 
   it('Should reject tokens with fewer than 3 dot-separated parts', async () => {
@@ -812,7 +762,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
+    expect(await res.text()).toBe('Authentication error: Unable to decode Bearer token')
   })
 
   it('Should reject tokens with crit header parameter', async () => {
@@ -1046,7 +996,7 @@ describe('Cloudflare Access middleware', async () => {
     })
     expect(res).not.toBeNull()
     expect(res.status).toBe(401)
-    expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
+    expect(await res.text()).toBe('Authentication error: Unable to decode Bearer token')
   })
 
   it('Should correctly decode tokens with base64url characters in payload', async () => {

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -856,6 +856,26 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Invalid token')
   })
 
+  it('Should reject tokens with whitespace or invalid characters in base64url segments', async () => {
+    // Construct a token where the header contains whitespace (invalid per RFC 7515 §5.2)
+    const validToken = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+    const parts = validToken.split('.')
+    // Insert whitespace into the header segment
+    const corruptedToken = `${parts[0]} ${parts[0]}.${parts[1]}.${parts[2]}`
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': corruptedToken,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Unable to decode bearer token')
+  })
+
   it('Should correctly decode tokens with base64url characters in payload', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: 'user+test/special_chars',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -301,6 +301,49 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('foo')
   })
 
+  it('Should accept token with correct audience when aud is a string (RFC 7519 §4.1.3)', async () => {
+    const appWithAud = new Hono()
+    appWithAud.use('/*', cloudflareAccess('my-cool-team-name', 'expected-aud-tag'))
+    appWithAud.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      aud: 'expected-aud-tag',
+    })
+
+    const res = await appWithAud.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
+  it('Should reject token when aud is a string substring of the expected aud', async () => {
+    const appWithAud = new Hono()
+    appWithAud.use('/*', cloudflareAccess('my-cool-team-name', 'expected-aud-tag'))
+    appWithAud.get('/hello-behind-access', (c) => c.text('foo'))
+
+    // "expected-aud" is a substring of "expected-aud-tag" — must NOT match
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      aud: 'expected-aud',
+    })
+
+    const res = await appWithAud.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Authentication error: Invalid token audience')
+  })
+
   it('Should skip audience check when aud is not configured', async () => {
     const token = generateJWT(keyPair1.privateKey, {
       sub: '1234567890',

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -490,10 +490,14 @@ describe('Cloudflare Access middleware', async () => {
 
   it('Should accept token expired within clock skew leeway (30s)', async () => {
     // Token that expired 10 seconds ago — within 30s leeway
-    const token = generateJWT(keyPair1.privateKey, {
-      sub: '1234567890',
-      iss: 'https://my-cool-team-name.cloudflareaccess.com',
-    }, -10) // exp = now - 10
+    const token = generateJWT(
+      keyPair1.privateKey,
+      {
+        sub: '1234567890',
+        iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      },
+      -10
+    ) // exp = now - 10
 
     // Manually override exp to be 10 seconds ago (generateJWT sets exp = now + expiresIn)
     // With expiresIn = -10, exp = now + (-10) = now - 10, which is within 30s leeway
@@ -705,9 +709,7 @@ describe('Cloudflare Access middleware', async () => {
     vi.useFakeTimers()
 
     const jwk1 = publicKeyToJWK(keyPair1.publicKey)
-    const fetchSpy = vi.fn(() =>
-      Promise.resolve(Response.json({ keys: [jwk1] }))
-    )
+    const fetchSpy = vi.fn(() => Promise.resolve(Response.json({ keys: [jwk1] })))
     vi.stubGlobal('fetch', fetchSpy)
 
     const freshApp = new Hono()
@@ -837,9 +839,7 @@ describe('Cloudflare Access middleware', async () => {
     const jwk1 = publicKeyToJWK(keyPair1.publicKey)
     const jwk2 = publicKeyToJWK(keyPair2.publicKey)
 
-    const fetchSpy = vi.fn(() =>
-      Promise.resolve(Response.json({ keys: [jwk1, jwk2] }))
-    )
+    const fetchSpy = vi.fn(() => Promise.resolve(Response.json({ keys: [jwk1, jwk2] })))
     vi.stubGlobal('fetch', fetchSpy)
 
     const freshApp = new Hono()
@@ -890,10 +890,7 @@ describe('Cloudflare Access middleware', async () => {
     const jwk1 = publicKeyToJWK(keyPair1.publicKey)
     vi.stubGlobal('fetch', () =>
       Response.json({
-        keys: [
-          { kid: 'ec-key', kty: 'EC', use: 'sig', crv: 'P-256', x: 'abc', y: 'def' },
-          jwk1,
-        ],
+        keys: [{ kid: 'ec-key', kty: 'EC', use: 'sig', crv: 'P-256', x: 'abc', y: 'def' }, jwk1],
       })
     )
 

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -451,7 +451,7 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Malformed token payload')
   })
 
-  it('Should re-fetch keys after cache expiration', async () => {
+  it('Should use cached keys within TTL', async () => {
     const fetchSpy = vi.fn(() =>
       Promise.resolve(
         Response.json({
@@ -481,6 +481,49 @@ describe('Cloudflare Access middleware', async () => {
       headers: { 'cf-access-jwt-assertion': token },
     })
     expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('Should re-fetch keys after cache expiration', async () => {
+    vi.useFakeTimers()
+
+    const fetchSpy = vi.fn(() =>
+      Promise.resolve(
+        Response.json({
+          keys: [publicKeyToJWK(keyPair1.publicKey), publicKeyToJWK(keyPair2.publicKey)],
+        })
+      )
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const freshApp = new Hono()
+    freshApp.use('/*', cloudflareAccess('my-cool-team-name'))
+    freshApp.get('/hello-behind-access', (c) => c.text('foo'))
+
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+
+    // First request fetches keys
+    await freshApp.request('http://localhost/hello-behind-access', {
+      headers: { 'cf-access-jwt-assertion': token },
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    // Advance time past the 1-hour cache TTL
+    vi.advanceTimersByTime(3601 * 1000)
+
+    // Third request should re-fetch keys since cache expired
+    const newToken = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    })
+    await freshApp.request('http://localhost/hello-behind-access', {
+      headers: { 'cf-access-jwt-assertion': newToken },
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+
+    vi.useRealTimers()
   })
 
   it('Should throw when accessTeamName contains invalid characters', () => {

--- a/packages/cloudflare-access/src/index.test.ts
+++ b/packages/cloudflare-access/src/index.test.ts
@@ -446,6 +446,44 @@ describe('Cloudflare Access middleware', async () => {
     expect(await res.text()).toBe('Authentication error: Token is not yet valid')
   })
 
+  it('Should accept token expired within clock skew leeway (30s)', async () => {
+    // Token that expired 10 seconds ago — within 30s leeway
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+    }, -10) // exp = now - 10
+
+    // Manually override exp to be 10 seconds ago (generateJWT sets exp = now + expiresIn)
+    // With expiresIn = -10, exp = now + (-10) = now - 10, which is within 30s leeway
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
+  it('Should accept token with nbf slightly in the future within clock skew leeway', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const token = generateJWT(keyPair1.privateKey, {
+      sub: '1234567890',
+      iss: 'https://my-cool-team-name.cloudflareaccess.com',
+      nbf: now + 20, // 20 seconds in the future, within 30s leeway
+    })
+
+    const res = await app.request('http://localhost/hello-behind-access', {
+      headers: {
+        'cf-access-jwt-assertion': token,
+      },
+    })
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('foo')
+  })
+
   it('Should reject token with non-RS256 algorithm', async () => {
     const token = generateJWTWithHeader(
       keyPair1.privateKey,

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -68,7 +68,7 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
     try {
       token = decodeJwt(encodedToken)
     } catch {
-      return c.text('Authentication error: Unable to decode Bearer token', 401)
+      return c.text('Authentication error: Unable to decode bearer token', 401)
     }
 
     // Validate algorithm
@@ -95,7 +95,7 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
 
     // Check is token is valid against at least one public key?
     if (!(await isValidJwtSignature(token, cacheKeys))) {
-      return c.text('Authentication error: Invalid Token', 401)
+      return c.text('Authentication error: Invalid token', 401)
     }
 
     // Is signed from the correct team?

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -34,6 +34,12 @@ declare module 'hono' {
 }
 
 export const cloudflareAccess = (accessTeamName: string, aud?: string): MiddlewareHandler => {
+  if (!/^[a-zA-Z0-9-]+$/.test(accessTeamName)) {
+    throw new Error(
+      'Invalid accessTeamName: must contain only alphanumeric characters and hyphens'
+    )
+  }
+
   // This var will hold already imported jwt keys, this reduces the load of importing the key on every request
   let cacheKeys: Record<string, CryptoKey> = {}
   let cacheExpiration = 0

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -172,7 +172,7 @@ async function getPublicKeys(accessTeamName: string) {
 
   const importedKeys: Record<string, CryptoKey> = {}
   for (const key of data.keys) {
-    // RFC 7517 §4.5: kid MUST be present for key selection to work
+    // Skip keys without kid — we need it to index into the cache for key selection
     if (!key.kid) {
       continue
     }
@@ -255,7 +255,7 @@ async function isValidJwtSignature(token: DecodedToken, keys: Record<string, Cry
 
   const signature = token.signature
 
-  // RFC 7515 §4.1.4: Use kid to select the verification key when present
+  // RFC 7515 §5.2: Use kid to select the verification key when present
   if (token.header.kid) {
     const key = keys[token.header.kid]
     if (key) {

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -76,6 +76,11 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
       return c.text('Authentication error: Invalid token algorithm', 401)
     }
 
+    // Validate payload structure
+    if (typeof token.payload.exp !== 'number' || typeof token.payload.iss !== 'string') {
+      return c.text('Authentication error: Malformed token payload', 401)
+    }
+
     // Is the token expired?
     const expiryDate = new Date(token.payload.exp * 1000)
     const currentDate = new Date(Date.now())

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -91,8 +91,14 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
     }
 
     // Is the token intended for the correct application?
-    if (aud && !token.payload.aud?.includes(aud)) {
-      return c.text('Authentication error: Invalid token audience', 401)
+    // RFC 7519 §4.1.3: aud may be a string or an array of strings — normalize to array
+    // to avoid String.prototype.includes() substring matching vulnerability
+    if (aud) {
+      const audClaim = token.payload.aud
+      const audArray = Array.isArray(audClaim) ? audClaim : [audClaim]
+      if (!audArray.includes(aud)) {
+        return c.text('Authentication error: Invalid token audience', 401)
+      }
     }
 
     // Check is token is valid against at least one public key?

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -88,6 +88,11 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
       return c.text('Authentication error: Token is expired', 401)
     }
 
+    // Is the token not yet valid?
+    if (token.payload.nbf && token.payload.nbf * 1000 > Date.now()) {
+      return c.text('Authentication error: Token is not yet valid', 401)
+    }
+
     // Check is token is valid against at least one public key?
     if (!(await isValidJwtSignature(token, cacheKeys))) {
       return c.text('Authentication error: Invalid Token', 401)

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -40,6 +40,7 @@ export const cloudflareAccess = (
   if (!/^[a-zA-Z0-9-]+$/.test(accessTeamName)) {
     throw new Error('Invalid accessTeamName: must contain only alphanumeric characters and hyphens')
   }
+  accessTeamName = accessTeamName.toLowerCase()
 
   const allowedAuds = aud ? (Array.isArray(aud) ? aud : [aud]) : []
 
@@ -110,7 +111,7 @@ export const cloudflareAccess = (
       }
     }
 
-    // Check is token is valid against at least one public key?
+    // Check if token is valid against at least one public key
     if (!(await isValidJwtSignature(token, cacheKeys))) {
       // Re-fetch JWKS and retry once if token has an unknown kid (key rotation mid-cache-period)
       if (token.header.kid && !cacheKeys[token.header.kid]) {
@@ -128,7 +129,7 @@ export const cloudflareAccess = (
     const nowSeconds = Math.floor(Date.now() / 1000)
 
     // Is the token expired? (checked after signature to avoid trusting unverified claims)
-    if (token.payload.exp + CLOCK_SKEW_SECONDS <= nowSeconds) {
+    if (token.payload.exp + CLOCK_SKEW_SECONDS < nowSeconds) {
       return c.text('Authentication error: Token is expired', 401)
     }
 
@@ -255,7 +256,7 @@ async function isValidJwtSignature(token: DecodedToken, keys: Record<string, Cry
 
   const signature = token.signature
 
-  // RFC 7515 §5.2: Use kid to select the verification key when present
+  // RFC 7515 §4.1.4: Use kid to select the verification key when present
   if (token.header.kid) {
     const key = keys[token.header.kid]
     if (key) {
@@ -263,12 +264,14 @@ async function isValidJwtSignature(token: DecodedToken, keys: Record<string, Cry
     }
   }
 
-  // Fall back to trying all keys when kid is absent or not found
-  for (const key of Object.values(keys)) {
-    const isValid = await validateSingleKey(key, signature, data)
+  // Fall back to trying all keys only when kid is absent
+  if (!token.header.kid) {
+    for (const key of Object.values(keys)) {
+      const isValid = await validateSingleKey(key, signature, data)
 
-    if (isValid) {
-      return true
+      if (isValid) {
+        return true
+      }
     }
   }
 

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -21,7 +21,7 @@ export type CloudflareAccessVariables = {
 }
 
 type DecodedToken = {
-  header: { alg: string; typ?: string; kid?: string }
+  header: { alg: string; typ?: string; kid?: string; crit?: string[] }
   payload: CloudflareAccessPayload
   signature: string
   raw: { header?: string; payload?: string; signature?: string }
@@ -72,6 +72,11 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
     // Validate algorithm
     if (token.header.alg !== 'RS256') {
       return c.text('Authentication error: Invalid token algorithm', 401)
+    }
+
+    // RFC 7515 §4.1.11: Reject tokens with critical extensions we don't understand
+    if (token.header.crit) {
+      return c.text('Authentication error: Unsupported critical extension', 401)
     }
 
     // Validate payload structure
@@ -135,13 +140,20 @@ async function getPublicKeys(accessTeamName: string) {
     })
   }
 
-  const data = await result.json<{ keys: JsonWebKeyWithKid[] }>()
+  const data = await result.json<{ keys: (JsonWebKey & { kid: string })[] }>()
 
   // Because we keep CryptoKey's in memory between requests, we need to make sure they are refreshed once in a while
   const cacheExpiration = Math.floor(Date.now() / 1000) + 3600 // 1h
 
   const importedKeys: Record<string, CryptoKey> = {}
   for (const key of data.keys) {
+    // RFC 7517 §4.1-4.3: Only import RSA keys intended for signature verification
+    if (key.kty !== 'RSA') {
+      continue
+    }
+    if (key.use && key.use !== 'sig') {
+      continue
+    }
     importedKeys[key.kid] = await crypto.subtle.importKey(
       'jwk',
       key,
@@ -169,14 +181,18 @@ function getJwt(c: Context) {
 }
 
 function base64urlDecode(str: string): string {
-  return atob(str.replace(/-/g, '+').replace(/_/g, '/'))
+  str = str.replace(/-/g, '+').replace(/_/g, '/')
+  // Restore padding removed per RFC 7515 §2
+  str += '='.repeat((4 - (str.length % 4)) % 4)
+  return atob(str)
 }
 
 function decodeJwt(token: string): DecodedToken {
-  const [header, payload, signature] = token.split('.')
-  if (!header || !payload || !signature) {
+  const parts = token.split('.')
+  if (parts.length !== 3) {
     throw new Error('Invalid token')
   }
+  const [header, payload, signature] = parts
 
   return {
     header: JSON.parse(base64urlDecode(header)) as DecodedToken['header'],
@@ -192,6 +208,15 @@ async function isValidJwtSignature(token: DecodedToken, keys: Record<string, Cry
 
   const signature = new Uint8Array(Array.from(token.signature).map((c) => c.charCodeAt(0)))
 
+  // RFC 7515 §4.1.4: Use kid to select the verification key when present
+  if (token.header.kid) {
+    const key = keys[token.header.kid]
+    if (key) {
+      return validateSingleKey(key, signature, data)
+    }
+  }
+
+  // Fall back to trying all keys when kid is absent or not found
   for (const key of Object.values(keys)) {
     const isValid = await validateSingleKey(key, signature, data)
 

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -47,6 +47,15 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
   // This var will hold already imported jwt keys, this reduces the load of importing the key on every request
   let cacheKeys: Record<string, CryptoKey> = {}
   let cacheExpiration = 0
+  let lastFetchTime = 0
+  const MIN_REFETCH_INTERVAL = 60 // Rate-limit JWKS re-fetches to prevent cache-busting DoS
+
+  async function refreshKeys() {
+    const publicKeys = await getPublicKeys(accessTeamName)
+    cacheKeys = publicKeys.keys
+    cacheExpiration = publicKeys.cacheExpiration
+    lastFetchTime = Math.floor(Date.now() / 1000)
+  }
 
   return createMiddleware(async (c, next) => {
     const encodedToken = getJwt(c)
@@ -56,9 +65,7 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
 
     // Load jwt keys if they are not in memory or already expired
     if (Object.keys(cacheKeys).length === 0 || Math.floor(Date.now() / 1000) >= cacheExpiration) {
-      const publicKeys = await getPublicKeys(accessTeamName)
-      cacheKeys = publicKeys.keys
-      cacheExpiration = publicKeys.cacheExpiration
+      await refreshKeys()
     }
 
     // Decode Token
@@ -99,6 +106,16 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
       if (!audArray.includes(aud)) {
         return c.text('Authentication error: Invalid token audience', 401)
       }
+    }
+
+    // Re-fetch JWKS if token has a kid not in our cache (key rotation mid-cache-period)
+    // Rate-limited to prevent attackers from busting the cache with forged kid values
+    if (
+      token.header.kid &&
+      !cacheKeys[token.header.kid] &&
+      Math.floor(Date.now() / 1000) - lastFetchTime >= MIN_REFETCH_INTERVAL
+    ) {
+      await refreshKeys()
     }
 
     // Check is token is valid against at least one public key?

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -117,7 +117,7 @@ export const cloudflareAccess = (
 
     // Check is token is valid against at least one public key?
     if (!(await isValidJwtSignature(token, cacheKeys))) {
-      return c.text('Authentication error: Invalid token', 401)
+      return c.text('Authentication error: Invalid Token', 401)
     }
 
     // RFC 7519 §4.1.4-4.1.5: allow small leeway for clock skew across distributed systems

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -152,7 +152,7 @@ async function getPublicKeys(accessTeamName: string) {
       // Dont cache error responses
       cacheTtlByStatus: { '200-299': 30, '300-599': 0 },
     },
-  })
+  } as RequestInit)
 
   if (!result.ok) {
     if (result.status === 404) {
@@ -166,7 +166,7 @@ async function getPublicKeys(accessTeamName: string) {
     })
   }
 
-  const data = await result.json<{ keys: (JsonWebKey & { kid?: string })[] }>()
+  const data = (await result.json()) as { keys: (JsonWebKey & { kid?: string })[] }
 
   // Because we keep CryptoKey's in memory between requests, we need to make sure they are refreshed once in a while
   const cacheExpiration = Math.floor(Date.now() / 1000) + 3600 // 1h
@@ -280,8 +280,13 @@ async function isValidJwtSignature(token: DecodedToken, keys: Record<string, Cry
 
 async function validateSingleKey(
   key: CryptoKey,
-  signature: BufferSource,
-  data: BufferSource
+  signature: Uint8Array,
+  data: Uint8Array
 ): Promise<boolean> {
-  return crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, signature, data)
+  return crypto.subtle.verify(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    signature.buffer as ArrayBuffer,
+    data.buffer as ArrayBuffer
+  )
 }

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -218,7 +218,8 @@ function base64urlDecode(str: string): string {
   str = str.replace(/-/g, '+').replace(/_/g, '/')
   // Restore padding removed per RFC 7515 §2
   str += '='.repeat((4 - (str.length % 4)) % 4)
-  return atob(str)
+  const bytes = Uint8Array.from(atob(str), (c) => c.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
 }
 
 function decodeJwt(token: string): DecodedToken {

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -40,6 +40,12 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
     )
   }
 
+  if (!aud) {
+    console.warn(
+      'cloudflare-access: No aud parameter provided. It is strongly recommended to pass your Application Audience (AUD) Tag to prevent cross-application token reuse.'
+    )
+  }
+
   // This var will hold already imported jwt keys, this reduces the load of importing the key on every request
   let cacheKeys: Record<string, CryptoKey> = {}
   let cacheExpiration = 0

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -101,10 +101,7 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
     // Is signed from the correct team?
     const expectedIss = `https://${accessTeamName}.cloudflareaccess.com`
     if (token.payload?.iss !== expectedIss) {
-      return c.text(
-        `Authentication error: Expected team name ${expectedIss}, but received ${token.payload?.iss}`,
-        401
-      )
+      return c.text('Authentication error: Invalid team name', 401)
     }
 
     // Is the token intended for the correct application?

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -33,7 +33,7 @@ declare module 'hono' {
   }
 }
 
-export const cloudflareAccess = (accessTeamName: string): MiddlewareHandler => {
+export const cloudflareAccess = (accessTeamName: string, aud?: string): MiddlewareHandler => {
   // This var will hold already imported jwt keys, this reduces the load of importing the key on every request
   let cacheKeys: Record<string, CryptoKey> = {}
   let cacheExpiration = 0
@@ -78,6 +78,11 @@ export const cloudflareAccess = (accessTeamName: string): MiddlewareHandler => {
         `Authentication error: Expected team name ${expectedIss}, but received ${token.payload?.iss}`,
         401
       )
+    }
+
+    // Is the token intended for the correct application?
+    if (aud && !token.payload.aud?.includes(aud)) {
+      return c.text('Authentication error: Invalid token audience', 401)
     }
 
     c.set('accessPayload', token.payload)

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -45,7 +45,7 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
     }
 
     // Load jwt keys if they are not in memory or already expired
-    if (Object.keys(cacheKeys).length === 0 || Math.floor(Date.now() / 1000) < cacheExpiration) {
+    if (Object.keys(cacheKeys).length === 0 || Math.floor(Date.now() / 1000) >= cacheExpiration) {
       const publicKeys = await getPublicKeys(accessTeamName)
       cacheKeys = publicKeys.keys
       cacheExpiration = publicKeys.cacheExpiration

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -23,7 +23,7 @@ export type CloudflareAccessVariables = {
 type DecodedToken = {
   header: { alg: string; typ?: string; kid?: string; crit?: string[] }
   payload: CloudflareAccessPayload
-  signature: string
+  signature: Uint8Array
   raw: { header?: string; payload?: string; signature?: string }
 }
 
@@ -222,6 +222,15 @@ function base64urlDecode(str: string): string {
   return new TextDecoder().decode(bytes)
 }
 
+function base64urlDecodeToBytes(str: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]*$/.test(str)) {
+    throw new Error('Invalid base64url encoding')
+  }
+  str = str.replace(/-/g, '+').replace(/_/g, '/')
+  str += '='.repeat((4 - (str.length % 4)) % 4)
+  return Uint8Array.from(atob(str), (c) => c.charCodeAt(0))
+}
+
 function decodeJwt(token: string): DecodedToken {
   const parts = token.split('.')
   if (parts.length !== 3) {
@@ -232,7 +241,7 @@ function decodeJwt(token: string): DecodedToken {
   return {
     header: JSON.parse(base64urlDecode(header)) as DecodedToken['header'],
     payload: JSON.parse(base64urlDecode(payload)) as CloudflareAccessPayload,
-    signature: base64urlDecode(signature),
+    signature: base64urlDecodeToBytes(signature),
     raw: { header, payload, signature },
   }
 }
@@ -241,7 +250,7 @@ async function isValidJwtSignature(token: DecodedToken, keys: Record<string, Cry
   const encoder = new TextEncoder()
   const data = encoder.encode([token.raw.header, token.raw.payload].join('.'))
 
-  const signature = new Uint8Array(Array.from(token.signature).map((c) => c.charCodeAt(0)))
+  const signature = token.signature
 
   // RFC 7515 §4.1.4: Use kid to select the verification key when present
   if (token.header.kid) {

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -4,16 +4,16 @@ import { createMiddleware } from 'hono/factory'
 import { HTTPException } from 'hono/http-exception'
 
 export type CloudflareAccessPayload = {
-  aud: string[]
-  email: string
+  aud: string | string[]
+  email?: string
   exp: number
   iat: number
   nbf?: number
   iss: string
-  type: string
-  identity_nonce: string
-  sub: string
-  country: string
+  type?: string
+  identity_nonce?: string
+  sub?: string
+  country?: string
 }
 
 export type CloudflareAccessVariables = {

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -33,12 +33,17 @@ declare module 'hono' {
   }
 }
 
-export const cloudflareAccess = (accessTeamName: string, aud?: string): MiddlewareHandler => {
+export const cloudflareAccess = (
+  accessTeamName: string,
+  aud?: string | string[]
+): MiddlewareHandler => {
   if (!/^[a-zA-Z0-9-]+$/.test(accessTeamName)) {
     throw new Error('Invalid accessTeamName: must contain only alphanumeric characters and hyphens')
   }
 
-  if (!aud) {
+  const allowedAuds = aud ? (Array.isArray(aud) ? aud : [aud]) : []
+
+  if (allowedAuds.length === 0) {
     console.warn(
       'cloudflare-access: No aud parameter provided. It is strongly recommended to pass your Application Audience (AUD) Tag to prevent cross-application token reuse.'
     )
@@ -98,12 +103,12 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
     }
 
     // Is the token intended for the correct application?
-    // RFC 7519 §4.1.3: aud may be a string or an array of strings — normalize to array
-    // to avoid String.prototype.includes() substring matching vulnerability
-    if (aud) {
+    // RFC 7519 §4.1.3: both the token's aud and the configured aud may be string or array.
+    // Normalize both to arrays and check for intersection.
+    if (allowedAuds.length > 0) {
       const audClaim = token.payload.aud
-      const audArray = Array.isArray(audClaim) ? audClaim : [audClaim]
-      if (!audArray.includes(aud)) {
+      const tokenAuds = Array.isArray(audClaim) ? audClaim : [audClaim]
+      if (!allowedAuds.some((a) => tokenAuds.includes(a))) {
         return c.text('Authentication error: Invalid token audience', 401)
       }
     }

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -79,7 +79,23 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
       return c.text('Authentication error: Malformed token payload', 401)
     }
 
-    // Is the token expired?
+    // Is signed from the correct team? (cheap check before expensive signature verification)
+    const expectedIss = `https://${accessTeamName}.cloudflareaccess.com`
+    if (token.payload.iss !== expectedIss) {
+      return c.text('Authentication error: Invalid team name', 401)
+    }
+
+    // Is the token intended for the correct application?
+    if (aud && !token.payload.aud?.includes(aud)) {
+      return c.text('Authentication error: Invalid token audience', 401)
+    }
+
+    // Check is token is valid against at least one public key?
+    if (!(await isValidJwtSignature(token, cacheKeys))) {
+      return c.text('Authentication error: Invalid token', 401)
+    }
+
+    // Is the token expired? (checked after signature to avoid trusting unverified claims)
     const expiryDate = new Date(token.payload.exp * 1000)
     const currentDate = new Date(Date.now())
     if (expiryDate <= currentDate) {
@@ -89,22 +105,6 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
     // Is the token not yet valid?
     if (token.payload.nbf && token.payload.nbf * 1000 > Date.now()) {
       return c.text('Authentication error: Token is not yet valid', 401)
-    }
-
-    // Check is token is valid against at least one public key?
-    if (!(await isValidJwtSignature(token, cacheKeys))) {
-      return c.text('Authentication error: Invalid token', 401)
-    }
-
-    // Is signed from the correct team?
-    const expectedIss = `https://${accessTeamName}.cloudflareaccess.com`
-    if (token.payload?.iss !== expectedIss) {
-      return c.text('Authentication error: Invalid team name', 401)
-    }
-
-    // Is the token intended for the correct application?
-    if (aud && !token.payload.aud?.includes(aud)) {
-      return c.text('Authentication error: Invalid token audience', 401)
     }
 
     c.set('accessPayload', token.payload)

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -71,6 +71,11 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
       return c.text('Authentication error: Unable to decode Bearer token', 401)
     }
 
+    // Validate algorithm
+    if (token.header.alg !== 'RS256') {
+      return c.text('Authentication error: Invalid token algorithm', 401)
+    }
+
     // Is the token expired?
     const expiryDate = new Date(token.payload.exp * 1000)
     const currentDate = new Date(Date.now())

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -35,9 +35,7 @@ declare module 'hono' {
 
 export const cloudflareAccess = (accessTeamName: string, aud?: string): MiddlewareHandler => {
   if (!/^[a-zA-Z0-9-]+$/.test(accessTeamName)) {
-    throw new Error(
-      'Invalid accessTeamName: must contain only alphanumeric characters and hyphens'
-    )
+    throw new Error('Invalid accessTeamName: must contain only alphanumeric characters and hyphens')
   }
 
   if (!aud) {

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -110,14 +110,17 @@ export const cloudflareAccess = (
       }
     }
 
-    // Re-fetch JWKS if token has a kid not in our cache (handles key rotation mid-cache-period)
-    if (token.header.kid && !cacheKeys[token.header.kid]) {
-      await refreshKeys()
-    }
-
     // Check is token is valid against at least one public key?
     if (!(await isValidJwtSignature(token, cacheKeys))) {
-      return c.text('Authentication error: Invalid Token', 401)
+      // Re-fetch JWKS and retry once if token has an unknown kid (key rotation mid-cache-period)
+      if (token.header.kid && !cacheKeys[token.header.kid]) {
+        await refreshKeys()
+        if (!(await isValidJwtSignature(token, cacheKeys))) {
+          return c.text('Authentication error: Invalid Token', 401)
+        }
+      } else {
+        return c.text('Authentication error: Invalid Token', 401)
+      }
     }
 
     // RFC 7519 §4.1.4-4.1.5: allow small leeway for clock skew across distributed systems

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -195,6 +195,10 @@ function getJwt(c: Context) {
 }
 
 function base64urlDecode(str: string): string {
+  // RFC 7515 §5.2: reject base64url strings with whitespace, line breaks, or invalid characters
+  if (!/^[A-Za-z0-9_-]*$/.test(str)) {
+    throw new Error('Invalid base64url encoding')
+  }
   str = str.replace(/-/g, '+').replace(/_/g, '/')
   // Restore padding removed per RFC 7515 §2
   str += '='.repeat((4 - (str.length % 4)) % 4)

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -8,7 +8,7 @@ export type CloudflareAccessPayload = {
   email: string
   exp: number
   iat: number
-  nbf: number
+  nbf?: number
   iss: string
   type: string
   identity_nonce: string

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -140,18 +140,26 @@ async function getPublicKeys(accessTeamName: string) {
     })
   }
 
-  const data = await result.json<{ keys: (JsonWebKey & { kid: string })[] }>()
+  const data = await result.json<{ keys: (JsonWebKey & { kid?: string })[] }>()
 
   // Because we keep CryptoKey's in memory between requests, we need to make sure they are refreshed once in a while
   const cacheExpiration = Math.floor(Date.now() / 1000) + 3600 // 1h
 
   const importedKeys: Record<string, CryptoKey> = {}
   for (const key of data.keys) {
+    // RFC 7517 §4.5: kid MUST be present for key selection to work
+    if (!key.kid) {
+      continue
+    }
     // RFC 7517 §4.1-4.3: Only import RSA keys intended for signature verification
     if (key.kty !== 'RSA') {
       continue
     }
     if (key.use && key.use !== 'sig') {
+      continue
+    }
+    // RFC 7517 §4.3: If key_ops is present, it must include "verify"
+    if (key.key_ops && !key.key_ops.includes('verify')) {
       continue
     }
     importedKeys[key.kid] = await crypto.subtle.importKey(

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -158,6 +158,10 @@ function getJwt(c: Context) {
   return jwt.trim()
 }
 
+function base64urlDecode(str: string): string {
+  return atob(str.replace(/-/g, '+').replace(/_/g, '/'))
+}
+
 function decodeJwt(token: string): DecodedToken {
   const [header, payload, signature] = token.split('.')
   if (!header || !payload || !signature) {
@@ -165,9 +169,9 @@ function decodeJwt(token: string): DecodedToken {
   }
 
   return {
-    header: JSON.parse(atob(header)) as DecodedToken['header'],
-    payload: JSON.parse(atob(payload)) as CloudflareAccessPayload,
-    signature: atob(signature.replace(/_/g, '/').replace(/-/g, '+')),
+    header: JSON.parse(base64urlDecode(header)) as DecodedToken['header'],
+    payload: JSON.parse(base64urlDecode(payload)) as CloudflareAccessPayload,
+    signature: base64urlDecode(signature),
     raw: { header, payload, signature },
   }
 }

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -106,15 +106,17 @@ export const cloudflareAccess = (accessTeamName: string, aud?: string): Middlewa
       return c.text('Authentication error: Invalid token', 401)
     }
 
+    // RFC 7519 §4.1.4-4.1.5: allow small leeway for clock skew across distributed systems
+    const CLOCK_SKEW_SECONDS = 30
+    const nowSeconds = Math.floor(Date.now() / 1000)
+
     // Is the token expired? (checked after signature to avoid trusting unverified claims)
-    const expiryDate = new Date(token.payload.exp * 1000)
-    const currentDate = new Date(Date.now())
-    if (expiryDate <= currentDate) {
+    if (token.payload.exp + CLOCK_SKEW_SECONDS <= nowSeconds) {
       return c.text('Authentication error: Token is expired', 401)
     }
 
     // Is the token not yet valid?
-    if (token.payload.nbf && token.payload.nbf * 1000 > Date.now()) {
+    if (token.payload.nbf && token.payload.nbf - CLOCK_SKEW_SECONDS > nowSeconds) {
       return c.text('Authentication error: Token is not yet valid', 401)
     }
 

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -52,14 +52,11 @@ export const cloudflareAccess = (
   // This var will hold already imported jwt keys, this reduces the load of importing the key on every request
   let cacheKeys: Record<string, CryptoKey> = {}
   let cacheExpiration = 0
-  let lastFetchTime = 0
-  const MIN_REFETCH_INTERVAL = 60 // Rate-limit JWKS re-fetches to prevent cache-busting DoS
 
   async function refreshKeys() {
     const publicKeys = await getPublicKeys(accessTeamName)
     cacheKeys = publicKeys.keys
     cacheExpiration = publicKeys.cacheExpiration
-    lastFetchTime = Math.floor(Date.now() / 1000)
   }
 
   return createMiddleware(async (c, next) => {
@@ -78,7 +75,7 @@ export const cloudflareAccess = (
     try {
       token = decodeJwt(encodedToken)
     } catch {
-      return c.text('Authentication error: Unable to decode bearer token', 401)
+      return c.text('Authentication error: Unable to decode Bearer token', 401)
     }
 
     // Validate algorithm
@@ -113,13 +110,8 @@ export const cloudflareAccess = (
       }
     }
 
-    // Re-fetch JWKS if token has a kid not in our cache (key rotation mid-cache-period)
-    // Rate-limited to prevent attackers from busting the cache with forged kid values
-    if (
-      token.header.kid &&
-      !cacheKeys[token.header.kid] &&
-      Math.floor(Date.now() / 1000) - lastFetchTime >= MIN_REFETCH_INTERVAL
-    ) {
+    // Re-fetch JWKS if token has a kid not in our cache (handles key rotation mid-cache-period)
+    if (token.header.kid && !cacheKeys[token.header.kid]) {
       await refreshKeys()
     }
 

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -21,7 +21,7 @@ export type CloudflareAccessVariables = {
 }
 
 type DecodedToken = {
-  header: object
+  header: { alg: string; typ?: string; kid?: string }
   payload: CloudflareAccessPayload
   signature: string
   raw: { header?: string; payload?: string; signature?: string }
@@ -165,7 +165,7 @@ function decodeJwt(token: string): DecodedToken {
   }
 
   return {
-    header: JSON.parse(atob(header)) as object,
+    header: JSON.parse(atob(header)) as DecodedToken['header'],
     payload: JSON.parse(atob(payload)) as CloudflareAccessPayload,
     signature: atob(signature.replace(/_/g, '/').replace(/-/g, '+')),
     raw: { header, payload, signature },


### PR DESCRIPTION
I was looking at using the `@hono/cloudflare-access` package, but I noticed that it did not accept the `aud` parameter to validate the [Application Audience Tag (AUD)](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json/#get-your-aud-tag) as described in the Cloudflare Access documentation and code examples. This is a security vulnerability (the same as https://github.com/honojs/hono/security/advisories/GHSA-m732-5p4w-x69g for `hono`) as it allows reusing a token assigned to a different Cloudflare Access application. This PR adds optional `aud` validation; a warning is provided when this is omitted. In addition, several changes were made for JWT validation security hardening to conform to relevant RFCs (RFC 7515, 7517, 7519), including:

- Validating the correct [algorithm](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json/#get-your-aud-tag:~:text=Select%20the%20RS256%20algorithm.)
- Validating the `nbf` claim (token is not before time), allow 30-second clock skew
- Fix bug in JWK cache logic, add `kid` support
- Prevent information leakage in the case of an invalid CF Access team name

For transparency, this PR was developed and reviewed with AI agent assistance, and I am not a security engineer. However, I have personally reviewed all changes, and I have tested it with my worker locally with yalc. Please let me know if any concerns.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
