### PR TITLE
fix(otel): set requestduration buckets to follow semconv

### DIFF
--- a/.changeset/six-onions-fry.md
+++ b/.changeset/six-onions-fry.md
@@ -1,5 +1,5 @@
 ---
-'@hono/otel': minor
+'@hono/otel': patch
 ---
 
 Fixes request duration histogram bucketing

--- a/.changeset/six-onions-fry.md
+++ b/.changeset/six-onions-fry.md
@@ -1,0 +1,5 @@
+---
+'@hono/otel': minor
+---
+
+Fixes request duration histogram bucketing

--- a/packages/otel/src/index.test.ts
+++ b/packages/otel/src/index.test.ts
@@ -345,7 +345,7 @@ describe('OpenTelemetry middleware - Metrics (combined)', () => {
     const durationMetric = metrics.find((m) => m.descriptor.name === 'http.server.request.duration')
     assert.ok(durationMetric)
     assert.strictEqual(durationMetric.descriptor.unit, 's')
-    const dps = durationMetric.dataPoints
+    const dps = durationMetric.dataPoints as DataPoint<Histogram>[]
     assert.strictEqual(dps.length, 1)
     const dp = dps[0]
     assert.strictEqual(dp.attributes['http.request.method'], 'GET')

--- a/packages/otel/src/index.test.ts
+++ b/packages/otel/src/index.test.ts
@@ -353,6 +353,10 @@ describe('OpenTelemetry middleware - Metrics (combined)', () => {
     if (dp.attributes['http.response.status_code']) {
       assert.strictEqual(dp.attributes['http.response.status_code'], 200)
     }
+    assert.deepStrictEqual(
+      dp.value.buckets.boundaries,
+      [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]
+    )
   })
 
   it('Should include serviceName and serviceVersion in metric attributes', async () => {

--- a/packages/otel/src/trackers.ts
+++ b/packages/otel/src/trackers.ts
@@ -18,6 +18,11 @@ export const createRequestDurationTracker = (
     description: 'Duration of HTTP requests in seconds',
     unit: 's',
     valueType: ValueType.DOUBLE,
+    advice: {
+      explicitBucketBoundaries: [
+        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+      ],
+    },
   })
   return {
     record(duration: number, attrs: Attributes) {


### PR DESCRIPTION
Fixes #1861 

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
