### PR TITLE
Add bugs metadata for @hono/mcp

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -37,6 +37,9 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/mcp"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://honohub.dev/docs/hono-mcp",
   "dependencies": {
     "pkce-challenge": "^5.0.0"


### PR DESCRIPTION
## Summary

- Add npm `bugs.url` metadata for `@hono/mcp`
- Point the field at the public `honojs/middleware` issue tracker

## Validation

- `node -e "const p=require('./packages/mcp/package.json'); console.log(JSON.stringify({name:p.name, version:p.version, bugs:p.bugs, homepage:p.homepage, repository:p.repository}, null, 2))"`
- `npm pack --dry-run --json`
- `git diff --check`