### PR TITLE
feat(inertia): add merge props with merge(), prepend(), and deepMerge()

### DIFF
--- a/.changeset/inertia-merge-props.md
+++ b/.changeset/inertia-merge-props.md
@@ -1,0 +1,38 @@
+---
+'@hono/inertia': minor
+---
+
+feat(inertia): add merge props with `merge()`, `prepend()`, and `deepMerge()`
+
+Adds three helpers that mark a prop for client-side combination on the
+**next partial reload**, instead of the default replace behavior:
+
+- `merge(data, { matchOn? })` — appends array items / shallow-spreads object keys.
+- `prepend(data, { matchOn? })` — same as `merge()` but inserts at the start.
+- `deepMerge(data, { matchOn? })` — recurses into nested arrays/objects (use for
+  wrapper-shaped paginated props like `{ data: [...], meta: {...} }`).
+
+The value travels as-is; the renderer advertises which keys to combine via the
+new `page.mergeProps` / `page.prependProps` / `page.deepMergeProps` arrays and
+emits dot-paths on `page.matchPropsOn` for the client's dedupe logic.
+
+```ts
+import { deepMerge, inertia, merge, prepend } from '@hono/inertia'
+
+app.use(inertia())
+
+app.get('/feed', (c) =>
+  c.render('Feed', {
+    posts: merge(await db.posts.page(n), { matchOn: 'id' }),
+    notifications: prepend(await fetchNotifications(), { matchOn: 'id' }),
+    conversations: deepMerge(
+      { data: await db.messages.page(n), meta: { nextCursor } },
+      { matchOn: 'data.id' },
+    ),
+  }),
+)
+```
+
+The merge metadata is emitted on every response (initial + partial) so the
+client knows which keys to combine on the next partial reload. Full page visits
+always replace props entirely.

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -215,6 +215,38 @@ app.get('/', (c) =>
 
 Multiple deferred props sharing the same `group` (the second argument, default `'default'`) are fetched together in a single follow-up request. On the initial response the resolvers are not invoked and the keys are advertised under `page.deferredProps[group]`; on the follow-up partial reload only the requested resolvers run.
 
+## Merge props
+
+By default a partial reload **replaces** the cached prop value. [Merge props](https://inertiajs.com/merging-props) instead **combine** the incoming value with the cached one — append items to a list, prepend new notifications, or deep merge a paginated wrapper. The value travels as-is and the metadata (`page.mergeProps` / `prependProps` / `deepMergeProps` / `matchPropsOn`) tells the Inertia client how to combine it on the next partial reload.
+
+Pick the helper that matches the shape:
+
+```ts
+import { deepMerge, inertia, merge, prepend } from '@hono/inertia'
+
+app.use(inertia())
+
+app.get('/feed', (c) =>
+  c.render('Feed', {
+    // append: concat array items / shallow-spread object keys
+    posts: merge(await db.posts.page(n), { matchOn: 'id' }),
+
+    // prepend: insert new items at the start
+    notifications: prepend(await fetchNotifications(), { matchOn: 'id' }),
+
+    // deep merge: recurse into wrapper-shaped paginated props
+    conversations: deepMerge(
+      { data: await db.messages.page(n), meta: { nextCursor } },
+      { matchOn: 'data.id' }
+    ),
+  })
+)
+```
+
+`matchOn` accepts a string or array of strings and is emitted as `<propKey>.<field>` on `page.matchPropsOn` (e.g. `merge(posts, { matchOn: 'id' })` on the `posts` prop ⇒ `matchPropsOn: ['posts.id']`), which the client uses to dedupe items by that field.
+
+The merge metadata is included on **every** response — initial and partial — so the client knows which keys to combine on the next partial reload. Full page visits always replace props entirely; merging only kicks in on subsequent partial reloads.
+
 ## Vite plugin
 
 ```ts

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import type { PageObject } from './index'
-import { defer, inertia } from './index'
+import { deepMerge, defer, inertia, merge, prepend } from './index'
 
 describe('inertia', () => {
   describe('full page (non Inertia request)', () => {
@@ -599,6 +599,287 @@ describe('inertia', () => {
       const html = await res.text()
       expect(html).toContain('"user":{"id":1}')
       expect(html).not.toContain('"posts":[')
+    })
+  })
+
+  describe('merge props', () => {
+    const partialHeaders = (component: string, only?: string) => {
+      const headers: Record<string, string> = {
+        'X-Inertia': 'true',
+        'X-Inertia-Version': 'v1',
+        'X-Inertia-Partial-Component': component,
+      }
+      if (only !== undefined) {
+        headers['X-Inertia-Partial-Data'] = only
+      }
+      return headers
+    }
+
+    it('emits page.mergeProps and unwraps the value for merge()', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          posts: merge([{ id: 1 }, { id: 2 }]),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        mergeProps?: string[]
+        prependProps?: string[]
+        deepMergeProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.props).toEqual({ posts: [{ id: 1 }, { id: 2 }] })
+      expect(body.mergeProps).toEqual(['posts'])
+      expect(body.prependProps).toBeUndefined()
+      expect(body.deepMergeProps).toBeUndefined()
+      expect(body.matchPropsOn).toBeUndefined()
+    })
+
+    it('emits page.prependProps for prepend()', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          notifications: prepend([{ id: 1 }]),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        prependProps?: string[]
+      }
+      expect(body.props).toEqual({ notifications: [{ id: 1 }] })
+      expect(body.prependProps).toEqual(['notifications'])
+    })
+
+    it('emits page.deepMergeProps for deepMerge()', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          feed: deepMerge({ data: [{ id: 1 }], meta: { total: 1 } }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        deepMergeProps?: string[]
+      }
+      expect(body.props).toEqual({ feed: { data: [{ id: 1 }], meta: { total: 1 } } })
+      expect(body.deepMergeProps).toEqual(['feed'])
+    })
+
+    it('builds matchPropsOn as "<key>.<field>" from a single matchOn string', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          posts: merge([{ id: 1 }], { matchOn: 'id' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { matchPropsOn?: string[] }
+      expect(body.matchPropsOn).toEqual(['posts.id'])
+    })
+
+    it('expands an array matchOn into one matchPropsOn entry per field', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          conversations: deepMerge(
+            { data: [{ id: 1, threadId: 'a' }] },
+            { matchOn: ['data.id', 'data.threadId'] }
+          ),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { matchPropsOn?: string[] }
+      expect(body.matchPropsOn).toEqual(['conversations.data.id', 'conversations.data.threadId'])
+    })
+
+    it('mixes merge / prepend / deepMerge in a single response', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          posts: merge([{ id: 1 }], { matchOn: 'id' }),
+          notifications: prepend([{ id: 9 }], { matchOn: 'id' }),
+          conversations: deepMerge({ data: [{ id: 1 }] }, { matchOn: 'data.id' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        mergeProps?: string[]
+        prependProps?: string[]
+        deepMergeProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.props).toEqual({
+        posts: [{ id: 1 }],
+        notifications: [{ id: 9 }],
+        conversations: { data: [{ id: 1 }] },
+      })
+      expect(body.mergeProps).toEqual(['posts'])
+      expect(body.prependProps).toEqual(['notifications'])
+      expect(body.deepMergeProps).toEqual(['conversations'])
+      expect(body.matchPropsOn).toEqual(['posts.id', 'notifications.id', 'conversations.data.id'])
+    })
+
+    it('still emits mergeProps on partial reloads so the client can keep combining', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          posts: merge([{ id: 3 }], { matchOn: 'id' }),
+          user: { id: 1 },
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Feed', 'posts') })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        mergeProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.props).toEqual({ posts: [{ id: 3 }] })
+      expect(body.mergeProps).toEqual(['posts'])
+      expect(body.matchPropsOn).toEqual(['posts.id'])
+    })
+
+    it('omits a merge-marked prop from mergeProps when the partial filter excludes it', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          posts: merge([{ id: 3 }], { matchOn: 'id' }),
+          notifications: prepend([{ id: 9 }], { matchOn: 'id' }),
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Feed', 'posts') })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        mergeProps?: string[]
+        prependProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.props).toEqual({ posts: [{ id: 3 }] })
+      expect(body.mergeProps).toEqual(['posts'])
+      expect(body.prependProps).toBeUndefined()
+      expect(body.matchPropsOn).toEqual(['posts.id'])
+    })
+
+    it('omits all merge fields from the page object when no prop is merge-marked', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { user: { id: 1 } }))
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        mergeProps?: string[]
+        prependProps?: string[]
+        deepMergeProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.mergeProps).toBeUndefined()
+      expect(body.prependProps).toBeUndefined()
+      expect(body.deepMergeProps).toBeUndefined()
+      expect(body.matchPropsOn).toBeUndefined()
+    })
+
+    it('embeds mergeProps and matchPropsOn in the initial HTML page object', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          posts: merge([{ id: 1 }], { matchOn: 'id' }),
+        })
+      )
+
+      const res = await app.request('/')
+
+      const html = await res.text()
+      expect(html).toContain('"mergeProps":["posts"]')
+      expect(html).toContain('"matchPropsOn":["posts.id"]')
+    })
+
+    it('resolves a function value passed to merge() on partial reloads', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          posts: merge(
+            () => {
+              calls.push('posts')
+              return [{ id: 1 }, { id: 2 }]
+            },
+            { matchOn: 'id' }
+          ),
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Feed', 'posts') })
+
+      expect(calls).toEqual(['posts'])
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        mergeProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.props).toEqual({ posts: [{ id: 1 }, { id: 2 }] })
+      expect(body.mergeProps).toEqual(['posts'])
+      expect(body.matchPropsOn).toEqual(['posts.id'])
+    })
+
+    it('unwraps the merge value for raw JSON requests (Accept: application/json) and skips the merge fields', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          posts: merge([{ id: 1 }], { matchOn: 'id' }),
+        })
+      )
+
+      const res = await app.request('/', { headers: { Accept: 'application/json' } })
+
+      // Accept: application/json returns the raw props (not a page object),
+      // so the merge metadata isn't relevant — only the unwrapped value matters.
+      expect(await res.json()).toEqual({ posts: [{ id: 1 }] })
     })
   })
 })

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -27,6 +27,32 @@ export type PageObject<P = Record<string, unknown>> = {
    * reload per group right after mount.
    */
   deferredProps?: Record<string, string[]>
+  /**
+   * Prop keys whose values should be appended to the cached value during
+   * subsequent partial reloads. Present whenever at least one prop was marked
+   * with {@link merge}. Emitted on both initial and partial responses so the
+   * client knows which keys to merge on the next partial reload.
+   */
+  mergeProps?: string[]
+  /**
+   * Prop keys whose values should be prepended to the cached value during
+   * subsequent partial reloads. Present whenever at least one prop was marked
+   * with {@link prepend}.
+   */
+  prependProps?: string[]
+  /**
+   * Prop keys whose values should be deep-merged with the cached value during
+   * subsequent partial reloads. Present whenever at least one prop was marked
+   * with {@link deepMerge}.
+   */
+  deepMergeProps?: string[]
+  /**
+   * Dot-paths used by the client to dedupe array items when merging. Each
+   * entry is `"<propKey>.<matchField>"` (e.g. `"posts.id"`), built from the
+   * `matchOn` option passed to {@link merge}, {@link prepend}, or
+   * {@link deepMerge}.
+   */
+  matchPropsOn?: string[]
 }
 
 /**
@@ -107,6 +133,123 @@ export const defer = <T>(resolver: () => T | Promise<T>, group = 'default'): T =
   }
   return marker as unknown as T
 }
+
+const MERGE_MARKER = Symbol.for('@hono/inertia/merge')
+
+/**
+ * Strategy applied by the Inertia client when combining incoming merge props
+ * with the cached value:
+ *
+ * - `'append'` — concat arrays (or shallow-spread object keys) at the end
+ * - `'prepend'` — concat arrays at the start
+ * - `'deep'` — recurse into nested arrays/objects, applying `matchOn` dedupe
+ */
+type MergeStrategy = 'append' | 'prepend' | 'deep'
+
+/**
+ * Internal marker produced by {@link merge}, {@link prepend}, and
+ * {@link deepMerge}. The renderer detects this and emits the resolved value
+ * as-is while recording the prop key against the corresponding
+ * `page.mergeProps` / `page.prependProps` / `page.deepMergeProps` bucket. The
+ * client then uses these on subsequent partial reloads to combine incoming
+ * values with the cached ones instead of replacing.
+ *
+ * The shape is intentionally opaque — only the type guard inside the renderer
+ * reads it. The factory returns `T` so usage at call sites is transparent.
+ */
+interface MergeProp<T = unknown> {
+  [MERGE_MARKER]: true
+  strategy: MergeStrategy
+  data: T
+  matchOn: string[]
+}
+
+const isMerge = (value: unknown): value is MergeProp =>
+  typeof value === 'object' && value !== null && MERGE_MARKER in value
+
+/**
+ * Options accepted by {@link merge}, {@link prepend}, and {@link deepMerge}.
+ */
+export interface MergeOptions {
+  /**
+   * Field(s) used by the Inertia client to dedupe array items when combining
+   * incoming and cached values. Each entry is appended to the prop key as a
+   * dot-path on `page.matchPropsOn` (e.g. `merge(posts, { matchOn: 'id' })`
+   * on the `posts` prop emits `matchPropsOn: ['posts.id']`).
+   */
+  matchOn?: string | string[]
+}
+
+const buildMerge =
+  (strategy: MergeStrategy) =>
+  <T>(data: T, options: MergeOptions = {}): T => {
+    const matchOn = options.matchOn
+      ? Array.isArray(options.matchOn)
+        ? options.matchOn
+        : [options.matchOn]
+      : []
+    const marker: MergeProp<T> = {
+      [MERGE_MARKER]: true,
+      strategy,
+      data,
+      matchOn,
+    }
+    return marker as unknown as T
+  }
+
+/**
+ * Marks a prop for **append merge** on partial reloads. The resolved value is
+ * sent as-is on this response, and the prop key is recorded under
+ * `page.mergeProps` so the client appends future partial-reload values to
+ * the cached array (or shallow-spreads object keys).
+ *
+ * Full page visits always replace props entirely — merging only kicks in on
+ * subsequent partial reloads.
+ *
+ * @example
+ * ```ts
+ * app.get('/feed', (c) =>
+ *   c.render('Feed', {
+ *     posts: merge(await db.posts.page(n), { matchOn: 'id' }),
+ *   }),
+ * )
+ * ```
+ *
+ * @see https://inertiajs.com/merging-props
+ */
+export const merge: <T>(data: T, options?: MergeOptions) => T = buildMerge('append')
+
+/**
+ * Marks a prop for **prepend merge** on partial reloads. Same as {@link merge}
+ * but new array items are inserted at the start of the cached array.
+ *
+ * @see https://inertiajs.com/merging-props
+ */
+export const prepend: <T>(data: T, options?: MergeOptions) => T = buildMerge('prepend')
+
+/**
+ * Marks a prop for **deep merge** on partial reloads. The client walks the
+ * value recursively: arrays follow `matchOn` dedupe rules (or concat), nested
+ * objects merge key-by-key, scalars replace.
+ *
+ * Use for wrapper-shaped paginated props like `{ data: [...], meta: {...} }`
+ * where a shallow merge would lose the inner `data` array.
+ *
+ * @example
+ * ```ts
+ * app.get('/feed', (c) =>
+ *   c.render('Feed', {
+ *     feed: deepMerge(
+ *       { data: await db.posts.page(n), meta: { total, nextCursor } },
+ *       { matchOn: 'data.id' },
+ *     ),
+ *   }),
+ * )
+ * ```
+ *
+ * @see https://inertiajs.com/merging-props
+ */
+export const deepMerge: <T>(data: T, options?: MergeOptions) => T = buildMerge('deep')
 
 export interface InertiaOptions {
   /**
@@ -226,6 +369,10 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       //     just like a regular function-valued prop.
       const kept: [string, unknown][] = []
       const deferredGroups: Record<string, string[]> = {}
+      const mergeProps: string[] = []
+      const prependProps: string[] = []
+      const deepMergeProps: string[] = []
+      const matchPropsOn: string[] = []
       let needsAsync = false
       for (const [key, value] of Object.entries(propsInput)) {
         if (isExcluded(key)) {
@@ -238,6 +385,29 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
           }
           needsAsync = true
           kept.push([key, value])
+          continue
+        }
+        // Merge markers are emitted on every response (initial + partial) so
+        // the client knows which keys to combine on the *next* partial reload.
+        // The wrapped value is unwrapped here and treated like a plain prop.
+        if (isMerge(value)) {
+          if (value.strategy === 'append') {
+            mergeProps.push(key)
+          } else if (value.strategy === 'prepend') {
+            prependProps.push(key)
+          } else {
+            deepMergeProps.push(key)
+          }
+          for (const p of value.matchOn) {
+            matchPropsOn.push(`${key}.${p}`)
+          }
+          // Unwrap and forward to the same lazy-resolution path used for plain
+          // props, so `merge(() => fetchPosts(), ...)` resolves on partial
+          // reloads instead of being JSON-stringified as a raw function.
+          if (typeof value.data === 'function') {
+            needsAsync = true
+          }
+          kept.push([key, value.data])
           continue
         }
         if (typeof value === 'function') {
@@ -255,6 +425,18 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
         }
         if (!isPartial && Object.keys(deferredGroups).length > 0) {
           page.deferredProps = deferredGroups
+        }
+        if (mergeProps.length > 0) {
+          page.mergeProps = mergeProps
+        }
+        if (prependProps.length > 0) {
+          page.prependProps = prependProps
+        }
+        if (deepMergeProps.length > 0) {
+          page.deepMergeProps = deepMergeProps
+        }
+        if (matchPropsOn.length > 0) {
+          page.matchPropsOn = matchPropsOn
         }
 
         c.header('Vary', 'Accept, X-Inertia')


### PR DESCRIPTION
## Summary

Third step of the [`@hono/inertia` v3 protocol breakdown](https://github.com/honojs/middleware/issues/1900): **③ Merge props**, built on top of the partial reload foundation from #1904.

Adds three helpers — `merge()`, `prepend()`, and `deepMerge()` — that mark a prop for client-side combination on the **next partial reload**, instead of the default replace behavior. The wrapped value travels as-is; the renderer advertises which keys to combine via the new `page.mergeProps` / `page.prependProps` / `page.deepMergeProps` arrays and emits dot-paths on `page.matchPropsOn` for the client's dedupe logic.

```ts
import { deepMerge, inertia, merge, prepend } from '@hono/inertia'

app.use(inertia())

app.get('/feed', (c) =>
  c.render('Feed', {
    posts: merge(await db.posts.page(n), { matchOn: 'id' }),
    notifications: prepend(await fetchNotifications(), { matchOn: 'id' }),
    conversations: deepMerge(
      { data: await db.messages.page(n), meta: { nextCursor } },
      { matchOn: 'data.id' },
    ),
  }),
)
```

## Protocol behaviour

| Visit kind | Behaviour |
|---|---|
| Initial / partial / JSON request | Wrapped value is unwrapped and sent as a plain prop |
| Response with at least one merge marker | `page.mergeProps` / `prependProps` / `deepMergeProps` / `matchPropsOn` emitted on **every** response (initial + partial) so the client knows which keys to combine on the next partial reload |
| Merge-marked prop excluded by `only`/`except` | Stripped before any metadata is recorded (no leak in `mergeProps` etc.) |
| Function value inside `merge()` (e.g. `merge(() => fetchPosts(), ...)`) | Resolved on the same lazy path as plain function props from #1904 |

Merging itself only takes effect on subsequent partial reloads — full page visits always replace props entirely (matches the upstream protocol).

## Implementation

- `merge<T>(data, { matchOn? }): T`, `prepend<T>(...)`, `deepMerge<T>(...)` return opaque markers (`Symbol.for('@hono/inertia/merge')`) that the renderer unwraps. The return type is `T`, so call sites and `TypedResponse` stay transparent — mirrors the `defer()` pattern from #1911.
- `matchOn` accepts a string or array; entries are emitted as `"<propKey>.<field>"` on `page.matchPropsOn` (e.g. `merge(posts, { matchOn: 'id' })` ⇒ `matchPropsOn: ['posts.id']`).
- `PageObject` gains four optional fields — `mergeProps?: string[]`, `prependProps?: string[]`, `deepMergeProps?: string[]`, `matchPropsOn?: string[]` — emitted only when at least one prop in the response carries the corresponding marker.

Scope intentionally kept small (single PR per protocol feature, like #1904 / #1911):

- ✅ Top-level \`merge()\` / \`prepend()\` / \`deepMerge()\` markers
- ✅ Single string and array \`matchOn\`
- ✅ Function value inside \`merge()\` (resolved via the existing lazy path)
- ✅ Strategy mixing in a single response
- ❌ Nested / dot-path merge markers — separate PR (would need to land alongside dot-path partial reloads)
- ❌ \`defer()\` inside \`merge()\` — separate PR (semantics deserve their own design discussion)
- ❌ Infinite scroll markers — separate PR (④ in the breakdown)

## Test plan

- [x] \`yarn workspace @hono/inertia test\` (\`40 passed\`, 12 new tests covering each helper, single + array \`matchOn\`, strategy mixing, partial reload behaviour, excluded-prop guard, function-inside-merge, HTML embed, JSON request)
- [x] \`eslint packages/inertia\` clean
- [x] \`prettier --check\` clean
- [x] \`tsc -b\` clean
- [x] \`tsdown\` build success