### PR TITLE
fix(zod-openapi): bump `zod-to-openapi` to allow nested discriminated unions

### DIFF
--- a/.changeset/many-suits-bake.md
+++ b/.changeset/many-suits-bake.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: bump @asteasolutions/zod-to-openapi to allow nested discriminated unions

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -53,7 +53,7 @@
     "zod": "^4.2.1"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^8.4.1",
+    "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@hono/zod-validator": "workspace:^",
     "openapi3-ts": "^4.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,14 +194,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asteasolutions/zod-to-openapi@npm:^8.4.1":
-  version: 8.4.1
-  resolution: "@asteasolutions/zod-to-openapi@npm:8.4.1"
+"@asteasolutions/zod-to-openapi@npm:^8.5.0":
+  version: 8.5.0
+  resolution: "@asteasolutions/zod-to-openapi@npm:8.5.0"
   dependencies:
     openapi3-ts: "npm:^4.1.2"
   peerDependencies:
     zod: ^4.0.0
-  checksum: 10c0/32f3ea00f2b96c94cde261780adb5a3afa119a0b64d438e43b198a3ed488b6719bd1d054f93186abb9c1742373beb87cc0efdefd5efdffc9943674cfa06f74ce
+  checksum: 10c0/989674e297dbf5daef56813795d5b40a18d8de49e95f67d4d81f17e5b59f678f1a202b68631fa1a2bc83f9bbcb57db90c6a33d33e71a09579e46a0707e785a4b
   languageName: node
   linkType: hard
 
@@ -2471,7 +2471,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hono/zod-openapi@workspace:packages/zod-openapi"
   dependencies:
-    "@asteasolutions/zod-to-openapi": "npm:^8.4.1"
+    "@asteasolutions/zod-to-openapi": "npm:^8.5.0"
     "@hono/zod-validator": "workspace:^"
     hono: "npm:^4.11.5"
     openapi3-ts: "npm:^4.5.0"


### PR DESCRIPTION
…d unions

### The author should do the following, if applicable

- [ ] Add tests
- [X] Run tests
- [X] `yarn changeset` at the top of this repo and push the changeset
- [X] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

See https://github.com/asteasolutions/zod-to-openapi/pull/367