### PR TITLE
chore(mcp): add npm bugs metadata

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -37,6 +37,9 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/mcp"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://honohub.dev/docs/hono-mcp",
   "dependencies": {
     "pkce-challenge": "^5.0.0"


### PR DESCRIPTION
## Summary
- add npm-standard `bugs.url` metadata to `@hono/mcp`

## Verification
- `node -e "const p=require('./packages/mcp/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,repository:p.repository,bugs:p.bugs}, null, 2))"`
- `npm pack --dry-run --json --ignore-scripts` from `packages/mcp/`

This is metadata-only and does not change runtime code.