### PR TITLE
feat(inertia): add deferred props with defer()

### DIFF
--- a/.changeset/inertia-deferred-props.md
+++ b/.changeset/inertia-deferred-props.md
@@ -1,0 +1,28 @@
+---
+'@hono/inertia': minor
+---
+
+feat(inertia): add deferred props with `defer()`
+
+Adds a `defer(resolver, group?)` helper that defers a prop until after the
+initial render. On the initial response the resolver is skipped and the
+prop key is advertised via `page.deferredProps[group]`; the Inertia client
+then issues one partial reload per group, at which point the resolver runs
+and the value is sent down.
+
+```ts
+import { defer, inertia } from '@hono/inertia'
+
+app.use(inertia())
+
+app.get('/', (c) =>
+  c.render('Dashboard', {
+    user: { id: 1 },                       // sent on initial response
+    posts: defer(() => fetchPosts()),      // fetched after mount
+    stats: defer(() => fetchStats(), 'secondary'),
+  }),
+)
+```
+
+Multiple deferred props that share a group are fetched together. The
+default group is `"default"`.

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -539,7 +539,7 @@ describe('inertia', () => {
 
       const html = await res.text()
       expect(html).toContain('"deferredProps":{"default":["posts"]}')
-      expect(html).not.toContain('"posts"\\:[{')
+      expect(html).not.toContain('"posts":[{')
     })
 
     it('mixes deferred props with eager function props on partial reloads', async () => {

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import type { PageObject } from './index'
-import { inertia } from './index'
+import { defer, inertia } from './index'
 
 describe('inertia', () => {
   describe('full page (non Inertia request)', () => {
@@ -384,6 +384,221 @@ describe('inertia', () => {
       expect(calls.sort()).toEqual(['a', 'b'])
       const body = (await res.json()) as { props: Record<string, unknown> }
       expect(body.props).toEqual({ a: 1, b: 2 })
+    })
+  })
+
+  describe('deferred props', () => {
+    const partialHeaders = (component: string, only?: string) => {
+      const headers: Record<string, string> = {
+        'X-Inertia': 'true',
+        'X-Inertia-Version': 'v1',
+        'X-Inertia-Partial-Component': component,
+      }
+      if (only !== undefined) {
+        headers['X-Inertia-Partial-Data'] = only
+      }
+      return headers
+    }
+
+    it('skips the resolver and advertises the key on the initial Inertia visit', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          user: { id: 1 },
+          posts: defer(() => {
+            calls.push('posts')
+            return [{ id: 1 }]
+          }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      expect(calls).toEqual([])
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        deferredProps?: Record<string, string[]>
+      }
+      expect(body.props).toEqual({ user: { id: 1 } })
+      expect(body.deferredProps).toEqual({ default: ['posts'] })
+    })
+
+    it('groups deferred keys by the provided group name', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          posts: defer(() => [{ id: 1 }]),
+          stats: defer(() => ({ total: 10 }), 'secondary'),
+          comments: defer(() => [], 'secondary'),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        deferredProps?: Record<string, string[]>
+      }
+      expect(body.props).toEqual({})
+      expect(body.deferredProps).toEqual({
+        default: ['posts'],
+        secondary: ['stats', 'comments'],
+      })
+    })
+
+    it('resolves a deferred prop when it is requested via partial reload', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          user: { id: 1 },
+          posts: defer(async () => {
+            await Promise.resolve()
+            calls.push('posts')
+            return [{ id: 1 }, { id: 2 }]
+          }),
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Home', 'posts') })
+
+      expect(calls).toEqual(['posts'])
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        deferredProps?: Record<string, string[]>
+      }
+      expect(body.props).toEqual({ posts: [{ id: 1 }, { id: 2 }] })
+      // deferredProps must not be re-emitted on partial reloads, otherwise
+      // the client would loop fetching the same group forever.
+      expect(body.deferredProps).toBeUndefined()
+    })
+
+    it('does not invoke deferred resolvers that are not in only', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          posts: defer(() => {
+            calls.push('posts')
+            return [{ id: 1 }]
+          }),
+          stats: defer(() => {
+            calls.push('stats')
+            return { total: 10 }
+          }, 'secondary'),
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Home', 'posts') })
+
+      expect(calls).toEqual(['posts'])
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ posts: [{ id: 1 }] })
+    })
+
+    it('skips deferred props on non-Inertia JSON requests', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          user: { id: 1 },
+          posts: defer(() => {
+            calls.push('posts')
+            return [{ id: 1 }]
+          }),
+        })
+      )
+
+      const res = await app.request('/', { headers: { Accept: 'application/json' } })
+
+      expect(calls).toEqual([])
+      expect(await res.json()).toEqual({ user: { id: 1 } })
+    })
+
+    it('embeds the deferredProps map in the initial HTML page object', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          user: { id: 1 },
+          posts: defer(() => [{ id: 1 }]),
+        })
+      )
+
+      const res = await app.request('/')
+
+      const html = await res.text()
+      expect(html).toContain('"deferredProps":{"default":["posts"]}')
+      expect(html).not.toContain('"posts"\\:[{')
+    })
+
+    it('mixes deferred props with eager function props on partial reloads', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          user: () => {
+            calls.push('user')
+            return { id: 1 }
+          },
+          posts: defer(() => {
+            calls.push('posts')
+            return [{ id: 1 }]
+          }),
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Home', 'user,posts') })
+
+      expect(calls.sort()).toEqual(['posts', 'user'])
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ user: { id: 1 }, posts: [{ id: 1 }] })
+    })
+
+    it('omits deferredProps from the page object when no prop is deferred', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { user: { id: 1 } }))
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { deferredProps?: Record<string, string[]> }
+      expect(body.deferredProps).toBeUndefined()
+    })
+
+    it('omits a deferred prop from initial response even on default (non-XHR) HTML visits', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          user: { id: 1 },
+          posts: defer(() => {
+            calls.push('posts')
+            return [{ id: 1 }]
+          }),
+        })
+      )
+
+      const res = await app.request('/')
+
+      expect(calls).toEqual([])
+      const html = await res.text()
+      expect(html).toContain('"user":{"id":1}')
+      expect(html).not.toContain('"posts":[')
     })
   })
 })

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -20,6 +20,13 @@ export type PageObject<P = Record<string, unknown>> = {
   props: P
   url: string
   version: string | null
+  /**
+   * Deferred prop keys grouped by their fetch group. Present only on initial
+   * (non-partial) responses when at least one prop was marked with
+   * {@link defer}. The Inertia client uses this to schedule one partial
+   * reload per group right after mount.
+   */
+  deferredProps?: Record<string, string[]>
 }
 
 /**
@@ -48,6 +55,58 @@ export type Resolved<T> = T extends (...args: never[]) => infer R ? Awaited<R> :
  * Applies {@link Resolved} to every property of `P`.
  */
 export type ResolvedProps<P> = { [K in keyof P]: Resolved<P[K]> }
+
+const DEFER_MARKER = Symbol.for('@hono/inertia/defer')
+
+/**
+ * Internal marker produced by {@link defer}. The renderer detects this and
+ * skips the resolver on initial responses (advertising the key under
+ * `page.deferredProps`) so the client can request the value via a partial
+ * reload after the initial render.
+ *
+ * The shape is intentionally opaque — only the type guard inside the renderer
+ * reads it. The factory returns `T` so usage at call sites is transparent.
+ */
+interface DeferredProp<T = unknown> {
+  [DEFER_MARKER]: true
+  resolver: () => T | Promise<T>
+  group: string
+}
+
+const isDeferred = (value: unknown): value is DeferredProp =>
+  typeof value === 'object' && value !== null && DEFER_MARKER in value
+
+/**
+ * Marks a prop as deferred. On the initial response the resolver is skipped
+ * and the prop key is advertised under `page.deferredProps[group]`. The
+ * client then issues one partial reload per group, which re-enters the
+ * middleware with the corresponding key in `X-Inertia-Partial-Data`, at
+ * which point the resolver runs and the value is sent down.
+ *
+ * Multiple deferred props that share a `group` are fetched together in a
+ * single partial reload. The default group is `"default"`.
+ *
+ * @example
+ * ```ts
+ * app.get('/', (c) =>
+ *   c.render('Dashboard', {
+ *     user: { id: 1 },                       // sent on initial response
+ *     posts: defer(() => fetchPosts()),      // skipped initially, fetched after mount
+ *     stats: defer(() => fetchStats(), 'secondary'),
+ *   }),
+ * )
+ * ```
+ *
+ * @see https://inertiajs.com/deferred-props
+ */
+export const defer = <T>(resolver: () => T | Promise<T>, group = 'default'): T => {
+  const marker: DeferredProp<T> = {
+    [DEFER_MARKER]: true,
+    resolver,
+    group,
+  }
+  return marker as unknown as T
+}
 
 export interface InertiaOptions {
   /**
@@ -156,17 +215,33 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
         (exceptKeys !== null && exceptKeys.includes(key))
 
       // Collect kept entries and decide sync vs async resolution. When no
-      // function-valued prop is encountered, the renderer stays fully sync —
-      // preserving the original `Response` (non-Promise) return type for the
-      // common case.
+      // function-valued or deferred prop is encountered, the renderer stays
+      // fully sync — preserving the original `Response` (non-Promise) return
+      // type for the common case.
+      //
+      // Deferred props are handled per visit kind:
+      //   - initial visit (`!isPartial`): the resolver is skipped, the key
+      //     is recorded in `deferredGroups`, and nothing is added to `kept`.
+      //   - partial visit (`isPartial`): the marker is kept and resolved
+      //     just like a regular function-valued prop.
       const kept: [string, unknown][] = []
-      let hasFunction = false
+      const deferredGroups: Record<string, string[]> = {}
+      let needsAsync = false
       for (const [key, value] of Object.entries(propsInput)) {
         if (isExcluded(key)) {
           continue
         }
+        if (isDeferred(value)) {
+          if (!isPartial) {
+            ;(deferredGroups[value.group] ??= []).push(key)
+            continue
+          }
+          needsAsync = true
+          kept.push([key, value])
+          continue
+        }
         if (typeof value === 'function') {
-          hasFunction = true
+          needsAsync = true
         }
         kept.push([key, value])
       }
@@ -177,6 +252,9 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
           props: resolvedProps,
           url: url.pathname + url.search,
           version,
+        }
+        if (!isPartial && Object.keys(deferredGroups).length > 0) {
+          page.deferredProps = deferredGroups
         }
 
         c.header('Vary', 'Accept, X-Inertia')
@@ -197,17 +275,17 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
         return c.html(rendered)
       }
 
-      if (!hasFunction) {
+      if (!needsAsync) {
         return respond(Object.fromEntries(kept))
       }
 
       return Promise.all(
-        kept.map(
-          async ([key, value]): Promise<[string, unknown]> => [
-            key,
-            typeof value === 'function' ? await (value as () => unknown)() : value,
-          ]
-        )
+        kept.map(async ([key, value]): Promise<[string, unknown]> => {
+          if (isDeferred(value)) {
+            return [key, await value.resolver()]
+          }
+          return [key, typeof value === 'function' ? await (value as () => unknown)() : value]
+        })
       ).then((entries) => respond(Object.fromEntries(entries)))
     }) as Parameters<typeof c.setRenderer>[0])
 


### PR DESCRIPTION
## Summary

Second step of the [`@hono/inertia` v3 protocol breakdown](https://github.com/honojs/middleware/issues/1900): **② Deferred props**, built on top of the partial reload foundation from #1904.

Adds a `defer(resolver, group?)` helper. On the initial response the resolver is skipped and the prop key is advertised under `page.deferredProps[group]`. The Inertia client then issues one partial reload per group, at which point the resolver runs and the value is sent down — letting heavy data fetching happen after the page becomes interactive.

```ts
import { defer, inertia } from '@hono/inertia'

app.use(inertia())

app.get('/', (c) =>
  c.render('Dashboard', {
    user: { id: 1 },                       // sent on initial response
    posts: defer(() => fetchPosts()),      // fetched after mount
    stats: defer(() => fetchStats(), 'secondary'),
  }),
)
```

Multiple deferred props that share a `group` are fetched together in a single partial reload. The default group is `"default"`.

## Protocol behaviour

| Visit kind | `posts: defer(fn)` behaviour |
|---|---|
| Initial (full page or `X-Inertia` GET) | `fn` **not invoked**, `page.deferredProps.default = ['posts']` emitted |
| Partial reload that includes `posts` in `X-Inertia-Partial-Data` | `fn` invoked, value returned under `props.posts` |
| Partial reload that does **not** include `posts` | `fn` **not invoked**, key omitted from response |
| Non-Inertia `Accept: application/json` request | `fn` **not invoked**, key omitted |

`deferredProps` is only emitted on the initial response; subsequent partial reloads strip it, so the client does not re-trigger the same group.

## Implementation

- `defer<T>(resolver, group = 'default'): T` returns an opaque marker (`Symbol.for('@hono/inertia/defer')`) that the renderer unwraps. The return type is `T`, so call sites stay transparent and `TypedResponse` infers the awaited resolver type.
- The renderer loop now distinguishes three prop kinds — plain values, function-valued props (from #1904), and deferred markers — and decides on a single sync/async path based on whether any resolver needs awaiting. The non-deferred sync path is preserved when no async work is needed.
- `PageObject` gains an optional `deferredProps?: Record<string, string[]>` field, only present on the initial response when at least one prop was deferred.

Scope intentionally kept small (single PR per protocol feature, like #1904):

- ✅ Top-level `defer()` markers
- ✅ Multiple groups + default group
- ✅ Skip on initial, resolve on requested partial
- ❌ Nested / dot-path deferred markers — separate PR
- ❌ `merge` / `prepend` / `deepMerge` / `always(fn)` / infinite scroll markers — separate PRs (③④⑤ in the breakdown)

## Test plan

- [x] `yarn workspace @hono/inertia test` (`28 passed`, 9 new tests covering initial skip / group emission / partial resolve / `only` filter / JSON request / mixed deferred + function props / no-defer no-emit / non-XHR HTML visit)
- [x] `eslint packages/inertia` clean
- [x] `prettier --check` clean
- [x] `tsc -b` clean
- [x] `tsdown` build success