### PR TITLE
fix(session): Use env adapter to access AUTH_SECRET

### DIFF
--- a/.changeset/all-dogs-dig.md
+++ b/.changeset/all-dogs-dig.md
@@ -1,0 +1,5 @@
+---
+'@hono/session': patch
+---
+
+Use of `env()` adapter to facilitate the retrieval of `AUTH_SECRET` across different runtimes as opposed to just cloudflare workers

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -1,5 +1,6 @@
 import type { Context, Env, MiddlewareHandler } from 'hono'
 import * as cookie from 'hono/cookie'
+import { env } from 'hono/adapter'
 import { createMiddleware } from 'hono/factory'
 import type { CookieOptions } from 'hono/utils/cookie'
 import type { EncryptionKey, MaxAgeDuration } from './cookies'
@@ -66,7 +67,7 @@ export const useSession = <Data extends SessionData>(
   let encryptionKey: EncryptionKey | undefined
 
   return createMiddleware<SessionEnv<Data>>(async (c, next) => {
-    const secret = options?.secret ?? c.env.AUTH_SECRET
+    const secret = options?.secret ?? env(c).AUTH_SECRET
 
     if (!secret) {
       throw new Error('Missing AUTH_SECRET')

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -1,6 +1,6 @@
 import type { Context, Env, MiddlewareHandler } from 'hono'
-import * as cookie from 'hono/cookie'
 import { env } from 'hono/adapter'
+import * as cookie from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
 import type { CookieOptions } from 'hono/utils/cookie'
 import type { EncryptionKey, MaxAgeDuration } from './cookies'


### PR DESCRIPTION
This facilities the retrieval of AUTH_SECRET across different runtimes as opposed to just cloudflare workers.
