### PR TITLE
docs(zod-openapi): note route mounting for large RPC apps

### DIFF
--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -398,6 +398,24 @@ const appRoutes = app.openapi(route, (c) => {
 const client = hc<typeof appRoutes>('http://localhost:8787/')
 ```
 
+#### Type-checking large RPC apps
+
+When an RPC app has many routes, register them on small `OpenAPIHono` instances and mount those apps with `.route()`.
+A long chain of `.openapi()` calls grows the schema type at each link.
+Type-checking can slow down when that app type is passed to `hc`.
+
+```ts
+const users = new OpenAPIHono().openapi(getUserRoute, getUserHandler)
+const posts = new OpenAPIHono().openapi(getPostRoute, getPostHandler)
+
+const appRoutes = new OpenAPIHono().route('/', users).route('/', posts)
+
+const client = hc<typeof appRoutes>('http://localhost:8787/')
+```
+
+Routing and OpenAPI output stay the same.
+TypeScript has less accumulated schema type work to do.
+
 ### Batch Route Registration
 
 For better code organization and type safety, you can use `defineOpenAPIRoute` and `openapiRoutes` to register multiple routes at once.


### PR DESCRIPTION
## Summary

Adds a zod-openapi README note about using `.route()` with small `OpenAPIHono` apps for RPC apps with many routes.

Refs #1918.

## Testing

- `bun install --no-save`
- `bun run prettier --check packages/zod-openapi/README.md`
- `bun run --filter @hono/zod-openapi lint`
- `bun run --filter @hono/zod-openapi typecheck`
- `bun run --filter @hono/zod-openapi test`

## AI assistance

I used an AI coding assistant for the docs wording and reviewed the diff before committing.
