### PR TITLE
chore: add missing bugs metadata to auth-js and prometheus packages

### DIFF
--- a/packages/auth-js/package.json
+++ b/packages/auth-js/package.json
@@ -51,6 +51,9 @@
     "directory": "packages/auth-js"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "@auth/core": ">=0.35.0",
     "hono": ">=3.0.0",

--- a/packages/prometheus/package.json
+++ b/packages/prometheus/package.json
@@ -39,6 +39,9 @@
     "directory": "packages/prometheus"
   },
   "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "peerDependencies": {
     "hono": ">=3.0.0",
     "prom-client": "^15.0.0"


### PR DESCRIPTION
Adds the missing bugs metadata fields to `@hono/auth-js` and `@hono/prometheus` package.json manifests.
