### PR TITLE
fix(zod-openapi): inherit defaultHook from parent app on nested routes

### DIFF
--- a/.changeset/inherit-default-hook-on-route.md
+++ b/.changeset/inherit-default-hook-on-route.md
@@ -1,5 +1,7 @@
 ---
-'@hono/zod-openapi': patch
+'@hono/zod-openapi': minor
 ---
 
-fix: inherit `defaultHook` from parent app on nested routes mounted via `app.route()`
+feat: inherit `defaultHook` from parent app on nested routes mounted via `app.route()`
+
+Behavior change: if a parent app has a `defaultHook` and a mounted sub-app does not declare its own, the sub-app's routes now use the parent's `defaultHook` instead of the built-in validation response.

--- a/.changeset/inherit-default-hook-on-route.md
+++ b/.changeset/inherit-default-hook-on-route.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: inherit `defaultHook` from parent app on nested routes mounted via `app.route()`

--- a/packages/zod-openapi/src/index.test.ts
+++ b/packages/zod-openapi/src/index.test.ts
@@ -1083,6 +1083,28 @@ describe('Routers', () => {
     })
     expect(res.status).toBe(200)
   })
+
+  it('Should apply the parent app defaultHook to nested routes mounted via app.route()', async () => {
+    const subApp = new OpenAPIHono().openapi(route, (c) => c.json({ id: 123 }))
+
+    const app = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) {
+          return c.json({ ok: false, source: 'parentDefaultHook' }, 422)
+        }
+      },
+    }).route('/api', subApp)
+
+    const res = await app.request('/api/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 'not-a-number' }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({ ok: false, source: 'parentDefaultHook' })
+  })
 })
 
 describe('Multi params', () => {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -576,7 +576,7 @@ export class OpenAPIHono<
             ? MaybePromise<RouteConfigToTypedResponse<R>> | undefined
             : MaybePromise<RouteConfigToTypedResponse<R>> | MaybePromise<Response> | undefined
         >
-      | undefined = this.defaultHook
+      | undefined = undefined
   ): OpenAPIHono<
     E,
     S & ToSchema<R['method'], MergePath<BasePath, P>, I, RouteConfigToTypedResponse<R>>,
@@ -586,25 +586,32 @@ export class OpenAPIHono<
       this.openAPIRegistry.registerPath(route)
     }
 
+    // Resolve the defaultHook lazily so nested apps mounted via `route()`
+    // can inherit the parent's defaultHook. See #1306.
+    const effectiveHook =
+      hook ??
+      ((result: any, c: any) =>
+        this.defaultHook ? (this.defaultHook as any)(result, c) : undefined)
+
     const validators: MiddlewareHandler[] = []
 
     if (route.request?.query) {
-      const validator = zValidator('query', route.request.query as any, hook as any)
+      const validator = zValidator('query', route.request.query as any, effectiveHook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.params) {
-      const validator = zValidator('param', route.request.params as any, hook as any)
+      const validator = zValidator('param', route.request.params as any, effectiveHook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.headers) {
-      const validator = zValidator('header', route.request.headers as any, hook as any)
+      const validator = zValidator('header', route.request.headers as any, effectiveHook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.cookies) {
-      const validator = zValidator('cookie', route.request.cookies as any, hook as any)
+      const validator = zValidator('cookie', route.request.cookies as any, effectiveHook as any)
       validators.push(validator as any)
     }
 
@@ -622,7 +629,7 @@ export class OpenAPIHono<
         if (isJSONContentType(mediaType)) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore we can ignore the type error since Zod Validator's types are not used
-          const validator = zValidator('json', schema, hook) as MiddlewareHandler
+          const validator = zValidator('json', schema, effectiveHook as any) as MiddlewareHandler
           if (route.request?.body?.required) {
             validators.push(validator)
           } else {
@@ -641,7 +648,7 @@ export class OpenAPIHono<
         if (isFormContentType(mediaType)) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore we can ignore the type error since Zod Validator's types are not used
-          const validator = zValidator('form', schema, hook) as MiddlewareHandler
+          const validator = zValidator('form', schema, effectiveHook as any) as MiddlewareHandler
           if (route.request?.body?.required) {
             validators.push(validator)
           } else {
@@ -792,6 +799,10 @@ export class OpenAPIHono<
 
     if (!(app instanceof OpenAPIHono)) {
       return this as any
+    }
+
+    if (app.defaultHook === undefined && this.defaultHook !== undefined) {
+      app.defaultHook = this.defaultHook
     }
 
     app.openAPIRegistry.definitions.forEach((def) => {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -576,7 +576,7 @@ export class OpenAPIHono<
             ? MaybePromise<RouteConfigToTypedResponse<R>> | undefined
             : MaybePromise<RouteConfigToTypedResponse<R>> | MaybePromise<Response> | undefined
         >
-      | undefined = this.defaultHook
+      | undefined = undefined // eslint-disable-line @typescript-eslint/no-useless-default-assignment
   ): OpenAPIHono<
     E,
     S & ToSchema<R['method'], MergePath<BasePath, P>, I, RouteConfigToTypedResponse<R>>,
@@ -586,25 +586,34 @@ export class OpenAPIHono<
       this.openAPIRegistry.registerPath(route)
     }
 
+    // Resolve the defaultHook lazily so nested apps mounted via `route()`
+    // can inherit the parent's defaultHook. See #1306.
+    /* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+    const effectiveHook =
+      hook ??
+      ((result: any, c: any) =>
+        this.defaultHook ? (this.defaultHook as any)(result, c) : undefined)
+    /* eslint-enable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+
     const validators: MiddlewareHandler[] = []
 
     if (route.request?.query) {
-      const validator = zValidator('query', route.request.query as any, hook as any)
+      const validator = zValidator('query', route.request.query as any, effectiveHook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.params) {
-      const validator = zValidator('param', route.request.params as any, hook as any)
+      const validator = zValidator('param', route.request.params as any, effectiveHook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.headers) {
-      const validator = zValidator('header', route.request.headers as any, hook as any)
+      const validator = zValidator('header', route.request.headers as any, effectiveHook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.cookies) {
-      const validator = zValidator('cookie', route.request.cookies as any, hook as any)
+      const validator = zValidator('cookie', route.request.cookies as any, effectiveHook as any)
       validators.push(validator as any)
     }
 
@@ -622,7 +631,7 @@ export class OpenAPIHono<
         if (isJSONContentType(mediaType)) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore we can ignore the type error since Zod Validator's types are not used
-          const validator = zValidator('json', schema, hook as any) as MiddlewareHandler
+          const validator = zValidator('json', schema, effectiveHook as any) as MiddlewareHandler
           if (route.request?.body?.required) {
             validators.push(validator)
           } else {
@@ -641,7 +650,7 @@ export class OpenAPIHono<
         if (isFormContentType(mediaType)) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore we can ignore the type error since Zod Validator's types are not used
-          const validator = zValidator('form', schema, hook as any) as MiddlewareHandler
+          const validator = zValidator('form', schema, effectiveHook as any) as MiddlewareHandler
           if (route.request?.body?.required) {
             validators.push(validator)
           } else {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -576,7 +576,7 @@ export class OpenAPIHono<
             ? MaybePromise<RouteConfigToTypedResponse<R>> | undefined
             : MaybePromise<RouteConfigToTypedResponse<R>> | MaybePromise<Response> | undefined
         >
-      | undefined = undefined
+      | undefined = this.defaultHook
   ): OpenAPIHono<
     E,
     S & ToSchema<R['method'], MergePath<BasePath, P>, I, RouteConfigToTypedResponse<R>>,
@@ -586,32 +586,25 @@ export class OpenAPIHono<
       this.openAPIRegistry.registerPath(route)
     }
 
-    // Resolve the defaultHook lazily so nested apps mounted via `route()`
-    // can inherit the parent's defaultHook. See #1306.
-    const effectiveHook =
-      hook ??
-      ((result: any, c: any) =>
-        this.defaultHook ? (this.defaultHook as any)(result, c) : undefined)
-
     const validators: MiddlewareHandler[] = []
 
     if (route.request?.query) {
-      const validator = zValidator('query', route.request.query as any, effectiveHook as any)
+      const validator = zValidator('query', route.request.query as any, hook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.params) {
-      const validator = zValidator('param', route.request.params as any, effectiveHook as any)
+      const validator = zValidator('param', route.request.params as any, hook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.headers) {
-      const validator = zValidator('header', route.request.headers as any, effectiveHook as any)
+      const validator = zValidator('header', route.request.headers as any, hook as any)
       validators.push(validator as any)
     }
 
     if (route.request?.cookies) {
-      const validator = zValidator('cookie', route.request.cookies as any, effectiveHook as any)
+      const validator = zValidator('cookie', route.request.cookies as any, hook as any)
       validators.push(validator as any)
     }
 
@@ -629,7 +622,7 @@ export class OpenAPIHono<
         if (isJSONContentType(mediaType)) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore we can ignore the type error since Zod Validator's types are not used
-          const validator = zValidator('json', schema, effectiveHook as any) as MiddlewareHandler
+          const validator = zValidator('json', schema, hook as any) as MiddlewareHandler
           if (route.request?.body?.required) {
             validators.push(validator)
           } else {
@@ -648,7 +641,7 @@ export class OpenAPIHono<
         if (isFormContentType(mediaType)) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore we can ignore the type error since Zod Validator's types are not used
-          const validator = zValidator('form', schema, effectiveHook as any) as MiddlewareHandler
+          const validator = zValidator('form', schema, hook as any) as MiddlewareHandler
           if (route.request?.body?.required) {
             validators.push(validator)
           } else {


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

When mounting a nested `OpenAPIHono` via `app.route(path, subApp)`, the sub-app's routes did not pick up the parent's `defaultHook`. The default hook on the parent was only applied to routes registered directly on the parent (`PR #408` did the analogous fix for `basePath()`).

The validator's `hook` parameter defaulted to `this.defaultHook` at registration time, so sub-app routes registered before mounting were bound to `undefined`. Switched the default to a lazy wrapper that reads `this.defaultHook` at request time, and propagated the parent's `defaultHook` to the sub-app on `route()` when the sub-app does not declare its own.

Added a regression test under the `Routers` describe block that fails on `main` and passes with the fix.