### PR TITLE
fix(mcp): allow loopback redirect_uri with any port per RFC 8252

### DIFF
--- a/packages/mcp/src/auth/helpers/authorize.test.ts
+++ b/packages/mcp/src/auth/helpers/authorize.test.ts
@@ -29,6 +29,13 @@ describe('Authorization Handler', () => {
     scope: 'profile email',
   }
 
+  const loopbackClient: OAuthClientInformationFull = {
+    client_id: 'loopback-client',
+    client_secret: 'valid-secret',
+    redirect_uris: ['http://localhost/callback', 'http://127.0.0.1/callback'],
+    scope: 'profile email',
+  }
+
   // Mock client store
   const mockClientStore: OAuthRegisteredClientsStore = {
     async getClient(clientId: string): Promise<OAuthClientInformationFull | undefined> {
@@ -36,6 +43,8 @@ describe('Authorization Handler', () => {
         return validClient
       } else if (clientId === 'multi-redirect-client') {
         return multiRedirectClient
+      } else if (clientId === 'loopback-client') {
+        return loopbackClient
       }
       return undefined
     },
@@ -183,6 +192,58 @@ describe('Authorization Handler', () => {
       expect(response.status).toBe(302)
       const location = new URL(response.headers.get('location')!)
       expect(location.origin + location.pathname).toBe('https://example.com/callback')
+    })
+
+    it('accepts localhost redirect_uri with different port per RFC 8252', async () => {
+      const url = new URL('/authorize', 'https://example.com')
+      url.searchParams.set('client_id', 'loopback-client')
+      url.searchParams.set('redirect_uri', 'http://localhost:58621/callback')
+      url.searchParams.set('response_type', 'code')
+      url.searchParams.set('code_challenge', 'challenge123')
+      url.searchParams.set('code_challenge_method', 'S256')
+      const response = await app.request(url)
+
+      expect(response.status).toBe(302)
+      const location = new URL(response.headers.get('location')!)
+      expect(location.origin + location.pathname).toBe('http://localhost:58621/callback')
+    })
+
+    it('accepts 127.0.0.1 redirect_uri with different port per RFC 8252', async () => {
+      const url = new URL('/authorize', 'https://example.com')
+      url.searchParams.set('client_id', 'loopback-client')
+      url.searchParams.set('redirect_uri', 'http://127.0.0.1:9999/callback')
+      url.searchParams.set('response_type', 'code')
+      url.searchParams.set('code_challenge', 'challenge123')
+      url.searchParams.set('code_challenge_method', 'S256')
+      const response = await app.request(url)
+
+      expect(response.status).toBe(302)
+      const location = new URL(response.headers.get('location')!)
+      expect(location.origin + location.pathname).toBe('http://127.0.0.1:9999/callback')
+    })
+
+    it('rejects loopback redirect_uri with different path', async () => {
+      const url = new URL('/authorize', 'https://example.com')
+      url.searchParams.set('client_id', 'loopback-client')
+      url.searchParams.set('redirect_uri', 'http://localhost:58621/evil')
+      url.searchParams.set('response_type', 'code')
+      url.searchParams.set('code_challenge', 'challenge123')
+      url.searchParams.set('code_challenge_method', 'S256')
+      const response = await app.request(url)
+
+      expect(response.status).toBe(400)
+    })
+
+    it('does not apply loopback port matching to non-loopback URIs', async () => {
+      const url = new URL('/authorize', 'https://example.com')
+      url.searchParams.set('client_id', 'valid-client')
+      url.searchParams.set('redirect_uri', 'https://example.com:9999/callback')
+      url.searchParams.set('response_type', 'code')
+      url.searchParams.set('code_challenge', 'challenge123')
+      url.searchParams.set('code_challenge_method', 'S256')
+      const response = await app.request(url)
+
+      expect(response.status).toBe(400)
     })
   })
 

--- a/packages/mcp/src/auth/helpers/authorize.ts
+++ b/packages/mcp/src/auth/helpers/authorize.ts
@@ -30,6 +30,37 @@ const RequestAuthorizationParamsSchema = z.object({
   resource: z.url().optional(),
 })
 
+const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '[::1]']
+
+/**
+ * RFC 8252 Section 7.3: Loopback redirect URIs use ephemeral ports,
+ * so the authorization server MUST allow any port and match only
+ * scheme, host, and path.
+ */
+function isLoopbackRedirectAllowed(redirectUri: string, registeredUris: string[]): boolean {
+  let req: URL
+  try {
+    req = new URL(redirectUri)
+  } catch {
+    return false
+  }
+
+  if (!LOOPBACK_HOSTS.includes(req.hostname)) {
+    return false
+  }
+
+  return registeredUris.some((registered) => {
+    try {
+      const reg = new URL(registered)
+      return (
+        reg.hostname === req.hostname && reg.protocol === req.protocol && reg.pathname === req.pathname
+      )
+    } catch {
+      return false
+    }
+  })
+}
+
 export function authorizeHandler(provider: OAuthServerProvider): MiddlewareHandler {
   return async (c) => {
     c.header('Cache-Control', 'no-store')
@@ -58,7 +89,10 @@ export function authorizeHandler(provider: OAuthServerProvider): MiddlewareHandl
       }
 
       if (redirect_uri !== undefined) {
-        if (!client.redirect_uris.includes(redirect_uri)) {
+        if (
+          !client.redirect_uris.includes(redirect_uri) &&
+          !isLoopbackRedirectAllowed(redirect_uri, client.redirect_uris)
+        ) {
           throw new InvalidRequestError('Unregistered redirect_uri')
         }
       } else if (client.redirect_uris.length === 1) {


### PR DESCRIPTION
We ran into this while running [Smithery](https://smithery.ai) as an MCP OAuth proxy using `@hono/mcp`. Claude Code registers `http://localhost/callback` in its client metadata but connects with an ephemeral port at runtime (e.g. `http://localhost:58621/callback`). The authorize handler rejects it because `redirect_uris.includes()` does a strict string comparison.

[RFC 8252 Section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) says loopback redirect URIs should match on scheme + host + path only, ignoring the port — native OAuth clients pick a random available port each time. Here's the excerpt:
```
 The authorization server MUST allow any port to be specified at the
   time of the request for loopback IP redirect URIs, to accommodate
   clients that obtain an available ephemeral port from the operating
   system at the time of the request.
   ```

This adds a small `isLoopbackRedirectAllowed()` helper that kicks in only for `localhost`, `127.0.0.1`, and `[::1]`. Everything else still uses strict matching. Four new tests cover the happy path, path mismatch rejection, and non-loopback strictness.

Fixes #1823

### The author should do the following, if applicable

- [x] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

> Note: haven't run `yarn changeset` yet — happy to add one if this approach looks right.