### PR TITLE
fix(otel): add npm bugs metadata

### DIFF
--- a/.changeset/metal-otel-bugs.md
+++ b/.changeset/metal-otel-bugs.md
@@ -1,0 +1,5 @@
+---
+"@hono/otel": patch
+---
+
+fix(otel): add npm bugs metadata

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -38,6 +38,9 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/otel"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=4.0.0"


### PR DESCRIPTION
## Summary
- add missing npm `bugs.url` metadata for `@hono/otel`
- include a patch changeset for the package metadata update

I noticed the earlier PR for this package was closed without merge, and the current package manifest still lacks the `bugs` field. This keeps the change metadata-only: no runtime code, exports, dependencies, or build behavior changed.

## Testing
- `node` package metadata assertion
- `cd packages/otel && npm pack --dry-run --ignore-scripts --json`
- `git diff --check`