### PR TITLE
docs: add oauth providers npm support metadata

### DIFF
--- a/.changeset/calm-buttons-serve.md
+++ b/.changeset/calm-buttons-serve.md
@@ -1,0 +1,5 @@
+---
+"@hono/oauth-providers": patch
+---
+
+Add npm support metadata for the oauth-providers package.

--- a/packages/oauth-providers/package.json
+++ b/packages/oauth-providers/package.json
@@ -6,6 +6,10 @@
     "url": "git+https://github.com/honojs/middleware.git",
     "directory": "packages/oauth-providers"
   },
+  "homepage": "https://github.com/honojs/middleware",
+  "bugs": {
+    "url": "https://github.com/honojs/middleware/issues"
+  },
   "description": "Social login for Hono JS, integrate authentication with facebook, github, google and linkedin to your projects.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for `@hono/oauth-providers`
- add `bugs.url` pointing to the repository issue tracker

## Verification
- `node` package metadata assertion
- `npm pack --dry-run --json ./packages/oauth-providers`
- `git diff --check`
