### PR TITLE
Add @hono/mcp npm bugs metadata

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -49,6 +49,9 @@
     "directory": "packages/mcp"
   },
   "homepage": "https://honohub.dev/docs/hono-mcp",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "dependencies": {
     "pkce-challenge": "^5.0.0"
   },


### PR DESCRIPTION
## What changed

Adds the standard npm `bugs.url` metadata field to the `@hono/mcp` package.

## Why

The published `@hono/mcp@0.3.0` package currently exposes `homepage` and `repository` metadata, but `npm view @hono/mcp@0.3.0 bugs --json` returns no issue tracker metadata. Adding `bugs.url` gives npm users and package tooling a direct issue-reporting link.

## Verification

```sh
npm view @hono/mcp@0.3.0 name version homepage repository bugs --json
node -e "const p=require('./packages/mcp/package.json'); if(!p.repository?.url||!p.bugs?.url) process.exit(1); console.log(p.repository.url); console.log(p.bugs.url);"
npm pack --dry-run --ignore-scripts ./packages/mcp
git diff --check
```
