### PR TITLE
chore(eslint-config): add bugs metadata

### DIFF
--- a/.changeset/calm-suits-visit.md
+++ b/.changeset/calm-suits-visit.md
@@ -1,0 +1,5 @@
+---
+"@hono/eslint-config": patch
+---
+
+Add package bugs metadata.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/honojs/middleware.git",
     "directory": "packages/eslint-config"
   },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "eslint": "^9.0.0",


### PR DESCRIPTION
## Summary

Adds `bugs.url` metadata to the `@hono/eslint-config` package so npm users and registry tooling can discover the public issue tracker from package metadata.

This is a small AI-assisted metadata cleanup. The published `@hono/eslint-config@2.1.0` package currently exposes repository, homepage, and license metadata, but `npm view @hono/eslint-config@2.1.0 name version repository homepage bugs license --json` does not expose `bugs`.

## Verification

```bash
npm view @hono/eslint-config@2.1.0 name version repository homepage bugs license --json
node -e "const p=require('./packages/eslint-config/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,bugs:p.bugs,homepage:p.homepage,license:p.license}, null, 2)); if (p.name !== '@hono/eslint-config' || p.bugs?.url !== 'https://github.com/honojs/middleware/issues') process.exit(1)"
git diff --check
npm pack ./packages/eslint-config --dry-run --json
```
