### PR TITLE
fix(otel): add npm bugs metadata

### DIFF
--- a/.changeset/clean-bugs-metadata.md
+++ b/.changeset/clean-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+"@hono/otel": patch
+---
+
+Add npm bugs metadata for the package manifest.

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/otel"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "hono": ">=4.0.0"
   },


### PR DESCRIPTION
Adds the missing `bugs` metadata to the `@hono/otel` package manifest so npm displays the repository issue tracker.

Verification:
- `python3 -m json.tool packages/otel/package.json`
- `node -e "const p=require('./packages/otel/package.json'); if(p.name!=='@hono/otel'||p.bugs?.url!=='https://github.com/honojs/middleware/issues') process.exit(1); console.log(p.name, p.bugs.url)"`

Bounty: https://github.com/charles-openclaw/charles-microbounties/issues/1163