### PR TITLE
chore(oidc-auth): bump oauth4webapi from 2.6.0 to 3.8.6

### DIFF
--- a/.changeset/eighty-ducks-punch.md
+++ b/.changeset/eighty-ducks-punch.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': patch
+---
+
+bump oauth4webapi dependency from 2.6.0 to 3.8.6

--- a/packages/oidc-auth/package.json
+++ b/packages/oidc-auth/package.json
@@ -52,7 +52,7 @@
     "vitest": "^4.1.7"
   },
   "dependencies": {
-    "oauth4webapi": "^2.6.0"
+    "oauth4webapi": "^3.8.6"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -12,13 +12,10 @@ import type { SignatureAlgorithm } from 'hono/utils/jwt/jwa'
 import * as oauth2 from 'oauth4webapi'
 
 export type IDToken = oauth2.IDToken
-export type TokenEndpointResponses =
-  | oauth2.OpenIDTokenEndpointResponse
-  | oauth2.TokenEndpointResponse
 export type OidcClaimsHook = (
   orig: OidcAuth | undefined,
   claims: IDToken | undefined,
-  response: TokenEndpointResponses
+  response: oauth2.TokenEndpointResponse
 ) => Promise<OidcAuthClaims>
 
 declare module 'hono' {
@@ -235,12 +232,25 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
       }
       const as = await getAuthorizationServer(c)
       const client = getClient(c)
-      const response = await oauth2.refreshTokenGrantRequest(as, client, auth.rtk)
-      const result = await oauth2.processRefreshTokenResponse(as, client, response)
-      if (oauth2.isOAuth2Error(result)) {
-        // The refresh_token might be expired or revoked
-        deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
-        return null
+      const response = await oauth2.refreshTokenGrantRequest(
+        as,
+        client,
+        oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
+        auth.rtk
+      )
+      let result: oauth2.TokenEndpointResponse
+      try {
+        result = await oauth2.processRefreshTokenResponse(as, client, response)
+      } catch (error) {
+        if (
+          error instanceof oauth2.ResponseBodyError ||
+          error instanceof oauth2.WWWAuthenticateChallengeError
+        ) {
+          // The refresh_token might be expired or revoked
+          deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
+          return null
+        }
+        throw error
       }
       auth = await updateAuth(c, auth, result)
     }
@@ -252,10 +262,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
 /**
  * Generates a new session JWT and sets the session cookie.
  */
-const setAuth = async (
-  c: Context,
-  response: oauth2.OpenIDTokenEndpointResponse
-): Promise<OidcAuth> => {
+const setAuth = async (c: Context, response: oauth2.TokenEndpointResponse): Promise<OidcAuth> => {
   return updateAuth(c, undefined, response)
 }
 
@@ -265,7 +272,7 @@ const setAuth = async (
 const updateAuth = async (
   c: Context,
   orig: OidcAuth | undefined,
-  response: TokenEndpointResponses
+  response: oauth2.TokenEndpointResponse
 ): Promise<OidcAuth> => {
   const env = getOidcAuthEnv(c)
   const claims = oauth2.getValidatedIdTokenClaims(response)
@@ -317,12 +324,21 @@ export const revokeSession = async (c: Context): Promise<void> => {
       const as = await getAuthorizationServer(c)
       const client = getClient(c)
       if (as.revocation_endpoint !== undefined) {
-        const response = await oauth2.revocationRequest(as, client, auth.rtk)
-        const result = await oauth2.processRevocationResponse(response)
-        if (oauth2.isOAuth2Error(result)) {
-          throw new HTTPException(500, {
-            message: `OAuth2Error: [${result.error}] ${result.error_description}`,
-          })
+        const response = await oauth2.revocationRequest(
+          as,
+          client,
+          oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
+          auth.rtk
+        )
+        try {
+          await oauth2.processRevocationResponse(response)
+        } catch (error) {
+          if (error instanceof oauth2.ResponseBodyError) {
+            throw new HTTPException(500, {
+              message: `OAuth2Error: [${error.error}] ${error.error_description}`,
+            })
+          }
+          throw error
         }
       }
     }
@@ -399,11 +415,16 @@ export const processOAuthCallback = async (
   const path = new URL(env.OIDC_REDIRECT_URI, c.req.url).pathname
   deleteCookie(c, 'state', { path })
   const currentUrl: URL = new URL(c.req.url)
-  const params = oauth2.validateAuthResponse(as, client, currentUrl, state)
-  if (oauth2.isOAuth2Error(params)) {
-    throw new HTTPException(500, {
-      message: `OAuth2Error: [${params.error}] ${params.error_description}`,
-    })
+  let params: URLSearchParams
+  try {
+    params = oauth2.validateAuthResponse(as, client, currentUrl, state)
+  } catch (error) {
+    if (error instanceof oauth2.AuthorizationResponseError) {
+      throw new HTTPException(500, {
+        message: `OAuth2Error: [${error.error}] ${error.error_description}`,
+      })
+    }
+    throw error
   }
 
   // Exchanges the authorization code for a refresh token
@@ -421,6 +442,7 @@ export const processOAuthCallback = async (
   const result = await exchangeAuthorizationCode(
     as,
     client,
+    oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
     params,
     redirectUri,
     nonce,
@@ -436,6 +458,7 @@ export const processOAuthCallback = async (
 const exchangeAuthorizationCode = async (
   as: oauth2.AuthorizationServer,
   client: oauth2.Client,
+  clientAuth: oauth2.ClientAuth,
   params: URLSearchParams,
   redirect_uri: string,
   nonce: string,
@@ -444,24 +467,29 @@ const exchangeAuthorizationCode = async (
   const response = await oauth2.authorizationCodeGrantRequest(
     as,
     client,
+    clientAuth,
     params,
     redirect_uri,
     code_verifier
   )
-  // Handle www-authenticate challenges
-  const challenges = oauth2.parseWwwAuthenticateChallenges(response)
-  if (challenges !== undefined) {
-    throw new HTTPException(500, {
-      message: `www-authenticate error: ${JSON.stringify(challenges)}`,
+  try {
+    return await oauth2.processAuthorizationCodeResponse(as, client, response, {
+      expectedNonce: nonce,
+      requireIdToken: true,
     })
+  } catch (error) {
+    if (error instanceof oauth2.WWWAuthenticateChallengeError) {
+      throw new HTTPException(500, {
+        message: `www-authenticate error: ${JSON.stringify(error.cause)}`,
+      })
+    }
+    if (error instanceof oauth2.ResponseBodyError) {
+      throw new HTTPException(500, {
+        message: `OAuth2Error: [${error.error}] ${error.error_description}`,
+      })
+    }
+    throw error
   }
-  const result = await oauth2.processAuthorizationCodeOpenIDResponse(as, client, response, nonce)
-  if (oauth2.isOAuth2Error(result)) {
-    throw new HTTPException(500, {
-      message: `OAuth2Error: [${result.error}] ${result.error_description}`,
-    })
-  }
-  return result
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2168,7 +2168,7 @@ __metadata:
     "@types/jsonwebtoken": "npm:^9.0.10"
     hono: "npm:^4.11.5"
     jsonwebtoken: "npm:^9.0.3"
-    oauth4webapi: "npm:^2.6.0"
+    oauth4webapi: "npm:^3.8.6"
     tsdown: "npm:^0.15.9"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.1.7"
@@ -12497,10 +12497,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oauth4webapi@npm:^2.6.0":
-  version: 2.9.0
-  resolution: "oauth4webapi@npm:2.9.0"
-  checksum: 10c0/7bbd2ab446c0621c71f6855c695b900d6ba1f56474b105751134112abf5cff9fbe2fe715d2ae0f57f0ed1adc600c37ae6bf007669af9f760dc982aaeaeb0968f
+"oauth4webapi@npm:^3.8.6":
+  version: 3.8.6
+  resolution: "oauth4webapi@npm:3.8.6"
+  checksum: 10c0/479810716702c5616e4a0eb80d4f1c264a6a2b63b04061a62a59375e195d2726e947507ede98e41ee3f9ca800f159621ea371c36f5c4346d015b6ec03e477440
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The breaking changes are in [v3.0.0](https://github.com/panva/oauth4webapi/releases/tag/v3.0.0). Error handling needed to be changed to try/catch, some of its methods were renamed, and some of its methods now require explicit `ClientAuth` information.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
