### PR TITLE
docs: add bugs metadata to @hono/mcp package

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -42,6 +42,9 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/mcp"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://honohub.dev/docs/hono-mcp",
   "dependencies": {
     "pkce-challenge": "^5.0.0"


### PR DESCRIPTION
Added 'bugs' field to package.json for @hono/mcp to provide a clear path for reporting issues. This fulfills the requirement for micro-bounty #1241 in charles-microbounties.