### PR TITLE
fix: add bugs metadata to swagger-ui and zod-openapi package.json

### DIFF
--- a/packages/swagger-ui/package.json
+++ b/packages/swagger-ui/package.json
@@ -51,5 +51,8 @@
   },
   "inlinedDependencies": {
     "@types/swagger-ui-dist": "3.30.6"
+  },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
   }
 }

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -58,5 +58,8 @@
   },
   "engines": {
     "node": ">=16.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
   }
 }


### PR DESCRIPTION
## Summary
The published npm packages `@hono/swagger-ui@0.6.1` and `@hono/zod-openapi@1.4.0` are missing the `bugs` field in their `package.json` metadata.

Both packages already have `repository`, `homepage`, and `license` set, but lack the `bugs` field. This means npm consumers do not get a direct link to the issue tracker from registry clients.

## Fix
Added the following field to both `packages/swagger-ui/package.json` and `packages/zod-openapi/package.json`:
```json
"bugs": {
  "url": "https://github.com/honojs/middleware/issues"
}
```

## Verification
- `npm view @hono/swagger-ui bugs --json` returns nothing
- `npm view @hono/zod-openapi bugs --json` returns nothing
- No dependencies, runtime code, or build configuration affected