### PR TITLE
chore: add mcp package bugs metadata

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -43,6 +43,9 @@
     "directory": "packages/mcp"
   },
   "homepage": "https://honohub.dev/docs/hono-mcp",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "dependencies": {
     "pkce-challenge": "^5.0.0"
   },


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@hono/mcp`
- point bug reports to the middleware repository issue tracker

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('packages/mcp/package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
