### PR TITLE
feat(inertia): add infinite scroll with scroll()

### DIFF
--- a/.changeset/inertia-infinite-scroll.md
+++ b/.changeset/inertia-infinite-scroll.md
@@ -1,0 +1,26 @@
+---
+'@hono/inertia': minor
+---
+
+feat(inertia): add infinite scroll with `scroll()`
+
+Adds a `scroll()` helper that wraps a paginated page payload with the metadata
+the Inertia client's `<InfiniteScroll>` adapter needs to keep loading more items
+as the user scrolls:
+
+```ts
+users: scroll({
+  data: await db.users.page(currentPage),
+  currentPage,
+  lastPage: 10,
+  pageName: 'users_page',
+  matchOn: 'id',
+})
+```
+
+The value travels as-is; the renderer emits `page.scrollProps[key] = {
+previousPage, nextPage, currentPage, pageName }` on every response and opts the
+prop into the merge protocol — defaulting to `append`, switched to `prepend`
+when the client sends `X-Inertia-Infinite-Scroll-Merge-Intent: prepend`. The
+optional `matchOn` is forwarded as `page.matchPropsOn` for client-side dedupe.
+Mirrors `Inertia::scroll(...)` in inertia-laravel 3.x.

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -247,6 +247,37 @@ app.get('/feed', (c) =>
 
 The merge metadata is included on **every** response — initial and partial — so the client knows which keys to combine on the next partial reload. Full page visits always replace props entirely; merging only kicks in on subsequent partial reloads.
 
+## Infinite scroll
+
+[Infinite scroll](https://inertiajs.com/docs/v2/data-props/infinite-scroll) keeps loading more items as the user scrolls — feeds, search results, chat history. The Inertia client's `<InfiniteScroll>` adapter handles the IntersectionObserver and the partial-reload requests; the server just needs to advertise the paging cursor.
+
+Wrap the page payload with `scroll()`:
+
+```ts
+import { inertia, scroll } from '@hono/inertia'
+
+app.use(inertia())
+
+app.get('/users', async (c) => {
+  const currentPage = Number(c.req.query('users_page') ?? 1)
+  return c.render('Users/Index', {
+    users: scroll({
+      data: await db.users.page(currentPage),
+      currentPage,
+      lastPage: 10,
+      pageName: 'users_page',
+      matchOn: 'id',
+    }),
+  })
+})
+```
+
+The renderer emits `page.scrollProps[key] = { previousPage, nextPage, currentPage, pageName }` — what the `<InfiniteScroll>` adapter reads to decide when to fetch the next page and which query string to use (e.g. `pageName: 'users_page'` ⇒ `?users_page=2`). `previousPage` is `currentPage - 1` (or `null` on the first page); `nextPage` is `currentPage + 1` (or `null` on the last page).
+
+Scroll props also opt into the [merge protocol](#merge-props) automatically. By default each incoming page is **appended** to the cached array; when the client sends `X-Inertia-Infinite-Scroll-Merge-Intent: prepend` (e.g. when scrolling backwards), the prop is moved into `page.prependProps` for that response instead. The optional `matchOn` is forwarded as `page.matchPropsOn` exactly like in `merge()` — accepting a string or array, with no default (omit it to skip dedupe).
+
+Full page visits always replace props entirely; the append/prepend behaviour only kicks in on subsequent partial reloads.
+
 ## Vite plugin
 
 ```ts

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -884,11 +884,7 @@ describe('inertia', () => {
   })
 
   describe('scroll props', () => {
-    const partialHeaders = (
-      component: string,
-      only?: string,
-      mergeIntent?: string
-    ) => {
+    const partialHeaders = (component: string, only?: string, mergeIntent?: string) => {
       const headers: Record<string, string> = {
         'X-Inertia': 'true',
         'X-Inertia-Version': 'v1',

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
-import type { PageObject } from './index'
-import { deepMerge, defer, inertia, merge, prepend } from './index'
+import type { PageObject, ScrollDescriptor } from './index'
+import { deepMerge, defer, inertia, merge, prepend, scroll } from './index'
 
 describe('inertia', () => {
   describe('full page (non Inertia request)', () => {
@@ -880,6 +880,405 @@ describe('inertia', () => {
       // Accept: application/json returns the raw props (not a page object),
       // so the merge metadata isn't relevant — only the unwrapped value matters.
       expect(await res.json()).toEqual({ posts: [{ id: 1 }] })
+    })
+  })
+
+  describe('scroll props', () => {
+    const partialHeaders = (
+      component: string,
+      only?: string,
+      mergeIntent?: string
+    ) => {
+      const headers: Record<string, string> = {
+        'X-Inertia': 'true',
+        'X-Inertia-Version': 'v1',
+        'X-Inertia-Partial-Component': component,
+      }
+      if (only !== undefined) {
+        headers['X-Inertia-Partial-Data'] = only
+      }
+      if (mergeIntent !== undefined) {
+        headers['X-Inertia-Infinite-Scroll-Merge-Intent'] = mergeIntent
+      }
+      return headers
+    }
+
+    it('emits page.scrollProps with paging metadata and unwraps the value', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({
+            data: [{ id: 1 }, { id: 2 }],
+            currentPage: 2,
+            lastPage: 5,
+            pageName: 'users_page',
+          }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        scrollProps?: Record<string, ScrollDescriptor>
+      }
+      expect(body.props).toEqual({ users: [{ id: 1 }, { id: 2 }] })
+      expect(body.scrollProps).toEqual({
+        users: { previousPage: 1, nextPage: 3, currentPage: 2, pageName: 'users_page' },
+      })
+    })
+
+    it('reports previousPage as null on the first page', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({ data: [], currentPage: 1, lastPage: 5, pageName: 'page' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { scrollProps?: Record<string, ScrollDescriptor> }
+      expect(body.scrollProps?.['users']?.previousPage).toBeNull()
+      expect(body.scrollProps?.['users']?.nextPage).toBe(2)
+    })
+
+    it('reports nextPage as null on the last page', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({ data: [], currentPage: 5, lastPage: 5, pageName: 'page' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { scrollProps?: Record<string, ScrollDescriptor> }
+      expect(body.scrollProps?.['users']?.previousPage).toBe(4)
+      expect(body.scrollProps?.['users']?.nextPage).toBeNull()
+    })
+
+    it('defaults the merge direction to append (mergeProps, not prependProps)', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({ data: [], currentPage: 1, lastPage: 5, pageName: 'page' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { mergeProps?: string[]; prependProps?: string[] }
+      expect(body.mergeProps).toEqual(['users'])
+      expect(body.prependProps).toBeUndefined()
+    })
+
+    it('switches to prepend when X-Inertia-Infinite-Scroll-Merge-Intent is prepend', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({ data: [], currentPage: 2, lastPage: 5, pageName: 'page' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: partialHeaders('Users/Index', 'users', 'prepend'),
+      })
+
+      const body = (await res.json()) as { mergeProps?: string[]; prependProps?: string[] }
+      expect(body.prependProps).toEqual(['users'])
+      expect(body.mergeProps).toBeUndefined()
+    })
+
+    it('treats an unknown merge-intent value (e.g. "append" or garbage) as append', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({ data: [], currentPage: 2, lastPage: 5, pageName: 'page' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: partialHeaders('Users/Index', 'users', 'bogus'),
+      })
+
+      const body = (await res.json()) as { mergeProps?: string[]; prependProps?: string[] }
+      expect(body.mergeProps).toEqual(['users'])
+      expect(body.prependProps).toBeUndefined()
+    })
+
+    it('emits matchPropsOn for a single matchOn string', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({
+            data: [{ id: 1 }],
+            currentPage: 1,
+            lastPage: 5,
+            pageName: 'page',
+            matchOn: 'id',
+          }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { matchPropsOn?: string[] }
+      expect(body.matchPropsOn).toEqual(['users.id'])
+    })
+
+    it('expands an array matchOn into one matchPropsOn entry per field', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({
+            data: [{ id: 1, tenantId: 'a' }],
+            currentPage: 1,
+            lastPage: 5,
+            pageName: 'page',
+            matchOn: ['id', 'tenantId'],
+          }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { matchPropsOn?: string[] }
+      expect(body.matchPropsOn).toEqual(['users.id', 'users.tenantId'])
+    })
+
+    it('omits matchPropsOn entirely when matchOn is not passed', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({ data: [], currentPage: 1, lastPage: 5, pageName: 'page' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { matchPropsOn?: string[] }
+      expect(body.matchPropsOn).toBeUndefined()
+    })
+
+    it('still emits scrollProps and mergeProps on partial reloads', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({
+            data: [{ id: 11 }],
+            currentPage: 2,
+            lastPage: 5,
+            pageName: 'page',
+            matchOn: 'id',
+          }),
+          tenant: { id: 1 },
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Users/Index', 'users') })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        scrollProps?: Record<string, ScrollDescriptor>
+        mergeProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.props).toEqual({ users: [{ id: 11 }] })
+      expect(body.scrollProps?.['users']?.currentPage).toBe(2)
+      expect(body.mergeProps).toEqual(['users'])
+      expect(body.matchPropsOn).toEqual(['users.id'])
+    })
+
+    it('omits a scroll-marked prop from scrollProps when the partial filter excludes it', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          users: scroll({
+            data: [{ id: 1 }],
+            currentPage: 1,
+            lastPage: 5,
+            pageName: 'page',
+            matchOn: 'id',
+          }),
+          orders: scroll({
+            data: [{ id: 2 }],
+            currentPage: 1,
+            lastPage: 3,
+            pageName: 'orders_page',
+            matchOn: 'id',
+          }),
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Feed', 'users') })
+
+      const body = (await res.json()) as {
+        props: Record<string, unknown>
+        scrollProps?: Record<string, ScrollDescriptor>
+        mergeProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.props).toEqual({ users: [{ id: 1 }] })
+      expect(Object.keys(body.scrollProps ?? {})).toEqual(['users'])
+      expect(body.mergeProps).toEqual(['users'])
+      expect(body.matchPropsOn).toEqual(['users.id'])
+    })
+
+    it('supports multiple scroll() props in a single response', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Dashboard', {
+          users: scroll({
+            data: [],
+            currentPage: 1,
+            lastPage: 5,
+            pageName: 'users_page',
+            matchOn: 'id',
+          }),
+          orders: scroll({
+            data: [],
+            currentPage: 2,
+            lastPage: 4,
+            pageName: 'orders_page',
+            matchOn: 'id',
+          }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        scrollProps?: Record<string, ScrollDescriptor>
+        mergeProps?: string[]
+        matchPropsOn?: string[]
+      }
+      expect(body.scrollProps).toEqual({
+        users: { previousPage: null, nextPage: 2, currentPage: 1, pageName: 'users_page' },
+        orders: { previousPage: 1, nextPage: 3, currentPage: 2, pageName: 'orders_page' },
+      })
+      expect(body.mergeProps).toEqual(['users', 'orders'])
+      expect(body.matchPropsOn).toEqual(['users.id', 'orders.id'])
+    })
+
+    it('coexists with merge() / prepend() in the same response', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Feed', {
+          users: scroll({
+            data: [{ id: 1 }],
+            currentPage: 1,
+            lastPage: 5,
+            pageName: 'page',
+            matchOn: 'id',
+          }),
+          announcements: prepend([{ id: 9 }], { matchOn: 'id' }),
+          ticker: merge([{ id: 1 }], { matchOn: 'id' }),
+        })
+      )
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as {
+        mergeProps?: string[]
+        prependProps?: string[]
+        matchPropsOn?: string[]
+        scrollProps?: Record<string, ScrollDescriptor>
+      }
+      expect(body.mergeProps).toEqual(['users', 'ticker'])
+      expect(body.prependProps).toEqual(['announcements'])
+      expect(body.matchPropsOn).toEqual(['users.id', 'announcements.id', 'ticker.id'])
+      expect(body.scrollProps?.['users']?.pageName).toBe('page')
+    })
+
+    it('embeds scrollProps in the initial HTML page object', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({
+            data: [{ id: 1 }],
+            currentPage: 1,
+            lastPage: 3,
+            pageName: 'users_page',
+            matchOn: 'id',
+          }),
+        })
+      )
+
+      const res = await app.request('/')
+
+      const html = await res.text()
+      expect(html).toContain('"scrollProps":{"users":')
+      expect(html).toContain('"pageName":"users_page"')
+      expect(html).toContain('"mergeProps":["users"]')
+      expect(html).toContain('"matchPropsOn":["users.id"]')
+    })
+
+    it('omits all scroll fields from the page object when no prop is scroll-marked', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { user: { id: 1 } }))
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { scrollProps?: Record<string, ScrollDescriptor> }
+      expect(body.scrollProps).toBeUndefined()
+    })
+
+    it('unwraps the scroll value for raw JSON requests (Accept: application/json)', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Users/Index', {
+          users: scroll({
+            data: [{ id: 1 }],
+            currentPage: 1,
+            lastPage: 3,
+            pageName: 'users_page',
+            matchOn: 'id',
+          }),
+        })
+      )
+
+      const res = await app.request('/', { headers: { Accept: 'application/json' } })
+
+      // Accept: application/json returns the raw props (not a page object),
+      // so scroll metadata isn't relevant — only the unwrapped value matters.
+      expect(await res.json()).toEqual({ users: [{ id: 1 }] })
     })
   })
 })

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -49,10 +49,37 @@ export type PageObject<P = Record<string, unknown>> = {
   /**
    * Dot-paths used by the client to dedupe array items when merging. Each
    * entry is `"<propKey>.<matchField>"` (e.g. `"posts.id"`), built from the
-   * `matchOn` option passed to {@link merge}, {@link prepend}, or
-   * {@link deepMerge}.
+   * `matchOn` option passed to {@link merge}, {@link prepend},
+   * {@link deepMerge}, or {@link scroll}.
    */
   matchPropsOn?: string[]
+  /**
+   * Pagination metadata emitted for every prop wrapped with {@link scroll}.
+   * Keyed by the prop name; each entry describes the previous/next page
+   * cursor that the Inertia client's `<InfiniteScroll>` adapter uses to
+   * trigger the next partial reload.
+   */
+  scrollProps?: Record<string, ScrollDescriptor>
+}
+
+/**
+ * Pagination metadata emitted on `page.scrollProps[key]` for each prop
+ * wrapped with {@link scroll}. The Inertia client's `<InfiniteScroll>`
+ * adapter reads these to know which page to request next (and whether more
+ * pages exist in either direction).
+ */
+export interface ScrollDescriptor {
+  /** `currentPage - 1`, or `null` if already on the first page. */
+  previousPage: number | null
+  /** `currentPage + 1`, or `null` if already on the last page. */
+  nextPage: number | null
+  /** Page number passed to {@link scroll}. */
+  currentPage: number
+  /**
+   * Query-string parameter the client uses to request the next page (e.g.
+   * `pageName: 'users_page'` ⇒ partial reload appends `?users_page=2`).
+   */
+  pageName: string
 }
 
 /**
@@ -251,6 +278,114 @@ export const prepend: <T>(data: T, options?: MergeOptions) => T = buildMerge('pr
  */
 export const deepMerge: <T>(data: T, options?: MergeOptions) => T = buildMerge('deep')
 
+const SCROLL_MARKER = Symbol.for('@hono/inertia/scroll')
+
+/**
+ * Request header sent by the Inertia client's `<InfiniteScroll>` adapter to
+ * tell the server whether the next partial reload should append (scrolling
+ * forward) or prepend (scrolling backward) its result onto the cached array.
+ *
+ * Mirrors `Inertia\Support\Header::INFINITE_SCROLL_MERGE_INTENT` from the
+ * Laravel adapter.
+ */
+const INFINITE_SCROLL_MERGE_INTENT_HEADER = 'X-Inertia-Infinite-Scroll-Merge-Intent'
+
+/**
+ * Internal marker produced by {@link scroll}. The renderer detects this,
+ * unwraps `data` as the prop value, emits {@link ScrollDescriptor} metadata
+ * on `page.scrollProps[key]`, and — mirroring `Inertia\ScrollProp` — opts
+ * the prop into the merge protocol (defaulting to `append`, switching to
+ * `prepend` when the client sends `X-Inertia-Infinite-Scroll-Merge-Intent:
+ * prepend`).
+ *
+ * The shape is intentionally opaque — only the type guard inside the
+ * renderer reads it. The factory returns `T[]` so usage at call sites is
+ * transparent.
+ */
+interface ScrollProp<T = unknown> {
+  [SCROLL_MARKER]: true
+  data: T[]
+  previousPage: number | null
+  nextPage: number | null
+  currentPage: number
+  pageName: string
+  matchOn: string[]
+}
+
+const isScroll = (value: unknown): value is ScrollProp =>
+  typeof value === 'object' && value !== null && SCROLL_MARKER in value
+
+/**
+ * Options accepted by {@link scroll}.
+ */
+export interface ScrollOptions<T> {
+  /** Page payload — the items rendered for `currentPage`. */
+  data: T[]
+  /** 1-indexed current page number. */
+  currentPage: number
+  /** Total page count. Used to compute `nextPage` (returns `null` when on the last page). */
+  lastPage: number
+  /** Query-string parameter the client uses to request the next page (e.g. `'users_page'` ⇒ `?users_page=2`). */
+  pageName: string
+  /**
+   * Field(s) used by the Inertia client to dedupe array items when
+   * combining incoming and cached pages. Each entry is emitted as
+   * `"<propKey>.<field>"` on `page.matchPropsOn`. Mirrors the `matchOn`
+   * option on {@link merge} — optional and no default, so items are
+   * appended verbatim if you do not pass a key.
+   */
+  matchOn?: string | string[]
+}
+
+/**
+ * Marks a prop as a paginated **infinite scroll** source. On every response
+ * the renderer emits `props[key] = data` and `page.scrollProps[key]` with
+ * the previous/next page cursor that the Inertia client's
+ * `<InfiniteScroll>` adapter reads to drive subsequent partial reloads.
+ *
+ * Scroll props opt into the merge protocol on every response (default
+ * `append`, switched to `prepend` when the client sends
+ * `X-Inertia-Infinite-Scroll-Merge-Intent: prepend`), so the cached array
+ * keeps growing instead of being replaced each page.
+ *
+ * Full page visits always replace props entirely — merging only kicks in on
+ * subsequent partial reloads.
+ *
+ * @example
+ * ```ts
+ * app.get('/users', (c) =>
+ *   c.render('Users/Index', {
+ *     users: scroll({
+ *       data: await db.users.page(currentPage),
+ *       currentPage,
+ *       lastPage: 10,
+ *       pageName: 'users_page',
+ *       matchOn: 'id',
+ *     }),
+ *   }),
+ * )
+ * ```
+ *
+ * @see https://inertiajs.com/docs/v2/data-props/infinite-scroll
+ */
+export const scroll = <T>(options: ScrollOptions<T>): T[] => {
+  const matchOn = options.matchOn
+    ? Array.isArray(options.matchOn)
+      ? options.matchOn
+      : [options.matchOn]
+    : []
+  const marker: ScrollProp<T> = {
+    [SCROLL_MARKER]: true,
+    data: options.data,
+    previousPage: options.currentPage > 1 ? options.currentPage - 1 : null,
+    nextPage: options.currentPage < options.lastPage ? options.currentPage + 1 : null,
+    currentPage: options.currentPage,
+    pageName: options.pageName,
+    matchOn,
+  }
+  return marker as unknown as T[]
+}
+
 export interface InertiaOptions {
   /**
    * Asset version. When an Inertia GET request's `X-Inertia-Version` header
@@ -367,12 +502,22 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       //     is recorded in `deferredGroups`, and nothing is added to `kept`.
       //   - partial visit (`isPartial`): the marker is kept and resolved
       //     just like a regular function-valued prop.
+      // Scroll props opt into the merge protocol on every response. Default
+      // direction is `append`; when the client's <InfiniteScroll> adapter is
+      // walking backwards it sends X-Inertia-Infinite-Scroll-Merge-Intent:
+      // prepend, which flips this prop into the prepend bucket instead.
+      // Mirrors `ScrollProp::configureMergeIntent` in inertia-laravel.
+      const scrollMergeIntent = c.req.header(INFINITE_SCROLL_MERGE_INTENT_HEADER)
+      const scrollDirection: 'append' | 'prepend' =
+        scrollMergeIntent === 'prepend' ? 'prepend' : 'append'
+
       const kept: [string, unknown][] = []
       const deferredGroups: Record<string, string[]> = {}
       const mergeProps: string[] = []
       const prependProps: string[] = []
       const deepMergeProps: string[] = []
       const matchPropsOn: string[] = []
+      const scrollProps: Record<string, ScrollDescriptor> = {}
       let needsAsync = false
       for (const [key, value] of Object.entries(propsInput)) {
         if (isExcluded(key)) {
@@ -385,6 +530,28 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
           }
           needsAsync = true
           kept.push([key, value])
+          continue
+        }
+        // Scroll markers emit pagination metadata on every response and opt
+        // the prop into the merge protocol so the client appends/prepends
+        // each incoming page to the cached array. Checked before isMerge so
+        // a scroll() prop never falls through to the plain merge branch.
+        if (isScroll(value)) {
+          scrollProps[key] = {
+            previousPage: value.previousPage,
+            nextPage: value.nextPage,
+            currentPage: value.currentPage,
+            pageName: value.pageName,
+          }
+          if (scrollDirection === 'prepend') {
+            prependProps.push(key)
+          } else {
+            mergeProps.push(key)
+          }
+          for (const p of value.matchOn) {
+            matchPropsOn.push(`${key}.${p}`)
+          }
+          kept.push([key, value.data])
           continue
         }
         // Merge markers are emitted on every response (initial + partial) so
@@ -437,6 +604,9 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
         }
         if (matchPropsOn.length > 0) {
           page.matchPropsOn = matchPropsOn
+        }
+        if (Object.keys(scrollProps).length > 0) {
+          page.scrollProps = scrollProps
         }
 
         c.header('Vary', 'Accept, X-Inertia')


### PR DESCRIPTION
## Summary

Final step of the [`@hono/inertia` v3 protocol breakdown](https://github.com/honojs/middleware/issues/1900): **④ Infinite scroll**, built on top of the merge protocol from #1932.

Adds a `scroll()` helper that wraps a paginated page payload with the metadata Inertia's [`<InfiniteScroll>`](https://inertiajs.com/docs/v2/data-props/infinite-scroll) adapter needs to keep loading more items as the user scrolls. The wrapped value travels as-is; the renderer emits a new `page.scrollProps` map with the previous/next page cursor and opts the prop into the merge protocol so each incoming page is appended (or prepended) to the cached array instead of replacing it.

```ts
import { inertia, scroll } from '@hono/inertia'

app.use(inertia())

app.get('/users', async (c) => {
  const currentPage = Number(c.req.query('users_page') ?? 1)
  return c.render('Users/Index', {
    users: scroll({
      data: await db.users.page(currentPage),
      currentPage,
      lastPage: 10,
      pageName: 'users_page',
      matchOn: 'id',
    }),
  })
})
```

Mirrors [`Inertia::scroll(...)`](https://github.com/inertiajs/inertia-laravel/blob/3.x/src/ScrollProp.php) in inertia-laravel 3.x.

## Protocol behaviour

| Visit kind | Behaviour |
|---|---|
| Any response with a `scroll()` prop | `scrollProps[key] = { previousPage, nextPage, currentPage, pageName }` emitted and `mergeProps.push(key)` by default |
| Request with `X-Inertia-Infinite-Scroll-Merge-Intent: prepend` | `prependProps.push(key)` instead of `mergeProps` (the `<InfiniteScroll>` adapter sends this when scrolling backwards) |
| `matchOn` passed (string or array) | One `"<key>.<field>"` entry per field appended to `page.matchPropsOn` for client-side dedupe; omitted entirely when `matchOn` is not passed |
| Scroll-marked prop excluded by `only` / `except` | Stripped before any metadata is recorded (no leak in `scrollProps`, `mergeProps`, or `matchPropsOn`) |
| Initial / partial / JSON request | Wrapped value is unwrapped and sent as a plain prop |

`previousPage` is `currentPage - 1` (or `null` on the first page); `nextPage` is `currentPage + 1` (or `null` on the last page).

## Implementation

- `scroll<T>({ data, currentPage, lastPage, pageName, matchOn? }): T[]` returns an opaque marker (`Symbol.for('@hono/inertia/scroll')`) that the renderer unwraps — same pattern as `defer()` (#1911) and `merge()` (#1932). The return type is `T[]` so call sites and `TypedResponse` stay transparent.
- `PageObject` gains one optional field, `scrollProps?: Record<string, ScrollDescriptor>`, where `ScrollDescriptor = { previousPage, nextPage, currentPage, pageName }`. `matchOn` is intentionally **not** part of the descriptor — it travels only via `page.matchPropsOn`, matching `Inertia\ScrollProp::metadata()` in the Laravel adapter.
- Default merge direction is `append`; the client switches it by sending `X-Inertia-Infinite-Scroll-Merge-Intent: prepend`. Unknown header values fall back to `append`. Mirrors `ScrollProp::configureMergeIntent` in inertia-laravel.
- `matchOn` accepts a string or string array, optional with no default, matching `Inertia::merge(matchOn:)` and the existing `merge()` helper in this package.

Scope intentionally kept small (single PR per protocol feature, like #1904 / #1911 / #1932):

- ✅ Top-level `scroll()` marker
- ✅ Single string and array `matchOn`
- ✅ Default `append` + `prepend` via the merge-intent header
- ✅ Coexistence with `merge()` / `prepend()` / `deepMerge()` / `defer()` in the same response
- ❌ Laravel paginator auto-extraction — Hono has no equivalent paginator object, so `data` / `currentPage` / `lastPage` / `pageName` are passed explicitly
- ❌ Nested / dot-path scroll markers — separate PR (would need to land alongside dot-path partial reloads, same constraint as #1932)

## Test plan

- [x] \`yarn workspace @hono/inertia test\` (\`56 passed\`, 16 new tests covering paging metadata, \`previousPage\` / \`nextPage\` boundaries, default-append direction, \`prepend\` via header, single / array \`matchOn\`, no-\`matchOn\` omission, partial-reload preservation, \`only\` / \`except\` guard, multi-\`scroll()\` in one response, coexistence with \`merge()\` / \`prepend()\`, HTML embed, raw JSON request, unknown header value fallback)
- [x] \`eslint packages/inertia\` clean
- [x] \`prettier --check\` clean
- [x] \`tsc -b\` clean
- [x] \`tsdown\` build success