### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "hono-middleware",
   "version": "0.0.0",
+  "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "description": "Third-party middleware for Hono",
   "type": "module",
   "workspaces": {


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.