### PR TITLE
chore: add dependabot cooldown and disable install scripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,16 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
 
   - package-ecosystem: npm
     allow:
       - dependency-type: development
+    cooldown:
+      default-days: 7
     directory: /
     groups:
       otel:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+enableScripts: false
+
 nmHoistingLimits: workspaces
 
 nodeLinker: node-modules


### PR DESCRIPTION
To avoid supply chain attacks, add `cooldown` for the dependabot and disable installing scripts.

### The author should do the following, if applicable

- [ ] Add tests
- [ ] Run tests
- [ ] `yarn changeset` at the top of this repo and push the changeset
- [ ] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
