### PR TITLE
Add bugs metadata to validator packages

### DIFF
--- a/.changeset/silver-maps-share.md
+++ b/.changeset/silver-maps-share.md
@@ -1,0 +1,9 @@
+---
+"@hono/arktype-validator": patch
+"@hono/typebox-validator": patch
+"@hono/standard-validator": patch
+"@hono/typedriver-validator": patch
+"@hono/swagger-ui": patch
+---
+
+Add npm bugs metadata for issue tracker discovery.

--- a/packages/arktype-validator/package.json
+++ b/packages/arktype-validator/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/arktype-validator"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "arktype": ">=2.0.0-dev",
     "hono": ">=3.0.0"

--- a/packages/standard-validator/package.json
+++ b/packages/standard-validator/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/standard-validator"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "@standard-schema/spec": "^1.0.0",
     "hono": ">=3.9.0"

--- a/packages/swagger-ui/package.json
+++ b/packages/swagger-ui/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/swagger-ui"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "hono": ">=4.0.0"
   },

--- a/packages/typebox-validator/package.json
+++ b/packages/typebox-validator/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/typebox-validator"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "hono": ">=3.9.0",
     "typebox": "^1.1.5"

--- a/packages/typedriver-validator/package.json
+++ b/packages/typedriver-validator/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/typedriver-validator"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "hono": ">=3.9.0",
     "typedriver": "^0.8.6"


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@hono/arktype-validator`
- add npm `bugs.url` metadata for `@hono/typebox-validator`
- add npm `bugs.url` metadata for `@hono/standard-validator`
- add npm `bugs.url` metadata for `@hono/typedriver-validator`
- add npm `bugs.url` metadata for `@hono/swagger-ui`
- include a patch changeset for the metadata updates

## Verification
- `node` manifest assertion for all five package manifests
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` in each touched package
