### PR TITLE
feat(node-ws): allow passing WebSocketServer options

### DIFF
--- a/.changeset/wicked-areas-fail.md
+++ b/.changeset/wicked-areas-fail.md
@@ -1,0 +1,5 @@
+---
+'@hono/node-ws': minor
+---
+
+Allow passing WebSocketServer options through createNodeWebSocket.

--- a/packages/node-ws/src/index.test.ts
+++ b/packages/node-ws/src/index.test.ts
@@ -327,4 +327,16 @@ describe('WebSocket helper', () => {
       })
     )
   })
+
+  it('should pass websocket options to WebSocketServer', () => {
+    const { wss } = createNodeWebSocket({
+      app: new Hono(),
+      webSocketOptions: {
+        maxPayload: 12345,
+      },
+    })
+
+    expect(wss.options.maxPayload).toBe(12345)
+  })
+
 })

--- a/packages/node-ws/src/index.ts
+++ b/packages/node-ws/src/index.ts
@@ -8,7 +8,7 @@ import type { IncomingMessage, Server } from 'node:http'
 import type { Http2SecureServer, Http2Server } from 'node:http2'
 import type { Duplex } from 'node:stream'
 import { CloseEvent } from './events'
-
+import type { ServerOptions } from 'ws'
 export interface NodeWebSocket {
   upgradeWebSocket: UpgradeWebSocket<
     WebSocket,
@@ -23,6 +23,7 @@ export interface NodeWebSocketInit {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   app: Hono<any, any, any>
   baseUrl?: string | URL
+  webSocketOptions?: ServerOptions
 }
 
 const generateConnectionSymbol = () => Symbol('connection')
@@ -36,7 +37,10 @@ const CONNECTION_SYMBOL_KEY: unique symbol = Symbol('CONNECTION_SYMBOL_KEY')
  * @returns NodeWebSocket
  */
 export const createNodeWebSocket = (init: NodeWebSocketInit): NodeWebSocket => {
-  const wss = new WebSocketServer({ noServer: true })
+  const wss = new WebSocketServer({
+    noServer: true,
+    ...init.webSocketOptions,
+  })
   const waiterMap = new Map<
     IncomingMessage,
     { resolve: (ws: WebSocket) => void; connectionSymbol: symbol }


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

Fixes #1786

## Summary

Add support for passing `WebSocketServer` options to `createNodeWebSocket()` via a new `webSocketOptions` field on `NodeWebSocketInit`.

This allows configuring options such as `maxPayload`, `perMessageDeflate`, and other supported `ws` server options.

## Changes

* Add `webSocketOptions?: ServerOptions` to `NodeWebSocketInit`
* Pass the provided options to the underlying `WebSocketServer`
* Add a test verifying that options are forwarded correctly
* Add a changeset for `@hono/node-ws`