### PR TITLE
feat(inertia): return props for JSON requests

### DIFF
--- a/.changeset/giant-candies-work.md
+++ b/.changeset/giant-candies-work.md
@@ -1,0 +1,5 @@
+---
+'@hono/inertia': minor
+---
+
+feat(inertia): return props for JSON requests

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -10,7 +10,7 @@ app.use(inertia())
 app.get('/posts/:id', (c) => c.render('Posts/Show', { post }))
 ```
 
-That's it. The middleware speaks the full [Inertia protocol](https://inertiajs.com/the-protocol) — JSON page objects for in-app navigation, hydratable HTML for initial loads, `409` redirects on asset version mismatch — while staying framework agnostic. Plug in any view layer through `rootView`, get end-to-end type safety on `c.render(component, props)` via the bundled Vite plugin, and ship to any runtime Hono runs on.
+That's it. The middleware speaks the full [Inertia protocol](https://inertiajs.com/the-protocol) — JSON page objects for in-app navigation, hydratable HTML for initial loads, `409` redirects on asset version mismatch — while staying framework agnostic. It also returns the rendered props JSON directly when a request accepts `application/json`, so the same route can serve a JSON response without an extra endpoint. Plug in any view layer through `rootView`, get end-to-end type safety on `c.render(component, props)` via the bundled Vite plugin, and ship to any runtime Hono runs on.
 
 ## Install
 

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -13,6 +13,7 @@ describe('inertia', () => {
       const res = await app.request('/')
 
       expect(res.status).toBe(200)
+      expect(res.headers.get('Vary')).toBe('Accept, X-Inertia')
       expect(res.headers.get('content-type')).toContain('text/html')
       const html = await res.text()
       expect(html).toContain('<!DOCTYPE html>')
@@ -103,6 +104,23 @@ describe('inertia', () => {
 
       expect(seen[0]?.version).toBeNull()
     })
+
+    it('responds with JSON props when JSON is accepted', async () => {
+      const app = new Hono()
+      app.use(inertia())
+      app.get('/', (c) => c.render('Home', { message: 'hello' }))
+
+      const res = await app.request('/', {
+        headers: {
+          Accept: 'application/json',
+        },
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Vary')).toBe('Accept, X-Inertia')
+      expect(res.headers.get('content-type')).toContain('application/json')
+      expect(await res.json()).toEqual({ message: 'hello' })
+    })
   })
 
   describe('Inertia (XHR) request', () => {
@@ -120,7 +138,7 @@ describe('inertia', () => {
 
       expect(res.status).toBe(200)
       expect(res.headers.get('X-Inertia')).toBe('true')
-      expect(res.headers.get('Vary')).toBe('X-Inertia')
+      expect(res.headers.get('Vary')).toBe('Accept, X-Inertia')
       expect(res.headers.get('content-type')).toContain('application/json')
       expect(await res.json()).toEqual({
         component: 'Posts/Index',

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -4,7 +4,8 @@
  *
  * Implements the [Inertia.js protocol](https://inertiajs.com/the-protocol) so
  * that `c.render(component, props)` returns the appropriate JSON page object
- * for XHR requests and a full HTML document for initial page loads.
+ * for Inertia XHR requests, props JSON for requests that accept JSON, and a
+ * full HTML document for initial page loads.
  */
 
 import type { Context, MiddlewareHandler, TypedResponse } from 'hono'
@@ -79,7 +80,8 @@ const defaultRootView: RootView = (page) =>
  * Inertia.js middleware for Hono.
  *
  * Sets up `c.render(component, props)` to respond according to the Inertia
- * protocol: JSON for `X-Inertia` requests, full HTML otherwise.
+ * protocol: JSON page objects for `X-Inertia` requests, props JSON for
+ * `Accept: application/json` requests, full HTML otherwise.
  *
  * @example
  * ```ts
@@ -116,10 +118,15 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
         version,
       }
 
+      c.header('Vary', 'Accept, X-Inertia')
+
       if (c.req.header('X-Inertia')) {
         c.header('X-Inertia', 'true')
-        c.header('Vary', 'X-Inertia')
         return c.json(page)
+      }
+
+      if (c.req.header('Accept')?.includes('application/json')) {
+        return c.json(props)
       }
 
       const rendered = rootView(page, c)


### PR DESCRIPTION
Adds a JSON response path to `@hono/inertia` so `c.render(component, props)` returns the rendered props directly when the request accepts `application/json`.

`X-Inertia` requests still return the Inertia page object, and normal initial page loads still return HTML. Responses now vary on both `Accept` and `X-Inertia` so caches can distinguish those response shapes.

Docs and tests are updated for the new response mode.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
