### PR TITLE
feat(oidc-auth): opt-in client_secret_post via setClientAuth (fixes #1992 for consumers who enable it)

### DIFF
--- a/.changeset/oidc-auth-client-secret-post.md
+++ b/.changeset/oidc-auth-client-secret-post.md
@@ -1,0 +1,5 @@
+---
+'@hono/oidc-auth': patch
+---
+
+Fix Google login failing with `OAuth2Error: [invalid_client] The OAuth client was not found`. `oauth4webapi` v3 percent-encodes the client id/secret for `client_secret_basic` per RFC 6749 Appendix B, but Google does not decode that encoding and rejects the resulting credentials when they contain `-`, `_` or `.`. Switch the token endpoint requests (authorization code exchange, refresh, revocation) to `client_secret_post`, which sends the client secret unencoded in the request body.

--- a/.changeset/oidc-auth-client-secret-post.md
+++ b/.changeset/oidc-auth-client-secret-post.md
@@ -1,5 +1,5 @@
 ---
-'@hono/oidc-auth': patch
+'@hono/oidc-auth': minor
 ---
 
 Fix Google login failing with `OAuth2Error: [invalid_client] The OAuth client was not found`. `oauth4webapi` v3 percent-encodes the client id/secret for `client_secret_basic` per RFC 6749 Appendix B, but Google does not decode that encoding and rejects the resulting credentials when they contain `-`, `_` or `.`.

--- a/.changeset/oidc-auth-client-secret-post.md
+++ b/.changeset/oidc-auth-client-secret-post.md
@@ -2,4 +2,6 @@
 '@hono/oidc-auth': patch
 ---
 
-Fix Google login failing with `OAuth2Error: [invalid_client] The OAuth client was not found`. `oauth4webapi` v3 percent-encodes the client id/secret for `client_secret_basic` per RFC 6749 Appendix B, but Google does not decode that encoding and rejects the resulting credentials when they contain `-`, `_` or `.`. Switch the token endpoint requests (authorization code exchange, refresh, revocation) to `client_secret_post`, which sends the client secret unencoded in the request body.
+Fix Google login failing with `OAuth2Error: [invalid_client] The OAuth client was not found`. `oauth4webapi` v3 percent-encodes the client id/secret for `client_secret_basic` per RFC 6749 Appendix B, but Google does not decode that encoding and rejects the resulting credentials when they contain `-`, `_` or `.`.
+
+Add `setClientAuth()` to let consumers opt in to `client_secret_post` for the token endpoint requests (authorization code exchange, refresh, revocation), which sends the client secret unencoded in the request body. Also add `setClient()` to set the OAuth2 client metadata directly. The default `token_endpoint_auth_method` remains `client_secret_basic`, so existing consumers are unaffected; only clients whose secret contains `-`, `_` or `.` need to call `setClientAuth(c, oauth2.ClientSecretPost(env.OIDC_CLIENT_SECRET))`.

--- a/packages/oidc-auth/README.md
+++ b/packages/oidc-auth/README.md
@@ -35,6 +35,8 @@ Here is a list of the IdPs that I have tested:
 | Google      | `https://accounts.google.com`                             |
 | Slack       | `https://slack.com`                                       |
 
+Note: by default the middleware authenticates to the token endpoint with `client_secret_basic`, which percent-encodes the client secret. Secrets containing `-`, `_` or `.` (this includes Google's `GOCSPX-` client secrets) get mangled by that encoding and the token exchange fails with `invalid_client`. Use `setClientAuth` to opt into `client_secret_post` for these secrets, see [Client authentication method](#client-authentication-method) below.
+
 ## Installation
 
 ```plain
@@ -166,6 +168,25 @@ app.use(async (c, next) => {
   return middleware(c, next)
 })
 ```
+
+## Client authentication method
+
+By default, the middleware authenticates to the token endpoint with `client_secret_basic`. Use `setClientAuth` to switch to a different method, such as `client_secret_post`, for IdPs whose client secret is not compatible with `client_secret_basic`'s encoding (e.g. Google's `GOCSPX-` secrets):
+
+```typescript
+import { oidcAuthMiddleware, setClientAuth } from '@hono/oidc-auth'
+import * as oauth2 from 'oauth4webapi'
+
+app.use('*', async (c, next) => {
+  setClientAuth(c, oauth2.ClientSecretPost(c.env.OIDC_CLIENT_SECRET))
+  await next()
+})
+app.use('*', oidcAuthMiddleware())
+```
+
+`setClientAuth` sets the auth method for the current request context, so it must run on every request, before `getAuth`, `revokeSession` or `processOAuthCallback` are called (not just on the callback route), otherwise the token refresh and revocation requests fall back to `client_secret_basic`.
+
+`setClient` works the same way to override the full OAuth2 client metadata instead of just the authentication method.
 
 ## Author
 

--- a/packages/oidc-auth/src/index.test.ts
+++ b/packages/oidc-auth/src/index.test.ts
@@ -175,6 +175,7 @@ const {
   revokeSession,
   initOidcAuthMiddleware,
   getClient,
+  setClientAuth,
 } = await import('.')
 
 const app = new Hono()
@@ -188,6 +189,10 @@ app.get('/callback-custom', async (c) => {
     sub: claims?.sub ?? orig?.sub ?? '',
     token: response.access_token,
   }))
+  return processOAuthCallback(c)
+})
+app.get('/callback-client-secret-post', async (c) => {
+  setClientAuth(c, oauth2.ClientSecretPost(MOCK_CLIENT_SECRET))
   return processOAuthCallback(c)
 })
 app.use('/*', oidcAuthMiddleware())
@@ -507,17 +512,38 @@ describe('processOAuthCallback()', () => {
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('http://localhost/1234')
   })
-  test('Should authenticate the token exchange with client_secret_post so Google receives the client secret byte-for-byte', async () => {
-    // Regression for #1992: oauth4webapi v3's ClientSecretBasic percent-encodes
-    // '-', '_' and '.' per RFC 6749 Appendix B. Google rejects that encoding, so
-    // the client secret (which contains those characters) must travel unencoded
-    // in the token request body (client_secret_post), not in a Basic auth header.
+  test('Should default to client_secret_basic for the token exchange', async () => {
     const req = new Request(`${MOCK_REDIRECT_URI}?code=1234&state=${MOCK_STATE}`, {
       method: 'GET',
       headers: {
         cookie: `state=${MOCK_STATE}; nonce=${MOCK_NONCE}; code_verifier=1234; continue=http%3A%2F%2Flocalhost%2F1234`,
       },
     })
+    await app.request(req, {}, {})
+    const authorizationCodeGrantRequest = vi.mocked(oauth2.authorizationCodeGrantRequest)
+    expect(authorizationCodeGrantRequest).toHaveBeenCalled()
+    const clientAuth = authorizationCodeGrantRequest.mock.calls.at(-1)?.[2]
+    const headers = new Headers()
+    const body = new URLSearchParams()
+    await clientAuth?.({ issuer: MOCK_ISSUER }, { client_id: MOCK_CLIENT_ID }, body, headers)
+    expect(headers.get('authorization')).toMatch(/^Basic /)
+    expect(body.get('client_secret')).toBeNull()
+  })
+  test('setClientAuth() should authenticate the token exchange with client_secret_post so Google receives the client secret byte-for-byte', async () => {
+    // Regression for #1992: oauth4webapi v3's ClientSecretBasic percent-encodes
+    // '-', '_' and '.' per RFC 6749 Appendix B. Google rejects that encoding, so
+    // consumers whose client secret contains those characters can opt in to
+    // client_secret_post via setClientAuth(), sending the secret unencoded in the
+    // token request body instead of a Basic auth header.
+    const req = new Request(
+      `${MOCK_REDIRECT_URI}-client-secret-post?code=1234&state=${MOCK_STATE}`,
+      {
+        method: 'GET',
+        headers: {
+          cookie: `state=${MOCK_STATE}; nonce=${MOCK_NONCE}; code_verifier=1234; continue=http%3A%2F%2Flocalhost%2F1234`,
+        },
+      }
+    )
     await app.request(req, {}, {})
     const authorizationCodeGrantRequest = vi.mocked(oauth2.authorizationCodeGrantRequest)
     expect(authorizationCodeGrantRequest).toHaveBeenCalled()

--- a/packages/oidc-auth/src/index.test.ts
+++ b/packages/oidc-auth/src/index.test.ts
@@ -507,6 +507,27 @@ describe('processOAuthCallback()', () => {
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('http://localhost/1234')
   })
+  test('Should authenticate the token exchange with client_secret_post so Google receives the client secret byte-for-byte', async () => {
+    // Regression for #1992: oauth4webapi v3's ClientSecretBasic percent-encodes
+    // '-', '_' and '.' per RFC 6749 Appendix B. Google rejects that encoding, so
+    // the client secret (which contains those characters) must travel unencoded
+    // in the token request body (client_secret_post), not in a Basic auth header.
+    const req = new Request(`${MOCK_REDIRECT_URI}?code=1234&state=${MOCK_STATE}`, {
+      method: 'GET',
+      headers: {
+        cookie: `state=${MOCK_STATE}; nonce=${MOCK_NONCE}; code_verifier=1234; continue=http%3A%2F%2Flocalhost%2F1234`,
+      },
+    })
+    await app.request(req, {}, {})
+    const authorizationCodeGrantRequest = vi.mocked(oauth2.authorizationCodeGrantRequest)
+    expect(authorizationCodeGrantRequest).toHaveBeenCalled()
+    const clientAuth = authorizationCodeGrantRequest.mock.calls.at(-1)?.[2]
+    const headers = new Headers()
+    const body = new URLSearchParams()
+    await clientAuth?.({ issuer: MOCK_ISSUER }, { client_id: MOCK_CLIENT_ID }, body, headers)
+    expect(headers.get('authorization')).toBeNull()
+    expect(body.get('client_secret')).toBe(MOCK_CLIENT_SECRET)
+  })
   test('Verify default callback path when OIDC_REDIRECT_URI is undefined', async () => {
     delete process.env.OIDC_REDIRECT_URI
     const req = new Request(`${MOCK_REDIRECT_URI}?code=1234&state=${MOCK_STATE}`, {

--- a/packages/oidc-auth/src/index.test.ts
+++ b/packages/oidc-auth/src/index.test.ts
@@ -6,6 +6,11 @@ import crypto from 'node:crypto'
 const MOCK_ISSUER = 'https://accounts.google.com'
 const MOCK_CLIENT_ID = 'CLIENT_ID_001'
 const MOCK_CLIENT_SECRET = 'CLIENT_SECRET_001'
+const MOCK_CUSTOM_CLIENT: oauth2.Client = {
+  client_id: MOCK_CLIENT_ID,
+  client_secret: 'CUSTOM_CLIENT_SECRET_001',
+  token_endpoint_auth_method: 'client_secret_basic',
+}
 const MOCK_REDIRECT_URI = 'http://localhost/callback'
 const MOCK_SUBJECT = 'USER_ID_001'
 const MOCK_EMAIL = 'user001@example.com'
@@ -175,6 +180,7 @@ const {
   revokeSession,
   initOidcAuthMiddleware,
   getClient,
+  setClient,
   setClientAuth,
 } = await import('.')
 
@@ -193,6 +199,10 @@ app.get('/callback-custom', async (c) => {
 })
 app.get('/callback-client-secret-post', async (c) => {
   setClientAuth(c, oauth2.ClientSecretPost(MOCK_CLIENT_SECRET))
+  return processOAuthCallback(c)
+})
+app.get('/callback-custom-client', async (c) => {
+  setClient(c, MOCK_CUSTOM_CLIENT)
   return processOAuthCallback(c)
 })
 app.use('/*', oidcAuthMiddleware())
@@ -553,6 +563,21 @@ describe('processOAuthCallback()', () => {
     await clientAuth?.({ issuer: MOCK_ISSUER }, { client_id: MOCK_CLIENT_ID }, body, headers)
     expect(headers.get('authorization')).toBeNull()
     expect(body.get('client_secret')).toBe(MOCK_CLIENT_SECRET)
+  })
+  test('setClient() should override the client metadata used for the token exchange', async () => {
+    const req = new Request(`${MOCK_REDIRECT_URI}-custom-client?code=1234&state=${MOCK_STATE}`, {
+      method: 'GET',
+      headers: {
+        cookie: `state=${MOCK_STATE}; nonce=${MOCK_NONCE}; code_verifier=1234; continue=http%3A%2F%2Flocalhost%2F1234`,
+      },
+    })
+    const res = await app.request(req, {}, {})
+    expect(res.status).toBe(302)
+    const authorizationCodeGrantRequest = vi.mocked(oauth2.authorizationCodeGrantRequest)
+    expect(authorizationCodeGrantRequest).toHaveBeenCalled()
+    const client = authorizationCodeGrantRequest.mock.calls.at(-1)?.[1]
+    expect(client).toEqual(MOCK_CUSTOM_CLIENT)
+    expect(client?.client_secret).not.toBe(MOCK_CLIENT_SECRET)
   })
   test('Verify default callback path when OIDC_REDIRECT_URI is undefined', async () => {
     delete process.env.OIDC_REDIRECT_URI

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -184,7 +184,7 @@ export const getClient = (c: Context): oauth2.Client => {
     client = {
       client_id: env.OIDC_CLIENT_ID,
       client_secret: env.OIDC_CLIENT_SECRET,
-      token_endpoint_auth_method: 'client_secret_basic',
+      token_endpoint_auth_method: 'client_secret_post',
     }
     c.set('oidcClient', client)
   }
@@ -235,7 +235,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
       const response = await oauth2.refreshTokenGrantRequest(
         as,
         client,
-        oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
+        oauth2.ClientSecretPost(env.OIDC_CLIENT_SECRET),
         auth.rtk
       )
       let result: oauth2.TokenEndpointResponse
@@ -327,7 +327,7 @@ export const revokeSession = async (c: Context): Promise<void> => {
         const response = await oauth2.revocationRequest(
           as,
           client,
-          oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
+          oauth2.ClientSecretPost(env.OIDC_CLIENT_SECRET),
           auth.rtk
         )
         try {
@@ -442,7 +442,7 @@ export const processOAuthCallback = async (
   const result = await exchangeAuthorizationCode(
     as,
     client,
-    oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
+    oauth2.ClientSecretPost(env.OIDC_CLIENT_SECRET),
     params,
     redirectUri,
     nonce,

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -31,6 +31,7 @@ declare module 'hono' {
     oidcAuth: OidcAuth | null
     oidcAuthJwt: string
     oidcClaimsHook?: OidcClaimsHook
+    clientAuth?: oauth2.ClientAuth
   }
 }
 
@@ -184,11 +185,26 @@ export const getClient = (c: Context): oauth2.Client => {
     client = {
       client_id: env.OIDC_CLIENT_ID,
       client_secret: env.OIDC_CLIENT_SECRET,
-      token_endpoint_auth_method: 'client_secret_post',
+      token_endpoint_auth_method: 'client_secret_basic',
     }
     c.set('oidcClient', client)
   }
   return client
+}
+
+/**
+ * Sets the OAuth2 client metadata.
+ */
+export const setClient = (c: Context, client: oauth2.Client) => {
+  c.set('oidcClient', client)
+}
+
+/**
+ * Sets the client authentication method used for token endpoint requests.
+ * If not set, falls back to `client_secret_basic`.
+ */
+export const setClientAuth = (c: Context, clientAuth: oauth2.ClientAuth) => {
+  c.set('clientAuth', clientAuth)
 }
 
 /**
@@ -235,7 +251,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
       const response = await oauth2.refreshTokenGrantRequest(
         as,
         client,
-        oauth2.ClientSecretPost(env.OIDC_CLIENT_SECRET),
+        c.get('clientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
         auth.rtk
       )
       let result: oauth2.TokenEndpointResponse
@@ -327,7 +343,7 @@ export const revokeSession = async (c: Context): Promise<void> => {
         const response = await oauth2.revocationRequest(
           as,
           client,
-          oauth2.ClientSecretPost(env.OIDC_CLIENT_SECRET),
+          c.get('clientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
           auth.rtk
         )
         try {
@@ -442,7 +458,7 @@ export const processOAuthCallback = async (
   const result = await exchangeAuthorizationCode(
     as,
     client,
-    oauth2.ClientSecretPost(env.OIDC_CLIENT_SECRET),
+    c.get('clientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
     params,
     redirectUri,
     nonce,

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -31,7 +31,7 @@ declare module 'hono' {
     oidcAuth: OidcAuth | null
     oidcAuthJwt: string
     oidcClaimsHook?: OidcClaimsHook
-    clientAuth?: oauth2.ClientAuth
+    oidcClientAuth?: oauth2.ClientAuth
   }
 }
 
@@ -204,7 +204,7 @@ export const setClient = (c: Context, client: oauth2.Client): void => {
  * If not set, falls back to `client_secret_basic`.
  */
 export const setClientAuth = (c: Context, clientAuth: oauth2.ClientAuth): void => {
-  c.set('clientAuth', clientAuth)
+  c.set('oidcClientAuth', clientAuth)
 }
 
 /**
@@ -251,7 +251,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
       const response = await oauth2.refreshTokenGrantRequest(
         as,
         client,
-        c.get('clientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
+        c.get('oidcClientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
         auth.rtk
       )
       let result: oauth2.TokenEndpointResponse
@@ -343,7 +343,7 @@ export const revokeSession = async (c: Context): Promise<void> => {
         const response = await oauth2.revocationRequest(
           as,
           client,
-          c.get('clientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
+          c.get('oidcClientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
           auth.rtk
         )
         try {
@@ -458,7 +458,7 @@ export const processOAuthCallback = async (
   const result = await exchangeAuthorizationCode(
     as,
     client,
-    c.get('clientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
+    c.get('oidcClientAuth') ?? oauth2.ClientSecretBasic(env.OIDC_CLIENT_SECRET),
     params,
     redirectUri,
     nonce,

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -195,7 +195,7 @@ export const getClient = (c: Context): oauth2.Client => {
 /**
  * Sets the OAuth2 client metadata.
  */
-export const setClient = (c: Context, client: oauth2.Client) => {
+export const setClient = (c: Context, client: oauth2.Client): void => {
   c.set('oidcClient', client)
 }
 
@@ -203,7 +203,7 @@ export const setClient = (c: Context, client: oauth2.Client) => {
  * Sets the client authentication method used for token endpoint requests.
  * If not set, falls back to `client_secret_basic`.
  */
-export const setClientAuth = (c: Context, clientAuth: oauth2.ClientAuth) => {
+export const setClientAuth = (c: Context, clientAuth: oauth2.ClientAuth): void => {
   c.set('clientAuth', clientAuth)
 }
 


### PR DESCRIPTION
Fixes #1992 for consumers who opt in.

`oauth4webapi` v3 percent-encodes the client secret for `client_secret_basic` per RFC 6749 Appendix B. Google does not decode that and returns `invalid_client` when the secret contains `-`, `_` or `.` (this includes Google's `GOCSPX-` secrets). It is the same failure mode the oauth4webapi author documents for this case (panva/oauth4webapi#165).

Adds `setClientAuth(c, clientAuth)` so consumers can opt into `client_secret_post` (or any other oauth4webapi client auth method) for the token endpoint requests (authorization-code exchange, refresh, revocation). Also adds `setClient(c, client)` to override the OAuth2 client metadata directly. The default stays `client_secret_basic`, so existing consumers are unaffected; only clients whose secret contains `-`, `_` or `.` need to call `setClientAuth(c, oauth2.ClientSecretPost(env.OIDC_CLIENT_SECRET))`.

Documented `setClientAuth` in the README, including the caveat that it must run on every request (not just the callback route) since refresh/revocation also read it. Added a regression test driving the `client_secret_post` path through `setClientAuth`, plus a test asserting the default stays `client_secret_basic`.