### PR TITLE
fix(zod-openapi): infer route middleware env in defineOpenAPIRoute handler

### DIFF
--- a/.changeset/tidy-mangos-grin.md
+++ b/.changeset/tidy-mangos-grin.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix(zod-openapi): infer route middleware env in `defineOpenAPIRoute` handler

--- a/packages/zod-openapi/src/index.test-d.ts
+++ b/packages/zod-openapi/src/index.test-d.ts
@@ -3,7 +3,7 @@ import { createMiddleware } from 'hono/factory'
 import type { ExtractSchema } from 'hono/types'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { Equal, Expect } from 'hono/utils/types'
-import { OpenAPIHono, createRoute, z, $ } from './index'
+import { OpenAPIHono, createRoute, defineOpenAPIRoute, z, $ } from './index'
 import type { HonoToOpenAPIHono, MiddlewareToHandlerType, OfHandlerType } from './index'
 
 describe('Types', () => {
@@ -315,6 +315,43 @@ describe('Middleware', () => {
         return c.json({})
       }
     )
+  })
+
+  it('Should infer Env from router middleware in defineOpenAPIRoute', () => {
+    defineOpenAPIRoute({
+      route: createRoute({
+        method: 'get',
+        path: '/books',
+        middleware: [
+          createMiddleware<{
+            Variables: { foo: string }
+          }>((c, next) => {
+            c.set('foo', 'abc')
+            return next()
+          }),
+          createMiddleware<{
+            Variables: { bar: number }
+          }>((c, next) => {
+            c.set('bar', 321)
+            return next()
+          }),
+        ] as const,
+        responses: {
+          200: {
+            description: 'response',
+          },
+        },
+      }),
+      handler: (c) => {
+        c.var.foo
+        c.var.bar
+
+        type verifyFoo = Expect<Equal<typeof c.var.foo, string>>
+        type verifyBar = Expect<Equal<typeof c.var.bar, number>>
+
+        return c.json({})
+      },
+    })
   })
 
   it('Should infer Env root when no middleware provided', async () => {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -406,7 +406,10 @@ type ComputeInput<R extends RouteConfig> = InputTypeParam<R> &
 
 // Helper: Calculate the expected Handler type for a specific RouteConfig
 type HandlerFromRoute<R extends RouteConfig, E extends Env> = Handler<
-  E,
+  // use the env from the middleware if it's defined
+  R['middleware'] extends MiddlewareHandler[] | MiddlewareHandler
+    ? RouteMiddlewareParams<R>['env'] & E
+    : E,
   ConvertPathType<R['path']>,
   ComputeInput<R>,
   R extends {


### PR DESCRIPTION
### What & why

`defineOpenAPIRoute` (added in #1752) types its `handler` with only the app `Env`, so variables set by route-level `middleware` are dropped. Inside the handler `c.var.*` falls back to `any`:

```ts
const requireIdentity = createMiddleware<{
  Variables: { identity: { id: string } }
}>(async (c, next) => {
  c.set('identity', { id: '123' })
  await next()
})

const route = defineOpenAPIRoute({
  route: createRoute({
    method: 'get',
    path: '/me',
    middleware: [requireIdentity] as const,
    responses: { 200: { description: 'ok' } },
  }),
  handler: (c) => {
    c.var.identity // typed as `any`, should be `{ id: string }`
    return c.text('ok')
  },
})
```

`OpenAPIHono.openapi()` already covers this case: when a route has middleware it widens the handler env to `RouteMiddlewareParams<R>['env'] & E`. `HandlerFromRoute`, which `defineOpenAPIRoute` relies on, only passed `E`. This change applies the same widening in `HandlerFromRoute`, so a route built through `defineOpenAPIRoute` infers the middleware variables.

Thanks to @aros for the report and for pointing at the existing `openapi()` handling.

### Test

Added a type test in `index.test-d.ts`, mirroring the existing `openapi()` middleware-env test, that asserts the handler's `c.var.foo` / `c.var.bar` resolve to the route middleware variable types. It fails on `main` (`Property 'foo' does not exist on type ...`) and passes with the fix.

Fixes #1879

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
