### PR TITLE
chore: add bugs metadata for @hono/mcp

### DIFF
--- a/.changeset/swift-comics-cross.md
+++ b/.changeset/swift-comics-cross.md
@@ -1,0 +1,5 @@
+---
+"@hono/mcp": patch
+---
+
+Add npm bugs metadata for the MCP package.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -37,6 +37,9 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/mcp"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://honohub.dev/docs/hono-mcp",
   "dependencies": {
     "pkce-challenge": "^5.0.0"


### PR DESCRIPTION
## Summary
- Add npm bugs metadata for the @hono/mcp package so npm users can jump to the public issue tracker.
- Preserve the existing package homepage and repository metadata.

## Validation
- Metadata smoke check for bugs/repository/homepage fields
- npm pack --dry-run --ignore-scripts ./packages/mcp
- git diff --check