### PR TITLE
Add bugs metadata for mcp package

### DIFF
--- a/.changeset/tidy-mcp-bugs.md
+++ b/.changeset/tidy-mcp-bugs.md
@@ -1,0 +1,5 @@
+---
+"@hono/mcp": patch
+---
+
+Add npm bugs metadata for the MCP package.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -42,6 +42,9 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/mcp"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://honohub.dev/docs/hono-mcp",
   "dependencies": {
     "pkce-challenge": "^5.0.0"


### PR DESCRIPTION
## Summary
- add standard npm `bugs.url` metadata to `@hono/mcp`
- point the issue tracker to the honojs/middleware issues page, matching the package repository
- add a patch changeset for the package metadata update

## Validation
- `node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/mcp/package.json','utf8')); if (p.name !== '@hono/mcp' || p.bugs?.url !== 'https://github.com/honojs/middleware/issues') process.exit(1); console.log(JSON.stringify({name:p.name,bugs:p.bugs}))"`
- `npm pack ./packages/mcp --dry-run --json --ignore-scripts`
- `git diff --check`