### PR TITLE
fix(standard-validator): preserve literal unions in RPC input type and fix hook data type

### DIFF
--- a/.changeset/standard-validator-infer-input.md
+++ b/.changeset/standard-validator-infer-input.md
@@ -1,0 +1,8 @@
+---
+'@hono/standard-validator': patch
+---
+
+fix(standard-validator): preserve literal union types in RPC input and fix hook data type
+
+- Port `InferInput` utility from `@hono/zod-validator` to preserve literal union types (e.g., `z.enum(["asc", "desc"])`) in the RPC client's input type, while still falling back to wire-level types (`string | string[]` for query, `string` for param/header/cookie) for non-literal values.
+- Fix hook `data` type to use `InferInput` instead of `InferOutput`, matching the runtime behavior where the raw input value is passed to the hook (fixes #1990).

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -3,6 +3,7 @@ import type { Context, Env, Input, TypedResponse, ValidationTargets } from 'hono
 import type { Handler } from 'hono/types'
 import { validator } from 'hono/validator'
 import { sanitizeIssues } from './sanitize-issues'
+import type { InferInput } from './utils'
 
 type HasUndefined<T> = undefined extends T ? true : false
 
@@ -118,14 +119,10 @@ const sValidator = <
   I extends Input = {
     in: HasUndefined<In> extends true
       ? {
-          [K in Target]?: In extends ValidationTargets[K]
-            ? In
-            : { [K2 in keyof In]?: ValidationTargets[K][K2] }
+          [K in Target]?: [In] extends [ValidationTargets[K]] ? In : InferInput<In, K>
         }
       : {
-          [K in Target]: In extends ValidationTargets[K]
-            ? In
-            : { [K2 in keyof In]: ValidationTargets[K][K2] }
+          [K in Target]: [In] extends [ValidationTargets[K]] ? In : InferInput<In, K>
         }
     out: { [K in Target]: Out }
   },
@@ -138,7 +135,7 @@ const sValidator = <
 >(
   target: Target,
   schema: Schema,
-  hook?: Hook<StandardSchemaV1.InferOutput<Schema>, E, P, Target, R>
+  hook?: Hook<StandardSchemaV1.InferInput<Schema>, E, P, Target, R>
 ): Handler<E, P, V, MustBeResponse<R>> =>
   // @ts-expect-error not typed well
   validator(target, async (value, c) => {

--- a/packages/standard-validator/src/utils.ts
+++ b/packages/standard-validator/src/utils.ts
@@ -1,0 +1,69 @@
+import type { FormValue, ParsedFormValue, ValidationTargets } from 'hono/types'
+import type { UnionToIntersection } from 'hono/utils/types'
+
+/**
+ * Checks if T is a literal union type (e.g., 'asc' | 'desc')
+ * that should be preserved in input types.
+ * Returns true for union literals, false for single literals or wide types.
+ */
+export type IsLiteralUnion<T, Base> = [Exclude<T, undefined>] extends [Base]
+  ? [Exclude<T, undefined>] extends [UnionToIntersection<Exclude<T, undefined>>]
+    ? false
+    : true
+  : false
+
+// Check if type is an optional union (T | undefined) but not unknown/any
+type IsOptionalUnion<T> = [unknown] extends [T]
+  ? false // unknown or any
+  : undefined extends T
+    ? true
+    : false
+
+// Helper to force TypeScript to expand type aliases
+type SimplifyDeep<T> = { [K in keyof T]: T[K] } & {}
+
+type InferInputInner<
+  Output,
+  Target extends keyof ValidationTargets,
+  T extends FormValue,
+> = SimplifyDeep<{
+  [K in keyof Output]: IsLiteralUnion<Output[K], string> extends true
+    ? Output[K]
+    : IsOptionalUnion<Output[K]> extends true
+      ? Output[K]
+      : Target extends 'form'
+        ? T | T[]
+        : Target extends 'query'
+          ? string | string[]
+          : Target extends 'param'
+            ? string
+            : Target extends 'header'
+              ? string
+              : Target extends 'cookie'
+                ? string
+                : unknown
+}>
+
+/**
+ * Utility type to infer input types for validation targets.
+ * Preserves literal union types (e.g., 'asc' | 'desc') while using
+ * the default ValidationTargets type for other values.
+ *
+ * @example
+ * ```ts
+ * // In @hono/standard-validator or similar:
+ * type Input = InferInput<StandardSchemaV1.InferInput<Schema>, 'query'>
+ * // { orderBy: 'asc' | 'desc', page: string | string[] }
+ * ```
+ */
+export type InferInput<
+  Output,
+  Target extends keyof ValidationTargets,
+  T extends FormValue = ParsedFormValue,
+> = [Exclude<Output, undefined>] extends [never]
+  ? {}
+  : [Exclude<Output, undefined>] extends [object]
+    ? undefined extends Output
+      ? SimplifyDeep<InferInputInner<Exclude<Output, undefined>, Target, T>> | undefined
+      : SimplifyDeep<InferInputInner<Output, Target, T>>
+    : {}


### PR DESCRIPTION
## Summary

This PR makes two type-level fixes to `@hono/standard-validator`:

### 1. Preserve literal union types in RPC client input

The current `sValidator()` maps all input property values through `ValidationTargets[K][K2]`, which widens literal unions like `z.enum(["asc", "desc"])` to `string | string[]` for query targets. This loses autocomplete in the Hono RPC client (`hc`).

**Before:**
```ts
const schema = z.object({ sortBy: z.enum(["name", "type"]) })
sValidator("query", schema)
// RPC client sees: sortBy?: string | string[]
```

**After:**
```ts
// RPC client sees: sortBy?: "name" | "type"
```

This is achieved by porting the `InferInput` utility type from `@hono/zod-validator` (`packages/zod-validator/src/utils.ts`). The utility selectively preserves literal string unions and optional unions while falling back to wire-level types (`string | string[]` for query, `string` for param/header/cookie) for non-literal values. This ensures coercion schemas like `z.coerce.number()` still correctly show `string | string[]` for query targets.

Additionally, the `In extends ValidationTargets[K]` check is now wrapped in tuple brackets (`[In] extends [ValidationTargets[K]]`) to prevent distributive conditional type behavior, matching `@hono/zod-validator`'s approach.

### 2. Fix hook `data` type to use `InferInput` instead of `InferOutput`

Fixes #1990

The `hook` parameter was typed as `Hook<StandardSchemaV1.InferOutput<Schema>, ...>`, but at runtime the hook receives `value` (the raw input), not `result.value` (the validated output):

```ts
// Both success and failure branches pass `value` (input), not `result.value` (output)
result.issues
  ? { data: value, error: result.issues, success: false, target }
  : { data: value, success: true, target }
```

Changed to `Hook<StandardSchemaV1.InferInput<Schema>, ...>` to match the runtime behavior.

## Changes

- **New file**: `packages/standard-validator/src/utils.ts` — `InferInput`, `IsLiteralUnion`, and helper types (ported from `packages/zod-validator/src/utils.ts`)
- **Modified**: `packages/standard-validator/src/index.ts` — uses `InferInput` for the `I` type parameter and fixes hook type

## Testing

- All 33 existing tests pass
- `tsc --noEmit` passes with zero errors
- Existing type-level assertions (including the `querySortSchema` enum test expecting `{ order: 'asc' | 'desc' }`) continue to pass
- No runtime code changes — type-only fix