### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@hono/zod-openapi",
   "version": "1.4.0",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "description": "A wrapper class of Hono which supports OpenAPI.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/zod-openapi/package.json`.