### PR TITLE
fix(otel): add npm bugs metadata

### DIFF
--- a/.changeset/tough-cameras-thank.md
+++ b/.changeset/tough-cameras-thank.md
@@ -1,0 +1,5 @@
+---
+"@hono/otel": patch
+---
+
+Add npm package bugs metadata for the issue tracker.

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/otel"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "hono": ">=4.0.0"
   },


### PR DESCRIPTION
## Summary

Adds the missing npm `bugs.url` metadata for `@hono/otel`, pointing to the repository issue tracker.

This keeps the package metadata aligned with the existing `repository`, `homepage`, and MIT `license` fields while leaving middleware runtime code unchanged.

## How I Tested These Changes

- `node` package metadata assertion for `@hono/otel` name/version/license/repository/homepage/bugs fields
- `cd packages/otel && npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

## Did you add a changeset?

Yes — patch changeset `.changeset/tough-cameras-thank.md` for `@hono/otel` package metadata.
