### PR TITLE
feat(inertia): add partial reloads support with lazy function props

### DIFF
--- a/.changeset/inertia-partial-reloads.md
+++ b/.changeset/inertia-partial-reloads.md
@@ -1,0 +1,5 @@
+---
+'@hono/inertia': minor
+---
+
+add server-side support for [Inertia.js partial reloads](https://inertiajs.com/partial-reloads). Honors the `X-Inertia-Partial-Component`, `X-Inertia-Partial-Data` (only), and `X-Inertia-Partial-Except` headers, and accepts function-valued props (`() => T | Promise<T>`) that are evaluated lazily — function props excluded from a partial reload are never invoked, so heavy data fetching can be skipped.

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -201,8 +201,12 @@ describe('inertia', () => {
         'X-Inertia-Version': 'v1',
         'X-Inertia-Partial-Component': component,
       }
-      if (only !== undefined) headers['X-Inertia-Partial-Data'] = only
-      if (except !== undefined) headers['X-Inertia-Partial-Except'] = except
+      if (only !== undefined) {
+        headers['X-Inertia-Partial-Data'] = only
+      }
+      if (except !== undefined) {
+        headers['X-Inertia-Partial-Except'] = except
+      }
       return headers
     }
 

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -193,4 +193,193 @@ describe('inertia', () => {
       expect(res.headers.get('X-Inertia')).toBe('true')
     })
   })
+
+  describe('partial reload', () => {
+    const partialHeaders = (component: string, only?: string, except?: string) => {
+      const headers: Record<string, string> = {
+        'X-Inertia': 'true',
+        'X-Inertia-Version': 'v1',
+        'X-Inertia-Partial-Component': component,
+      }
+      if (only !== undefined) headers['X-Inertia-Partial-Data'] = only
+      if (except !== undefined) headers['X-Inertia-Partial-Except'] = except
+      return headers
+    }
+
+    it('returns only the props listed in X-Inertia-Partial-Data', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { a: 1, b: 2, c: 3 }))
+
+      const res = await app.request('/', { headers: partialHeaders('Home', 'a,c') })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        component: 'Home',
+        props: { a: 1, c: 3 },
+        url: '/',
+        version: 'v1',
+      })
+    })
+
+    it('excludes the props listed in X-Inertia-Partial-Except', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { a: 1, b: 2, c: 3 }))
+
+      const res = await app.request('/', {
+        headers: partialHeaders('Home', undefined, 'b'),
+      })
+
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ a: 1, c: 3 })
+    })
+
+    it('does not invoke lazy function props that are filtered out', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          heavy: () => {
+            calls.push('heavy')
+            return 'h'
+          },
+          light: () => {
+            calls.push('light')
+            return 'l'
+          },
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Home', 'light') })
+
+      expect(calls).toEqual(['light'])
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ light: 'l' })
+    })
+
+    it('invokes every function prop on a normal Inertia visit', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          a: () => {
+            calls.push('a')
+            return 1
+          },
+          b: () => {
+            calls.push('b')
+            return 2
+          },
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      expect(calls.sort()).toEqual(['a', 'b'])
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ a: 1, b: 2 })
+    })
+
+    it('awaits async function props', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          users: async () => {
+            await new Promise((r) => setTimeout(r, 5))
+            return [{ id: 1 }]
+          },
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ users: [{ id: 1 }] })
+    })
+
+    it('ignores partial headers when the component does not match', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          x: () => {
+            calls.push('x')
+            return 1
+          },
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Other', 'x') })
+
+      expect(calls).toEqual(['x'])
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ x: 1 })
+    })
+
+    it('handles whitespace and empty entries in the header list', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { a: 1, b: 2, c: 3 }))
+
+      const res = await app.request('/', {
+        headers: partialHeaders('Home', ' a , , c '),
+      })
+
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ a: 1, c: 3 })
+    })
+
+    it('applies only and except in combination (intersection)', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { a: 1, b: 2, c: 3 }))
+
+      const res = await app.request('/', {
+        headers: partialHeaders('Home', 'a,b', 'b'),
+      })
+
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ a: 1 })
+    })
+
+    it('treats only/except headers as full visit when partial component is absent', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          a: () => {
+            calls.push('a')
+            return 1
+          },
+          b: () => {
+            calls.push('b')
+            return 2
+          },
+        })
+      )
+
+      // Only/Except without Partial-Component => not a partial reload
+      const res = await app.request('/', {
+        headers: {
+          'X-Inertia': 'true',
+          'X-Inertia-Version': 'v1',
+          'X-Inertia-Partial-Data': 'a',
+        },
+      })
+
+      expect(calls.sort()).toEqual(['a', 'b'])
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ a: 1, b: 2 })
+    })
+  })
 })

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -137,7 +137,8 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       const partialComponent = c.req.header('X-Inertia-Partial-Component')
       const partialData = c.req.header('X-Inertia-Partial-Data')
       const partialExcept = c.req.header('X-Inertia-Partial-Except')
-      const isPartial = partialComponent === component && Boolean(partialData || partialExcept)
+      const isPartial =
+        partialComponent === component && (partialData !== undefined || partialExcept !== undefined)
 
       const parseKeys = (header: string | undefined): string[] | null =>
         header
@@ -161,8 +162,12 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       const kept: [string, unknown][] = []
       let hasFunction = false
       for (const [key, value] of Object.entries(propsInput)) {
-        if (isExcluded(key)) continue
-        if (typeof value === 'function') hasFunction = true
+        if (isExcluded(key)) {
+          continue
+        }
+        if (typeof value === 'function') {
+          hasFunction = true
+        }
         kept.push([key, value])
       }
 

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -82,6 +82,14 @@ export interface InertiaOptions {
 export const serializePage = (page: PageObject): string =>
   JSON.stringify(page).replace(/\//g, '\\/')
 
+const parseKeys = (header: string | undefined): string[] | null =>
+  header
+    ? header
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : null
+
 const defaultRootView: RootView = (page) =>
   `<!DOCTYPE html>
 <html>
@@ -139,14 +147,6 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       const partialExcept = c.req.header('X-Inertia-Partial-Except')
       const isPartial =
         partialComponent === component && (partialData !== undefined || partialExcept !== undefined)
-
-      const parseKeys = (header: string | undefined): string[] | null =>
-        header
-          ? header
-              .split(',')
-              .map((s) => s.trim())
-              .filter(Boolean)
-          : null
 
       const onlyKeys = isPartial ? parseKeys(partialData) : null
       const exceptKeys = isPartial ? parseKeys(partialExcept) : null

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -30,6 +30,25 @@ export type PageObject<P = Record<string, unknown>> = {
  */
 export type RootView = (page: PageObject, c: Context) => string | Promise<string>
 
+/**
+ * A prop value that can be resolved lazily. When the value is a function it
+ * is only invoked if the prop is included in the current render, which is the
+ * key mechanism behind partial reloads — heavy data fetching can be skipped
+ * for props that the client did not request.
+ */
+export type Resolvable<T> = T | (() => T | Promise<T>)
+
+/**
+ * Resolved form of a {@link Resolvable}. Resolves the awaited return value of
+ * a function prop, or the value itself otherwise.
+ */
+export type Resolved<T> = T extends (...args: never[]) => infer R ? Awaited<R> : T
+
+/**
+ * Applies {@link Resolved} to every property of `P`.
+ */
+export type ResolvedProps<P> = { [K in keyof P]: Resolved<P[K]> }
+
 export interface InertiaOptions {
   /**
    * Asset version. When an Inertia GET request's `X-Inertia-Version` header
@@ -109,31 +128,82 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       }
     }
 
-    c.setRenderer(((component: string, props: Record<string, unknown> = {}) => {
+    c.setRenderer(((component: string, propsInput: Record<string, unknown> = {}) => {
       const url = new URL(c.req.url)
-      const page: PageObject = {
-        component,
-        props,
-        url: url.pathname + url.search,
-        version,
+
+      // Partial reload negotiation: the client (Inertia core) signals
+      // "only re-evaluate these props" via X-Inertia-Partial-Component +
+      // X-Inertia-Partial-Data / X-Inertia-Partial-Except.
+      const partialComponent = c.req.header('X-Inertia-Partial-Component')
+      const partialData = c.req.header('X-Inertia-Partial-Data')
+      const partialExcept = c.req.header('X-Inertia-Partial-Except')
+      const isPartial = partialComponent === component && Boolean(partialData || partialExcept)
+
+      const parseKeys = (header: string | undefined): string[] | null =>
+        header
+          ? header
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : null
+
+      const onlyKeys = isPartial ? parseKeys(partialData) : null
+      const exceptKeys = isPartial ? parseKeys(partialExcept) : null
+
+      const isExcluded = (key: string): boolean =>
+        (onlyKeys !== null && !onlyKeys.includes(key)) ||
+        (exceptKeys !== null && exceptKeys.includes(key))
+
+      // Collect kept entries and decide sync vs async resolution. When no
+      // function-valued prop is encountered, the renderer stays fully sync —
+      // preserving the original `Response` (non-Promise) return type for the
+      // common case.
+      const kept: [string, unknown][] = []
+      let hasFunction = false
+      for (const [key, value] of Object.entries(propsInput)) {
+        if (isExcluded(key)) continue
+        if (typeof value === 'function') hasFunction = true
+        kept.push([key, value])
       }
 
-      c.header('Vary', 'Accept, X-Inertia')
+      const respond = (resolvedProps: Record<string, unknown>) => {
+        const page: PageObject = {
+          component,
+          props: resolvedProps,
+          url: url.pathname + url.search,
+          version,
+        }
 
-      if (c.req.header('X-Inertia')) {
-        c.header('X-Inertia', 'true')
-        return c.json(page)
+        c.header('Vary', 'Accept, X-Inertia')
+
+        if (c.req.header('X-Inertia')) {
+          c.header('X-Inertia', 'true')
+          return c.json(page)
+        }
+
+        if (c.req.header('Accept')?.includes('application/json')) {
+          return c.json(resolvedProps)
+        }
+
+        const rendered = rootView(page, c)
+        if (rendered instanceof Promise) {
+          return rendered.then((html) => c.html(html))
+        }
+        return c.html(rendered)
       }
 
-      if (c.req.header('Accept')?.includes('application/json')) {
-        return c.json(props)
+      if (!hasFunction) {
+        return respond(Object.fromEntries(kept))
       }
 
-      const rendered = rootView(page, c)
-      if (rendered instanceof Promise) {
-        return rendered.then((html) => c.html(html))
-      }
-      return c.html(rendered)
+      return Promise.all(
+        kept.map(
+          async ([key, value]): Promise<[string, unknown]> => [
+            key,
+            typeof value === 'function' ? await (value as () => unknown)() : value,
+          ]
+        )
+      ).then((entries) => respond(Object.fromEntries(entries)))
     }) as Parameters<typeof c.setRenderer>[0])
 
     return next()
@@ -174,7 +244,7 @@ declare module 'hono' {
     <C extends PageName, P = Record<string, never>>(
       component: C,
       props?: P
-    ): Response & TypedResponse<{ component: C; props: P }, 200, 'html'>
+    ): Response & TypedResponse<{ component: C; props: ResolvedProps<P> }, 200, 'html'>
   }
   interface NotFoundResponse extends Response, TypedResponse<string, 404, 'text'> {}
 }


### PR DESCRIPTION
Resolves the first item ("partial reloads") of #1900.

## Summary

Adds server-side support for [Inertia.js partial reloads](https://inertiajs.com/partial-reloads):

- Reads `X-Inertia-Partial-Component`, `X-Inertia-Partial-Data` (only), and `X-Inertia-Partial-Except` headers.
- Accepts function-valued props that are evaluated lazily, so heavy data fetching is skipped for props that the client did not request.

```ts
app.get('/', (c) =>
  c.render('Home', {
    fast: 'inline value',
    slow: () => db.expensiveQuery(), // not invoked when excluded by a partial
  })
)
```

## Scope

This PR sticks to the foundation that the rest of the breakdown in #1900 builds on:

- ✅ `only` / `except` props filtering
- ✅ Lazy function props (`() => T | Promise<T>`)
- ✅ Component-mismatch guard: partial headers are ignored when `X-Inertia-Partial-Component` does not match the rendered component

Deferred to follow-up PRs:
- ② Deferred props (`<Deferred>`)
- ③ Merge / prepend props
- ④ Infinite scroll
- ⑤ `always(fn)` marker for one-shot props such as flashed messages

## Behavior notes

- A request is treated as a partial reload only when `X-Inertia-Partial-Component` matches the component being rendered **and** at least one of `X-Inertia-Partial-Data` / `X-Inertia-Partial-Except` is present. Otherwise the request is processed as a normal Inertia visit.
- The renderer stays fully synchronous when no function-valued prop is present, preserving the existing `Response` (non-`Promise<Response>`) return type for the common case.
- Function props excluded from the partial render are never invoked.

## Backward compatibility

Callers that pass only plain values keep the exact same behavior. The new type `ResolvedProps<P>` awaits the return type of any function-valued prop — plain props are pass-through.

## Tests

9 new tests in `packages/inertia/src/index.test.ts` covering the partial filter, lazy invocation skip, async resolution, component mismatch, whitespace handling, only+except intersection, and the "partial-only header without component" guard.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)