### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@hono/eslint-config",
   "version": "2.1.0",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "description": "ESLint Config for Hono projects",
   "type": "module",
   "module": "./index.js",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/eslint-config/package.json`.