### PR TITLE
fix: add trpc-server bugs metadata

### DIFF
--- a/.changeset/trpc-server-bugs-metadata.md
+++ b/.changeset/trpc-server-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+"@hono/trpc-server": patch
+---
+
+Add npm bugs metadata for the package manifest.

--- a/packages/trpc-server/package.json
+++ b/packages/trpc-server/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/trpc-server"
   },
   "homepage": "https://honojs.dev",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "@trpc/server": "^10.10.0 || >11.0.0-rc",
     "hono": ">=4.0.0"


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@hono/trpc-server`
- include a patch changeset for the package metadata update

## Verification
- `node` manifest assertion for `packages/trpc-server/package.json`
- `cd packages/trpc-server && npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

This is metadata-only and does not change tRPC/Hono runtime behavior, exports, dependencies, or package version.
