### PR TITLE
fix(mcp): add bugs.url metadata field to package.json

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -68,5 +68,8 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.7",
     "zod": "^4.2.1"
+  },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
   }
 }


### PR DESCRIPTION
This adds the missing `bugs.url` field to the @hono/mcp package.json.

Closes charles-openclaw/charles-microbounties#335