### PR TITLE
fix(inertia): resolve page.url for non-GET requests

### DIFF
--- a/.changeset/brave-tools-create.md
+++ b/.changeset/brave-tools-create.md
@@ -1,0 +1,13 @@
+---
+'@hono/inertia': minor
+---
+
+feat(inertia): add an option to override `page.url`
+
+`c.render(component, props, options)` now accepts an optional third argument
+`options?: RenderOptions` with a `url` field. Overrides `page.url`. It is primarily
+used to prevent incorrect URLs when using no-referrer, origin, or strict-origin.
+
+```ts
+app.post('/users', (c) => c.render('Users/New', {}, { url: '/users/new' }))
+```

--- a/.changeset/red-trees-tease.md
+++ b/.changeset/red-trees-tease.md
@@ -4,15 +4,15 @@
 
 fix(inertia): use the Referer for non-GET requests to keep the original URL
 
-For non-GET requests, `page.url` now uses the `Referer` header
-(falling back to `c.req.url`) instead of `c.req.url` to keep the original URL.
+For non-GET requests, `page.url` now uses the `Referer` header (falling
+back to `c.req.url`) instead of `c.req.url` to keep the original URL.
 
 feat(inertia): add an option to override `page.url`
 
-`c.render(component, props, options)` now accepts an optional third argument
-`options?: RenderOptions` with a `url` field. Overrides `page.url`.
+`c.render(component, props, options)` now accepts an optional third
+argument `options?: RenderOptions` with a `url` field. Overrides `page.url`.
 It is primarily used to prevent incorrect URLs when using no-referrer.
 
 ```ts
-app.post('/users', (c) => c.render('Users/New', { ok: true }, { url: '/users/new' }))
+app.post('/users', (c) => c.render('Users/New', {}, { url: '/users/new' }))
 ```

--- a/.changeset/red-trees-tease.md
+++ b/.changeset/red-trees-tease.md
@@ -1,0 +1,18 @@
+---
+'@hono/inertia': minor
+---
+
+fix(inertia): use the Referer for non-GET requests to keep the original URL
+
+For non-GET requests, `page.url` now uses the `Referer` header
+(falling back to `c.req.url`) instead of `c.req.url` to keep the original URL.
+
+feat(inertia): add an option to override `page.url`
+
+`c.render(component, props, options)` now accepts an optional third argument
+`options?: RenderOptions` with a `url` field. Overrides `page.url`.
+It is primarily used to prevent incorrect URLs when using no-referrer.
+
+```ts
+app.post('/users', (c) => c.render('Users/New', { ok: true }, { url: '/users/new' }))
+```

--- a/.changeset/red-trees-tease.md
+++ b/.changeset/red-trees-tease.md
@@ -4,15 +4,7 @@
 
 fix(inertia): use the Referer for non-GET requests to keep the original URL
 
-For non-GET requests, `page.url` now uses the `Referer` header (falling
-back to `c.req.url`) instead of `c.req.url` to keep the original URL.
-
-feat(inertia): add an option to override `page.url`
-
-`c.render(component, props, options)` now accepts an optional third
-argument `options?: RenderOptions` with a `url` field. Overrides `page.url`.
-It is primarily used to prevent incorrect URLs when using no-referrer.
-
-```ts
-app.post('/users', (c) => c.render('Users/New', {}, { url: '/users/new' }))
-```
+**Behavior change**: For non-GET requests, `page.url` previously used
+`c.req.url` (e.g. the POST target). It now uses the `Referer` header
+(falling back to `c.req.url` when unavailable). If you were relying on
+the old value, pass the explicit `options.url` instead.

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -176,6 +176,24 @@ export default function Show({ post }: PageProps<'Posts/Show'>) {
 }
 ```
 
+## Page URL resolution
+
+`c.render` resolves the current page's URL. Its default source depends on the request method:
+
+| Method                       | Default Page URL source                                       |
+| ---------------------------- | ------------------------------------------------------------- |
+| `GET`                        | `c.req.url`                                                   |
+| non-`GET` (`POST`, `PUT`, …) | `Referer` header (falls back to `c.req.url` when unavailable) |
+
+### Override Page URL
+
+When the `Referer` header is unavailable (e.g. under a `no-referrer` Referrer-Policy) or reduced to the origin (under an `origin` or `strict-origin`), the resolved URL may not reflect the original URL. To pin a deterministic value regardless, pass the third argument to `c.render`:
+
+```ts
+// Resolved URL: '/users/new'
+app.post('/users', (c) => c.render('Users/New', {}, { url: '/users/new' }))
+```
+
 ## Partial reloads
 
 Inertia's [partial reloads](https://inertiajs.com/partial-reloads) let a single visit re-fetch only a subset of the page's props, leaving the rest as they were. `@hono/inertia` honors the `X-Inertia-Partial-Component`, `X-Inertia-Partial-Data`, and `X-Inertia-Partial-Except` headers transparently — the route signature stays the same.

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -257,6 +257,38 @@ describe('inertia', () => {
       const body = (await res.json()) as PageObject
       expect(body.url).toBe('/users/new')
     })
+
+    it('prefers options.url over Referer when both are present on a non-GET request', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.post('/users', (c) => c.render('Users/New', {}, { url: '/override' }))
+
+      const res = await app.request('/users', {
+        method: 'POST',
+        headers: {
+          'X-Inertia': 'true',
+          'X-Inertia-Version': 'v1',
+          Referer: 'http://localhost/users/new',
+        },
+      })
+
+      const body = (await res.json()) as PageObject
+      expect(body.url).toBe('/override')
+    })
+
+    it('keeps only the pathname when options.url is an absolute URL', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.post('/users', (c) => c.render('Users/New', {}, { url: 'https://example.com/override' }))
+
+      const res = await app.request('/users', {
+        method: 'POST',
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as PageObject
+      expect(body.url).toBe('/override')
+    })
   })
 
   describe('partial reload', () => {

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -215,7 +215,7 @@ describe('inertia', () => {
     it('uses the Referer for non-GET requests to keep the original URL', async () => {
       const app = new Hono()
       app.use(inertia({ version: 'v1' }))
-      app.post('/users', (c) => c.render('Users/New', { ok: true }))
+      app.post('/users', (c) => c.render('Users/New'))
 
       const res = await app.request('/users', {
         method: 'POST',
@@ -233,7 +233,7 @@ describe('inertia', () => {
     it('falls back to c.req.url when Referer is missing on non-GET requests', async () => {
       const app = new Hono()
       app.use(inertia({ version: 'v1' }))
-      app.post('/users', (c) => c.render('Users/New', { ok: true }))
+      app.post('/users', (c) => c.render('Users/New'))
 
       const res = await app.request('/users', {
         method: 'POST',
@@ -247,14 +247,11 @@ describe('inertia', () => {
     it('overrides page.url via options.url on a non-GET request', async () => {
       const app = new Hono()
       app.use(inertia({ version: 'v1' }))
-      app.post('/users', (c) => c.render('Users/New', { ok: true }, { url: '/users/new' }))
+      app.post('/users', (c) => c.render('Users/New', {}, { url: '/users/new' }))
 
       const res = await app.request('/users', {
         method: 'POST',
-        headers: {
-          'X-Inertia': 'true',
-          'X-Inertia-Version': 'v1',
-        },
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
       })
 
       const body = (await res.json()) as PageObject

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -194,6 +194,74 @@ describe('inertia', () => {
     })
   })
 
+  describe('page.url resolution', () => {
+    it('uses c.req.url for GET requests', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/users', (c) => c.render('Users/Index', { users: [] }))
+
+      const res = await app.request('/users?page=2', {
+        headers: {
+          'X-Inertia': 'true',
+          'X-Inertia-Version': 'v1',
+          Referer: 'http://localhost/users?page=1',
+        },
+      })
+
+      const body = (await res.json()) as PageObject
+      expect(body.url).toBe('/users?page=2')
+    })
+
+    it('uses the Referer for non-GET requests to keep the original URL', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.post('/users', (c) => c.render('Users/New', { ok: true }))
+
+      const res = await app.request('/users', {
+        method: 'POST',
+        headers: {
+          'X-Inertia': 'true',
+          'X-Inertia-Version': 'v1',
+          Referer: 'http://localhost/users/new',
+        },
+      })
+
+      const body = (await res.json()) as PageObject
+      expect(body.url).toBe('/users/new')
+    })
+
+    it('falls back to c.req.url when Referer is missing on non-GET requests', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.post('/users', (c) => c.render('Users/New', { ok: true }))
+
+      const res = await app.request('/users', {
+        method: 'POST',
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as PageObject
+      expect(body.url).toBe('/users')
+    })
+
+    it('overrides page.url via options.url on a non-GET request', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.post('/users', (c) => c.render('Users/New', { ok: true }, { url: '/users/new' }))
+
+      const res = await app.request('/users', {
+        method: 'POST',
+        headers: {
+          'X-Inertia': 'true',
+          'X-Inertia-Version': 'v1',
+        },
+      })
+
+      const body = (await res.json()) as PageObject
+      expect(body.url).toBe('/users/new')
+    })
+  })
+
   describe('partial reload', () => {
     const partialHeaders = (component: string, only?: string, except?: string) => {
       const headers: Record<string, string> = {

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -474,7 +474,8 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
     }
 
     c.setRenderer(((component: string, propsInput: Record<string, unknown> = {}) => {
-      const url = new URL(c.req.url)
+      // Use the Referer for non-GET requests to keep the original URL.
+      const url = new URL(c.req.method === 'GET' ? c.req.url : c.req.header('Referer') ?? c.req.url)
 
       // Partial reload negotiation: the client (Inertia core) signals
       // "only re-evaluate these props" via X-Inertia-Partial-Component +

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -473,9 +473,13 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       }
     }
 
-    c.setRenderer(((component: string, propsInput: Record<string, unknown> = {}) => {
+    c.setRenderer(((component: string, propsInput: Record<string, unknown> = {}, options: RenderOptions = {}) => {
       // Use the Referer for non-GET requests to keep the original URL.
-      const url = new URL(c.req.method === 'GET' ? c.req.url : c.req.header('Referer') ?? c.req.url)
+      // Override with options.url if provided.
+      const url =
+        options.url === undefined
+          ? new URL(c.req.method === 'GET' ? c.req.url : c.req.header('Referer') ?? c.req.url)
+          : new URL(options.url, c.req.url)
 
       // Partial reload negotiation: the client (Inertia core) signals
       // "only re-evaluate these props" via X-Inertia-Partial-Component +
@@ -675,11 +679,23 @@ export type PageName = keyof InertiaPages extends never
   ? string
   : Extract<keyof InertiaPages, string>
 
+/**
+ * Render options accepted as the third argument of `c.render`.
+ */
+export interface RenderOptions {
+  /**
+   * Overrides `page.url`. 
+   * It is primarily used to prevent incorrect URLs when using no-referrer.
+   */
+  url?: string
+}
+
 declare module 'hono' {
   interface ContextRenderer {
     <C extends PageName, P = Record<string, never>>(
       component: C,
-      props?: P
+      props?: P,
+      options?: RenderOptions
     ): Response & TypedResponse<{ component: C; props: ResolvedProps<P> }, 200, 'html'>
   }
   interface NotFoundResponse extends Response, TypedResponse<string, 404, 'text'> {}

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -473,12 +473,16 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       }
     }
 
-    c.setRenderer(((component: string, propsInput: Record<string, unknown> = {}, options: RenderOptions = {}) => {
+    c.setRenderer(((
+      component: string,
+      propsInput: Record<string, unknown> = {},
+      options: RenderOptions = {}
+    ) => {
       // Use the Referer for non-GET requests to keep the original URL.
       // Override with options.url if provided.
       const url =
         options.url === undefined
-          ? new URL(c.req.method === 'GET' ? c.req.url : c.req.header('Referer') ?? c.req.url)
+          ? new URL(c.req.method === 'GET' ? c.req.url : (c.req.header('Referer') ?? c.req.url))
           : new URL(options.url, c.req.url)
 
       // Partial reload negotiation: the client (Inertia core) signals
@@ -684,7 +688,7 @@ export type PageName = keyof InertiaPages extends never
  */
 export interface RenderOptions {
   /**
-   * Overrides `page.url`. 
+   * Overrides `page.url`.
    * It is primarily used to prevent incorrect URLs when using no-referrer.
    */
   url?: string

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -480,10 +480,15 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
     ) => {
       // Use the Referer for non-GET requests to keep the original URL.
       // Override with options.url if provided.
-      const url =
-        options.url === undefined
-          ? new URL(c.req.method === 'GET' ? c.req.url : (c.req.header('Referer') ?? c.req.url))
-          : new URL(options.url, c.req.url)
+      const url = (() => {
+        try {
+          return options.url === undefined
+            ? new URL(c.req.method === 'GET' ? c.req.url : (c.req.header('Referer') ?? c.req.url))
+            : new URL(options.url, c.req.url)
+        } catch {
+          return new URL(c.req.url)
+        }
+      })()
 
       // Partial reload negotiation: the client (Inertia core) signals
       // "only re-evaluate these props" via X-Inertia-Partial-Component +
@@ -688,8 +693,8 @@ export type PageName = keyof InertiaPages extends never
  */
 export interface RenderOptions {
   /**
-   * Overrides `page.url`.
-   * It is primarily used to prevent incorrect URLs when using no-referrer.
+   * Overrides `page.url`. It is primarily used to prevent
+   * incorrect URLs when using no-referrer, origin, or strict-origin.
    */
   url?: string
 }


### PR DESCRIPTION
Issue: https://github.com/honojs/middleware/issues/1989

### Changes

#### fix(inertia): use the Referer for non-GET requests to keep the original URL

For non-GET requests, `page.url` now uses the `Referer` header (falling back to `c.req.url`) instead of `c.req.url` to keep the original URL.

#### feat(inertia): add an option to override `page.url`

`c.render(component, props, options)` now accepts an optional third argument `options?: RenderOptions` with a `url` field. Overrides `page.url`. It is primarily used to prevent incorrect URLs when using no-referrer, origin, or strict-origin.

```ts
// You can set `/users/new` as the URL even without a Referer.
app.post('/users', (c) => c.render('Users/New', {}, { url: '/users/new' }))
```

> [!NOTE]
> This option does not exist in inertia-laravel. Whether to include it requires consideration.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `yarn changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
