### PR TITLE
Add bugs metadata for node-ws package

### DIFF
--- a/.changeset/tidy-node-ws-bugs.md
+++ b/.changeset/tidy-node-ws-bugs.md
@@ -1,0 +1,5 @@
+---
+"@hono/node-ws": patch
+---
+
+Add npm bugs metadata for the node-ws package.

--- a/packages/node-ws/package.json
+++ b/packages/node-ws/package.json
@@ -36,6 +36,9 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/node-ws"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://github.com/honojs/middleware",
   "devDependencies": {
     "@hono/node-server": "^1.19.11",


### PR DESCRIPTION
## Summary
- add the standard npm bugs.url metadata to @hono/node-ws
- point the issue tracker to the honojs/middleware issues page, matching the package repository

## Validation
- node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/node-ws/package.json','utf8')); if (p.bugs?.url !== 'https://github.com/honojs/middleware/issues') process.exit(1)"
- git diff --check