### PR TITLE
fix(node-ws): forward response headers during upgrade

### DIFF
--- a/.changeset/polite-cooks-report.md
+++ b/.changeset/polite-cooks-report.md
@@ -2,4 +2,7 @@
 '@hono/node-ws': patch
 ---
 
-Forward Hono response headers to WebSocket upgrade responses.
+Fix: forward Hono response headers (e.g., `Set-Cookie`, custom auth headers)
+to WebSocket upgrade responses so headers set by middleware are not dropped
+during the handshake. Hop-by-hop headers (per [RFC 9110 Section 7.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#name-connection))
+and headers managed by `ws` are skipped to avoid corrupting the handshake.

--- a/.changeset/polite-cooks-report.md
+++ b/.changeset/polite-cooks-report.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': patch
+---
+
+Forward Hono response headers to WebSocket upgrade responses.

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -270,6 +270,57 @@ describe('WebSocket helper', () => {
     expect(await mainPromise).toBe(true)
   })
 
+  it('Should include response headers in the WebSocket upgrade response', async () => {
+    app.use(async (c, next) => {
+      await next()
+      c.header('x-auth-result', c.req.header('authorization') ? 'authorized' : 'missing')
+    })
+    app.get(
+      '/',
+      upgradeWebSocket(() => ({}))
+    )
+
+    const ws = new WebSocket('ws://localhost:3030/', {
+      headers: {
+        authorization: 'Bearer token',
+      },
+    })
+    const responseHeaders = await new Promise<Record<string, string | string[] | undefined>>(
+      (resolve) => {
+        ws.on('upgrade', (response) => {
+          resolve(response.headers)
+        })
+      }
+    )
+    ws.close()
+
+    expect(responseHeaders['x-auth-result']).toBe('authorized')
+  })
+
+  it('Should include response headers in rejected WebSocket response', async () => {
+    app.get(
+      '/',
+      () =>
+        new Response(null, {
+          status: 401,
+          headers: {
+            'x-auth-result': 'missing',
+          },
+        })
+    )
+
+    const ws = new WebSocket('ws://localhost:3030/')
+    const responseHeaders = await new Promise<Record<string, string | string[] | undefined>>(
+      (resolve) => {
+        ws.on('unexpected-response', (_, response) => {
+          resolve(response.headers)
+        })
+      }
+    )
+
+    expect(responseHeaders['x-auth-result']).toBe('missing')
+  })
+
   it('Should not async processes to create events affect message handling', async () => {
     const mainPromise = new Promise<boolean>((resolve) =>
       app.get(

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -30,13 +30,24 @@ const generateConnectionSymbol = () => Symbol('connection')
 /** @example `c.env[CONNECTION_SYMBOL_KEY]` */
 const CONNECTION_SYMBOL_KEY: unique symbol = Symbol('CONNECTION_SYMBOL_KEY')
 
+// Hop-by-hop headers per RFC 9110 Section 7.6.1
+// (https://www.rfc-editor.org/rfc/rfc9110.html#name-connection) plus
+// `keep-alive` (commonly treated as hop-by-hop by HTTP implementations) and
+// WebSocket handshake headers managed by `ws` itself. These must not be
+// forwarded onto the upgrade response or the handshake will be corrupted.
 const responseHeadersToSkip = new Set([
   'connection',
   'content-length',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
   'sec-websocket-accept',
   'sec-websocket-extensions',
   'sec-websocket-protocol',
-  'upgrade',
 ])
 
 const appendResponseHeaders = (headers: string[], responseHeaders: Headers) => {
@@ -100,12 +111,12 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
         const waiter = waiterMap.get(request)
 
         if (!waiter || waiter.connectionSymbol !== env[CONNECTION_SYMBOL_KEY]) {
-          const headers = ['Connection: close', 'Content-Length: 0']
-          appendResponseHeaders(headers, response.headers)
+          const responseLines = ['Connection: close', 'Content-Length: 0']
+          appendResponseHeaders(responseLines, response.headers)
 
           socket.end(
             `HTTP/1.1 ${response.status.toString()} ${STATUS_CODES[response.status] ?? ''}\r\n` +
-              `${headers.join('\r\n')}\r\n` +
+              `${responseLines.join('\r\n')}\r\n` +
               '\r\n'
           )
           waiterMap.delete(request)
@@ -116,6 +127,8 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
           appendResponseHeaders(headers, response.headers)
         }
 
+        // `headers` is emitted synchronously inside `handleUpgrade`, so this
+        // listener cannot leak across concurrent upgrades on the shared `wss`.
         wss.on('headers', addResponseHeaders)
         try {
           wss.handleUpgrade(request, socket, head, (ws) => {

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -30,6 +30,24 @@ const generateConnectionSymbol = () => Symbol('connection')
 /** @example `c.env[CONNECTION_SYMBOL_KEY]` */
 const CONNECTION_SYMBOL_KEY: unique symbol = Symbol('CONNECTION_SYMBOL_KEY')
 
+const responseHeadersToSkip = new Set([
+  'connection',
+  'content-length',
+  'sec-websocket-accept',
+  'sec-websocket-extensions',
+  'sec-websocket-protocol',
+  'upgrade',
+])
+
+const appendResponseHeaders = (headers: string[], responseHeaders: Headers) => {
+  responseHeaders.forEach((value, key) => {
+    if (responseHeadersToSkip.has(key.toLowerCase())) {
+      return
+    }
+    headers.push(`${key}: ${value}`)
+  })
+}
+
 /**
  * Create WebSockets for Node.js
  * @param init Options
@@ -82,19 +100,30 @@ export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
         const waiter = waiterMap.get(request)
 
         if (!waiter || waiter.connectionSymbol !== env[CONNECTION_SYMBOL_KEY]) {
+          const headers = ['Connection: close', 'Content-Length: 0']
+          appendResponseHeaders(headers, response.headers)
+
           socket.end(
             `HTTP/1.1 ${response.status.toString()} ${STATUS_CODES[response.status] ?? ''}\r\n` +
-              'Connection: close\r\n' +
-              'Content-Length: 0\r\n' +
+              `${headers.join('\r\n')}\r\n` +
               '\r\n'
           )
           waiterMap.delete(request)
           return
         }
 
-        wss.handleUpgrade(request, socket, head, (ws) => {
-          wss.emit('connection', ws, request)
-        })
+        const addResponseHeaders = (headers: string[]) => {
+          appendResponseHeaders(headers, response.headers)
+        }
+
+        wss.on('headers', addResponseHeaders)
+        try {
+          wss.handleUpgrade(request, socket, head, (ws) => {
+            wss.emit('connection', ws, request)
+          })
+        } finally {
+          wss.off('headers', addResponseHeaders)
+        }
       })
     },
     upgradeWebSocket: defineWebSocketHelper(async (c, events, options) => {


### PR DESCRIPTION
## Summary

Forward Hono response headers to the WebSocket upgrade response so headers set by middleware (e.g. `Set-Cookie`, custom auth headers, `WWW-Authenticate` on reject) are no longer dropped during the handshake.

Previously, `injectWebSocket` discarded `response.headers` after `init.app.request(...)`, so any header attached by Hono middleware never reached the client — both on successful upgrades and on rejected upgrades (4xx/5xx).

## Changes

- On successful upgrade, response headers are appended via `wss.on('headers', ...)` (the official `ws` API for injecting handshake headers). The listener is removed in `finally`; `headers` is emitted synchronously inside `handleUpgrade`, so it cannot leak across concurrent upgrades.
- On rejected upgrade (no waiter / connectionSymbol mismatch), response headers are written into the manual `socket.end(...)` HTTP response.
- Skip hop-by-hop headers per [RFC 9110 §7.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#name-connection) (`connection`, `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailer`, `transfer-encoding`, `upgrade`), plus framing (`content-length`) and WebSocket handshake headers managed by `ws` (`sec-websocket-accept`, `sec-websocket-extensions`, `sec-websocket-protocol`) to avoid corrupting the handshake.

## Verification

- `yarn workspace @hono/node-ws typecheck`
- `yarn workspace @hono/node-ws test run` (15/15 passing, including 2 new tests)
- `yarn prettier --check packages/node-ws/src/index.ts packages/node-ws/src/index.test.ts .changeset/polite-cooks-report.md`

New tests cover:
- Custom response header set by middleware reaches the client on a successful upgrade.
- Custom response header is preserved on a rejected (401) upgrade response.