### PR TITLE
fix(zod-openapi): preserve onError/notFound bindings set after basePath()

### DIFF
--- a/.changeset/zod-openapi-basepath-onerror.md
+++ b/.changeset/zod-openapi-basepath-onerror.md
@@ -1,0 +1,10 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix(zod-openapi): preserve `onError()`/`notFound()` set after `basePath()`
+
+`OpenAPIHono.basePath()` used to rebuild the instance by spreading the plain `Hono` clone returned by `super.basePath()`.
+That spread copied the clone's arrow-function instance fields (`onError`, `notFound`, `request`, `fetch`),
+which stay bound to the discarded clone — so calling `.onError()` (or `.notFound()`) *after* `.basePath()` mutated the throwaway clone instead of the returned app and silently had no effect (the parent's handler ran instead).
+`basePath()` now transplants only the routing state onto a properly constructed `OpenAPIHono`, keeping its own correctly-bound methods. Fixes #2021.

--- a/packages/zod-openapi/eslint-suppressions.json
+++ b/packages/zod-openapi/eslint-suppressions.json
@@ -46,7 +46,7 @@
       "count": 2
     },
     "@typescript-eslint/no-unsafe-argument": {
-      "count": 13
+      "count": 12
     },
     "@typescript-eslint/no-unsafe-assignment": {
       "count": 1

--- a/packages/zod-openapi/src/index.test.ts
+++ b/packages/zod-openapi/src/index.test.ts
@@ -1370,6 +1370,57 @@ describe('basePath()', () => {
     const client = hc<typeof routes>('http://localhost/')
     expect(client.api.doc31.$url().pathname).toBe('/api/doc31')
   })
+
+  const errorRoute = createRoute({
+    method: 'get',
+    path: '/error',
+    responses: {
+      200: {
+        description: 'ok',
+      },
+    },
+  })
+  const throwHandler = () => {
+    throw new Error('boom')
+  }
+
+  it('Should fire onError() registered after basePath()', async () => {
+    const parent = new OpenAPIHono()
+    const sub = new OpenAPIHono().basePath('/api')
+    sub.openapi(errorRoute, throwHandler)
+    sub.onError((err, c) => c.text('caught: ' + err.message, 500))
+    parent.route('/', sub)
+
+    const res = await parent.request('/api/error')
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('caught: boom')
+  })
+
+  it('Should fire onError() registered before basePath()', async () => {
+    const parent = new OpenAPIHono()
+    const base = new OpenAPIHono()
+    base.onError((err, c) => c.text('caught: ' + err.message, 500))
+    const sub = base.basePath('/api')
+    sub.openapi(errorRoute, throwHandler)
+    parent.route('/', sub)
+
+    const res = await parent.request('/api/error')
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('caught: boom')
+  })
+
+  // Note: `route()` does not propagate `notFoundHandler` (only `errorHandler`),
+  // so this is a same-instance contract test that `notFound()` set after
+  // `basePath()` targets the returned instance -- not a regression guard for the
+  // binding fix (it passes with or without the fix).
+  it('notFound() set after basePath() targets the returned instance', async () => {
+    const app = new OpenAPIHono().basePath('/api')
+    app.notFound((c) => c.text('custom not found', 404))
+
+    const res = await app.request('/api/missing')
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('custom not found')
+  })
 })
 
 describe('onError() and onNotFound()', () => {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -850,7 +850,21 @@ export class OpenAPIHono<
   override basePath<SubPath extends string>(
     path: SubPath
   ): OpenAPIHono<E, S, MergePath<BasePath, SubPath>> {
-    return new OpenAPIHono({ ...(super.basePath(path) as any), defaultHook: this.defaultHook })
+    const cloned = super.basePath(path)
+    const newApp = new OpenAPIHono<E, S, MergePath<BasePath, SubPath>>({
+      defaultHook: this.defaultHook,
+    })
+    newApp.router = cloned.router
+    newApp.routes = cloned.routes
+    const { getPath } = cloned
+
+    const clonedInternal = cloned as unknown as { errorHandler: ErrorHandler<E>; _basePath: string }
+    Object.assign(newApp, {
+      getPath,
+      errorHandler: clonedInternal.errorHandler,
+      _basePath: clonedInternal._basePath,
+    })
+    return newApp
   }
 
   // Type overrides to return OpenAPIHono instead of Hono


### PR DESCRIPTION
Issue: #2021 

## Summary

`OpenAPIHono.basePath()` dropped any `.onError()` / `.notFound()` registered on the returned instance
after the `basePath()` call. The handler silently had no effect, and the parent app's handler
ran instead. This surfaced while migrating a plain Hono app to OpenAPIHono: a route()-mounted
sub-app quietly changed which onError handled its thrown errors.

## Reproduction

```ts
import { Hono } from 'hono'
import { OpenAPIHono } from '@hono/zod-openapi'

const sub = new OpenAPIHono().basePath('/v2')
sub.onError(() => new Response('from sub'))
sub.get('/boom', () => {
  throw new Error('boom')
})

const app = new Hono()
app.onError(() => new Response('from parent'))
app.route('/', sub)

const res = await app.request('/v2/boom')
console.log(await res.text()) // 'from parent' ← expected 'from sub'
```

## Root cause

`OpenAPIHono.basePath()` rebuilt the instance by spreading the plain Hono clone returned by `super.basePath()`:

```ts
return new OpenAPIHono({ ...(super.basePath(path) as any), defaultHook: this.defaultHook })
```

`onError`, `notFound`, `request`, and `fetch` are arrow-function instance fields, so they are own-enumerable properties permanently bound to the instance they were created on.
`super.basePath()` returns a throwaway clone, and spreading it copies those clone-bound methods
into the constructor options — where Object.assign(this, options) then overwrites the freshly constructed (and correctly bound) methods on the returned instance.

As a result, `sub.onError(h)` mutated errorHandler on the discarded clone, not on the returned
sub (sub.errorHandler stayed the built-in default). Route registration only appeared to work
because the returned instance and the clone share the same underlying router / routes. When
parent.route('/', sub) reads sub.errorHandler as a plain property, it still sees the default,
so it does not wrap the sub-app's handlers — and the parent's onError ends up handling the thrown error.

## Fix

Construct a properly initialized OpenAPIHono (so its own arrow-field methods stay bound to it) and transplant only the routing state — router, routes, getPath, errorHandler, _basePath — from the clone, instead of spreading the clone into the constructor. Carrying errorHandler over preserves the "onError() before basePath()" ordering that core Hono's clone already captured.

## Tests

- Should fire onError() registered after basePath() — regression guard for this issue (fails on main, passes with the fix).
- Should fire onError() registered before basePath() — guards the opposite ordering so the errorHandler transplant can't regress.
- notFound() set after basePath() targets the returned instance — a same-instance contract test. Note: route() propagates errorHandler but not notFoundHandler, so this documents the binding rather than acting as a regression guard (it passes with or without the fix; commented inline).

Verified locally: full @hono/zod-openapi suite passes (81 tests, type-check clean), ESLint clean, Prettier clean.


### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
