### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/swagger-ui/package.json
+++ b/packages/swagger-ui/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@hono/swagger-ui",
   "version": "0.6.1",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "description": "A middleware for using SwaggerUI in Hono",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/swagger-ui/package.json`.