### PR TITLE
chore(zod-openapi): add bugs metadata

### DIFF
--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/zod-openapi"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "hono": ">=4.10.0",
     "zod": "^4.0.0"


### PR DESCRIPTION
Adds npm bugs metadata for @hono/zod-openapi so npm users can find the issue tracker from package metadata.

  No runtime code changes.