### PR TITLE
fix(zod-openapi): replace any type parameters in OpenAPIHonoOptions.defaultHook

### DIFF
--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -236,7 +236,7 @@ type ConvertPathType<T extends string> = T extends `${infer Start}/{${infer Para
   : T
 
 export type OpenAPIHonoOptions<E extends Env> = {
-  defaultHook?: Hook<any, E, any, any>
+  defaultHook?: Hook<unknown, E, string, Response | void | Promise<Response | void>>
 }
 type HonoInit<E extends Env> = ConstructorParameters<typeof Hono>[0] & OpenAPIHonoOptions<E>
 


### PR DESCRIPTION
## Fix: Replace `any` type parameters in `OpenAPIHonoOptions.defaultHook`

### Problem

`OpenAPIHonoOptions` types `defaultHook` as `Hook<any, E, any, any>`:

```ts
export type OpenAPIHonoOptions<E extends Env> = {
  defaultHook?: Hook<any, E, any, any>
}
```

This leaks `any` into the `c` parameter of every `defaultHook` callback, even when `OpenAPIHono` is fully parameterized with a concrete `Env`. The `Context<E, P>` inside `Hook` resolves to `Context<any, any>`, which defeats strict type checking and causes failures with tools like `type-coverage --strict`.

### Root cause

`Hook` is correctly typed:

```ts
export type Hook<T, E extends Env, P extends string, R> = (
  result: ...,
  c: Context<E, P>
) => R
```

But the three `any` defaults passed at the call site undo that precision.

### Fix

```ts
export type OpenAPIHonoOptions<E extends Env> = {
  defaultHook?: Hook<unknown, E, string, Response | void | Promise<Response | void>>
}
```

- **`T: unknown`** — `defaultHook` is a catch-all that applies to all routes regardless of their specific input shape. `unknown` is the correct type when the data type cannot be known at this level (as opposed to `any`, which silently opts out of type checking).
- **`P: string`** — a route path is always a `string`. Using `any` here causes `c.req` and related path-typed members to resolve to `any`.
- **`R: Response | void | Promise<Response | void>`** — these are the only meaningful return types for a hook. `any` allows returning anything, including values that would be silently ignored.

### Impact

Before this change, users who set `defaultHook` on a fully typed `OpenAPIHono<BlankEnv>` instance still get `c: Context<any, any>` in the callback. After this change, `c` is correctly inferred as `Context<BlankEnv, string>` without any annotation required.

No behaviour changes — runtime is unaffected.