### PR TITLE
zod-openapi: infer parent Variables in defineOpenAPIRoute

### DIFF
--- a/.changeset/zod-openapi-define-route-middleware-env.md
+++ b/.changeset/zod-openapi-define-route-middleware-env.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+`defineOpenAPIRoute` now infers handler `Env` (Variables/Bindings) from the route's `middleware`, matching `OpenAPIHono.openapi()` behavior.

--- a/packages/zod-openapi/src/handler.test-d.ts
+++ b/packages/zod-openapi/src/handler.test-d.ts
@@ -1,7 +1,7 @@
 import type { MiddlewareHandler } from 'hono'
 import type { Equal, Expect } from 'hono/utils/types'
 import type { MiddlewareToHandlerType, OfHandlerType, RouteHandler } from '.'
-import { OpenAPIHono, createRoute, z } from '.'
+import { OpenAPIHono, createRoute, defineOpenAPIRoute, z } from '.'
 
 describe('supports async handler', () => {
   const route = createRoute({
@@ -227,5 +227,43 @@ describe('supports async handler', () => {
     hono.openapi(routeWithDefault, successHandler)
     hono.openapi(routeWithDefault, notFoundHandler)
     hono.openapi(routeWithDefault, errorHandler)
+  })
+})
+
+describe('defineOpenAPIRoute', () => {
+  test('handler infers env type from route middleware', () => {
+    // https://github.com/honojs/middleware/issues/1879
+    type Identity = { id: string }
+    type CustomEnv = { Variables: { identity: Identity } }
+
+    const requireIdentity: MiddlewareHandler<CustomEnv> = async (c, next) => {
+      c.set('identity', { id: '123' })
+      await next()
+    }
+
+    const definition = defineOpenAPIRoute({
+      route: createRoute({
+        method: 'get',
+        path: '/me',
+        middleware: [requireIdentity] as const,
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: z.object({ id: z.string() }),
+              },
+            },
+            description: 'ok',
+          },
+        },
+      }),
+      handler: (c) => {
+        type IdentityType = typeof c.var.identity
+        type Verify = Expect<Equal<IdentityType, Identity>>
+        return c.json({ id: c.var.identity.id }, 200)
+      },
+    })
+
+    new OpenAPIHono().openapiRoutes([definition])
   })
 })

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -404,9 +404,16 @@ type ComputeInput<R extends RouteConfig> = InputTypeParam<R> &
   InputTypeForm<R> &
   InputTypeJson<R>
 
+// Helper: Merge env with route middleware env (if any)
+type EnvFromRoute<R extends RouteConfig, E extends Env> = R['middleware'] extends
+  | MiddlewareHandler[]
+  | MiddlewareHandler
+  ? RouteMiddlewareParams<R>['env'] & E
+  : E
+
 // Helper: Calculate the expected Handler type for a specific RouteConfig
 type HandlerFromRoute<R extends RouteConfig, E extends Env> = Handler<
-  E,
+  EnvFromRoute<R, E>,
   ConvertPathType<R['path']>,
   ComputeInput<R>,
   R extends {
@@ -425,7 +432,7 @@ type HandlerFromRoute<R extends RouteConfig, E extends Env> = Handler<
 type HookFromRoute<R extends RouteConfig, E extends Env> =
   | Hook<
       ComputeInput<R>,
-      E,
+      EnvFromRoute<R, E>,
       ConvertPathType<R['path']>,
       R extends {
         responses: {


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

Fixes #1879. `defineOpenAPIRoute`'s `HandlerFromRoute`/`HookFromRoute` previously dropped the route `middleware`'s `Variables`, leaving `c.var.*` typed as `any`. They now use the same `R['middleware'] extends MiddlewareHandler[] | MiddlewareHandler ? RouteMiddlewareParams<R>['env'] & E : E` pattern that `OpenAPIHono.openapi()` already uses, and a new type test in `handler.test-d.ts` asserts the inferred handler env carries the middleware's `Variables`.