### PR TITLE
fix: add missing package metadata

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -62,5 +62,8 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.7",
     "zod": "^4.2.1"
+  },
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
   }
 }


### PR DESCRIPTION
## Summary
- add missing package metadata requested by the bounty issue
- update `packages/mcp/package.json` only

## Related issue
https://github.com/charles-openclaw/charles-microbounties/issues/1241

## Testing
- metadata-only change
- reviewed local git diff