### PR TITLE
add websocket server options support for node-ws

### DIFF
--- a/.changeset/support-websocket-server-options.md
+++ b/.changeset/support-websocket-server-options.md
@@ -1,0 +1,5 @@
+---
+"@hono/node-ws": minor
+---
+
+Add support for passing WebSocketServer options to createNodeWebSocket

--- a/packages/node-ws/README.md
+++ b/packages/node-ws/README.md
@@ -26,6 +26,32 @@ const server = serve(app)
 injectWebSocket(server)
 ```
 
+## Options
+
+You can pass options to the underlying WebSocketServer from the `ws` library:
+
+```ts
+const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({
+  app,
+  websocketServerOptions: {
+    maxPayload: 1024 * 1024, // 1MB max message size
+    perMessageDeflate: false, // Disable compression
+    clientTracking: true, // Track connected clients
+    // ... other ws.ServerOptions
+  },
+})
+```
+
+Available options include:
+
+- `maxPayload`: Maximum allowed message size in bytes
+- `perMessageDeflate`: Enable/disable per-message compression
+- `clientTracking`: Enable/disable client tracking
+- `verifyClient`: Function to verify client connections
+- And more - see [ws documentation](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback) for full list
+
+**Note:** The `noServer` option is always set to `true` internally and cannot be overridden.
+
 ## Author
 
 Shotaro Nakamura <https://github.com/nakasyou>

--- a/packages/node-ws/eslint-suppressions.json
+++ b/packages/node-ws/eslint-suppressions.json
@@ -1,21 +1,4 @@
 {
-  "src/index.test.ts": {
-    "@typescript-eslint/no-unsafe-argument": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unsafe-assignment": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unsafe-call": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unsafe-member-access": {
-      "count": 1
-    },
-    "@typescript-eslint/unbound-method": {
-      "count": 1
-    }
-  },
   "src/index.ts": {
     "@typescript-eslint/no-base-to-string": {
       "count": 1

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -1,7 +1,5 @@
+import type { ServerType } from '@hono/node-server'
 import { serve } from '@hono/node-server'
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import type { ServerType } from '@hono/node-server/dist/types'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { HTTPException } from 'hono/http-exception'
@@ -12,20 +10,18 @@ import { createNodeWebSocket } from '.'
 describe('WebSocket helper', () => {
   let app: Hono
   let server: ServerType
-  let injectWebSocket: ReturnType<typeof createNodeWebSocket>['injectWebSocket']
-  let upgradeWebSocket: ReturnType<typeof createNodeWebSocket>['upgradeWebSocket']
-  let wss: ReturnType<typeof createNodeWebSocket>['wss']
+  let nodeWs: ReturnType<typeof createNodeWebSocket>
 
   beforeEach(async () => {
     app = new Hono()
-    ;({ injectWebSocket, upgradeWebSocket, wss } = createNodeWebSocket({ app }))
+    nodeWs = createNodeWebSocket({ app })
 
     server = await new Promise<ServerType>((resolve) => {
       const server = serve({ fetch: app.fetch, port: 3030 }, () => {
         resolve(server)
       })
     })
-    injectWebSocket(server)
+    nodeWs.injectWebSocket(server)
   })
 
   afterEach(() => {
@@ -36,7 +32,7 @@ describe('WebSocket helper', () => {
     const mainPromise = new Promise<boolean>((resolve) =>
       app.get(
         '/',
-        upgradeWebSocket(
+        nodeWs.upgradeWebSocket(
           () =>
             new Promise((resolveWS) =>
               setTimeout(() => {
@@ -93,7 +89,7 @@ describe('WebSocket helper', () => {
     const mainPromise = new Promise<boolean>((resolve) =>
       app.get(
         '/',
-        upgradeWebSocket(() => ({
+        nodeWs.upgradeWebSocket(() => ({
           onOpen() {
             resolve(true)
           },
@@ -110,7 +106,7 @@ describe('WebSocket helper', () => {
     const mainPromise = new Promise((resolve) =>
       app.get(
         '/',
-        upgradeWebSocket(() => ({
+        nodeWs.upgradeWebSocket(() => ({
           onMessage(data) {
             resolve(data.data)
           },
@@ -132,7 +128,7 @@ describe('WebSocket helper', () => {
 
     app.get(
       '/',
-      upgradeWebSocket(() => ({
+      nodeWs.upgradeWebSocket(() => ({
         onOpen() {
           openConnections++
         },
@@ -181,7 +177,7 @@ describe('WebSocket helper', () => {
     const testReason = 'Test!'
     app.get(
       '/',
-      upgradeWebSocket(() => ({
+      nodeWs.upgradeWebSocket(() => ({
         onClose(event) {
           expect(event.code).toBe(testCode)
           expect(event.reason).toBe(testReason)
@@ -198,7 +194,7 @@ describe('WebSocket helper', () => {
     const mainPromise = new Promise<WSMessageReceive>((resolve) =>
       app.get(
         '/',
-        upgradeWebSocket(() => ({
+        nodeWs.upgradeWebSocket(() => ({
           onMessage(data) {
             resolve(data.data)
           },
@@ -237,7 +233,7 @@ describe('WebSocket helper', () => {
     const mainPromise = new Promise<boolean>((resolve) =>
       app.get(
         '/',
-        upgradeWebSocket(() => ({
+        nodeWs.upgradeWebSocket(() => ({
           onOpen() {
             resolve(true)
           },
@@ -257,7 +253,7 @@ describe('WebSocket helper', () => {
     const mainPromise = new Promise<boolean>((resolve) =>
       app.get(
         '/',
-        upgradeWebSocket(() => ({
+        nodeWs.upgradeWebSocket(() => ({
           onOpen() {
             resolve(true)
           },
@@ -274,7 +270,7 @@ describe('WebSocket helper', () => {
     const mainPromise = new Promise<boolean>((resolve) =>
       app.get(
         '/',
-        upgradeWebSocket(async () => {
+        nodeWs.upgradeWebSocket(async () => {
           await new Promise((resolve) => setTimeout(resolve, 100))
           return {
             onMessage() {
@@ -296,7 +292,7 @@ describe('WebSocket helper', () => {
   it('Should return the wss used for the websocket helper', async () => {
     let clientWs: WebSocket | null = null
     const mainPromise = new Promise<void>((resolve) =>
-      wss.on('connection', (ws) => {
+      nodeWs.wss.on('connection', (ws) => {
         clientWs = ws
         resolve()
       })
@@ -304,20 +300,20 @@ describe('WebSocket helper', () => {
 
     app.get(
       '/',
-      upgradeWebSocket(() => ({}))
+      nodeWs.upgradeWebSocket(() => ({}))
     )
     new WebSocket('ws://localhost:3030/')
 
     await mainPromise
 
     expect(clientWs).toBeTruthy()
-    expect(wss.clients.size).toBe(1)
+    expect(nodeWs.wss.clients.size).toBe(1)
   })
 
   it('Should allow for custom HTTPException status code', async () => {
     app.get(
       '/',
-      upgradeWebSocket(() => {
+      nodeWs.upgradeWebSocket(() => {
         throw new HTTPException(401)
       })
     )
@@ -334,7 +330,7 @@ describe('WebSocket helper', () => {
     it('Should accept and apply custom WebSocketServer options', async () => {
       const customApp = new Hono()
       const maxPayload = 1024 * 1024 // 1MB
-      const { injectWebSocket, upgradeWebSocket, wss } = createNodeWebSocket({
+      const customNodeWs = createNodeWebSocket({
         app: customApp,
         websocketServerOptions: {
           maxPayload,
@@ -347,11 +343,11 @@ describe('WebSocket helper', () => {
           resolve(server)
         })
       })
-      injectWebSocket(customServer)
+      customNodeWs.injectWebSocket(customServer)
 
       customApp.get(
         '/',
-        upgradeWebSocket(() => ({
+        customNodeWs.upgradeWebSocket(() => ({
           onOpen() {
             // Connection opened successfully
           },
@@ -359,8 +355,8 @@ describe('WebSocket helper', () => {
       )
 
       // Verify options are applied
-      expect(wss.options.maxPayload).toBe(maxPayload)
-      expect(wss.options.perMessageDeflate).toBe(false)
+      expect(customNodeWs.wss.options.maxPayload).toBe(maxPayload)
+      expect(customNodeWs.wss.options.perMessageDeflate).toBe(false)
 
       const ws = new WebSocket('ws://localhost:3031/')
       await new Promise<void>((resolve) => ws.on('open', resolve))
@@ -368,9 +364,9 @@ describe('WebSocket helper', () => {
       customServer.close()
     })
 
-    it('Should always set noServer to true regardless of passed options', async () => {
+    it('Should always set noServer to true regardless of passed options', () => {
       const customApp = new Hono()
-      const { wss } = createNodeWebSocket({
+      const customNodeWs = createNodeWebSocket({
         app: customApp,
         websocketServerOptions: {
           // Even if we don't pass noServer, it should be true
@@ -379,12 +375,12 @@ describe('WebSocket helper', () => {
       })
 
       // noServer should always be true for this implementation
-      expect(wss.options.noServer).toBe(true)
+      expect(customNodeWs.wss.options.noServer).toBe(true)
     })
 
     it('Should work without websocketServerOptions (backward compatibility)', async () => {
       const customApp = new Hono()
-      const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({
+      const customNodeWs = createNodeWebSocket({
         app: customApp,
       })
 
@@ -393,12 +389,12 @@ describe('WebSocket helper', () => {
           resolve(server)
         })
       })
-      injectWebSocket(customServer)
+      customNodeWs.injectWebSocket(customServer)
 
       const connectionPromise = new Promise<boolean>((resolve) =>
         customApp.get(
           '/',
-          upgradeWebSocket(() => ({
+          customNodeWs.upgradeWebSocket(() => ({
             onOpen() {
               resolve(true)
             },

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -329,4 +329,86 @@ describe('WebSocket helper', () => {
       })
     )
   })
+
+  describe('WebSocketServer options', () => {
+    it('Should accept and apply custom WebSocketServer options', async () => {
+      const customApp = new Hono()
+      const maxPayload = 1024 * 1024 // 1MB
+      const { injectWebSocket, upgradeWebSocket, wss } = createNodeWebSocket({
+        app: customApp,
+        websocketServerOptions: {
+          maxPayload,
+          perMessageDeflate: false,
+        },
+      })
+
+      const customServer = await new Promise<ServerType>((resolve) => {
+        const server = serve({ fetch: customApp.fetch, port: 3031 }, () => {
+          resolve(server)
+        })
+      })
+      injectWebSocket(customServer)
+
+      customApp.get(
+        '/',
+        upgradeWebSocket(() => ({
+          onOpen() {
+            // Connection opened successfully
+          },
+        }))
+      )
+
+      // Verify options are applied
+      expect(wss.options.maxPayload).toBe(maxPayload)
+      expect(wss.options.perMessageDeflate).toBe(false)
+
+      const ws = new WebSocket('ws://localhost:3031/')
+      await new Promise<void>((resolve) => ws.on('open', resolve))
+      ws.close()
+      customServer.close()
+    })
+
+    it('Should always set noServer to true regardless of passed options', async () => {
+      const customApp = new Hono()
+      const { wss } = createNodeWebSocket({
+        app: customApp,
+        websocketServerOptions: {
+          // Even if we don't pass noServer, it should be true
+          maxPayload: 2048,
+        },
+      })
+
+      // noServer should always be true for this implementation
+      expect(wss.options.noServer).toBe(true)
+    })
+
+    it('Should work without websocketServerOptions (backward compatibility)', async () => {
+      const customApp = new Hono()
+      const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({
+        app: customApp,
+      })
+
+      const customServer = await new Promise<ServerType>((resolve) => {
+        const server = serve({ fetch: customApp.fetch, port: 3032 }, () => {
+          resolve(server)
+        })
+      })
+      injectWebSocket(customServer)
+
+      const connectionPromise = new Promise<boolean>((resolve) =>
+        customApp.get(
+          '/',
+          upgradeWebSocket(() => ({
+            onOpen() {
+              resolve(true)
+            },
+          }))
+        )
+      )
+
+      new WebSocket('ws://localhost:3032/')
+      expect(await connectionPromise).toBe(true)
+      customServer.close()
+    })
+  })
 })

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -1,7 +1,7 @@
 import type { Hono } from 'hono'
 import { defineWebSocketHelper } from 'hono/ws'
 import type { UpgradeWebSocket, WSContext } from 'hono/ws'
-import type { WebSocket } from 'ws'
+import type { ServerOptions, WebSocket } from 'ws'
 import { WebSocketServer } from 'ws'
 import { STATUS_CODES } from 'node:http'
 import type { IncomingMessage, Server } from 'node:http'
@@ -23,6 +23,11 @@ export interface NodeWebSocketInit {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   app: Hono<any, any, any>
   baseUrl?: string | URL
+  /**
+   * Options to pass to the WebSocketServer constructor.
+   * Note: `noServer` option will always be set to `true` internally.
+   */
+  websocketServerOptions?: Omit<ServerOptions, 'noServer'>
 }
 
 const generateConnectionSymbol = () => Symbol('connection')
@@ -36,7 +41,10 @@ const CONNECTION_SYMBOL_KEY: unique symbol = Symbol('CONNECTION_SYMBOL_KEY')
  * @returns NodeWebSocket
  */
 export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
-  const wss = new WebSocketServer({ noServer: true })
+  const wss = new WebSocketServer({
+    noServer: true,
+    ...init.websocketServerOptions,
+  })
   const waiterMap = new Map<
     IncomingMessage,
     { resolve: (ws: WebSocket) => void; connectionSymbol: symbol }


### PR DESCRIPTION
This PR adds support for passing custom WebSocketServer options to createNodeWebSocket, addressing issue #1786.

- Added websocketServerOptions parameter to NodeWebSocketInit interface
- Users can now configure WebSocketServer options like maxPayload, perMessageDeflate, clientTracking, etc.
- The noServer option remains enforced as true internally and cannot be overridden
- Added comprehensive tests to verify the new functionality
- Updated README with usage examples and documentation