### PR TITLE
Add zod-validator bugs metadata

### DIFF
--- a/.changeset/happy-lions-study.md
+++ b/.changeset/happy-lions-study.md
@@ -1,0 +1,5 @@
+---
+"@hono/zod-validator": patch
+---
+
+Add zod-validator bugs metadata.

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -37,6 +37,9 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/zod-validator"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=4.10.0",


### PR DESCRIPTION
## Summary

Adds missing npm `bugs.url` metadata for `@hono/zod-validator`, pointing to the Hono middleware issue tracker.

## Motivation

The package already publishes repository and homepage metadata, but consumers and registry tooling cannot discover the standard npm bugs/support link from the package manifest.

## Validation

```sh
node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/zod-validator/package.json','utf8')); if(p.bugs?.url !== 'https://github.com/honojs/middleware/issues') throw new Error('missing bugs metadata'); console.log(JSON.stringify({name:p.name,homepage:p.homepage,bugs:p.bugs}, null, 2));"
git diff --check
```

`git diff --check` passed with only the local Windows line-ending warning.

AI-assisted with Codex; reviewed and validated before submission.