### PR TITLE
fix(zod-openapi): resolve defaultHook through the ancestor chain on nested routes

### DIFF
--- a/.changeset/brown-dingos-mate.md
+++ b/.changeset/brown-dingos-mate.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: resolve defaultHook through the ancestor chain on nested routes

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,15 @@ import baseConfig from '@hono/eslint-config'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig(
-  globalIgnores(['.yarn', '**/coverage', '**/dist', '**/.cache', '**/.turbo', 'packages/node-ws']),
+  globalIgnores([
+    '.yarn',
+    '**/coverage',
+    '**/dist',
+    '**/.cache',
+    '**/.turbo',
+    '**/sandbox',
+    'packages/node-ws',
+  ]),
   {
     extends: baseConfig,
 

--- a/packages/zod-openapi/eslint-suppressions.json
+++ b/packages/zod-openapi/eslint-suppressions.json
@@ -46,7 +46,7 @@
       "count": 2
     },
     "@typescript-eslint/no-unsafe-argument": {
-      "count": 12
+      "count": 14
     },
     "@typescript-eslint/no-unsafe-assignment": {
       "count": 1
@@ -58,7 +58,7 @@
       "count": 5
     },
     "@typescript-eslint/no-unsafe-return": {
-      "count": 4
+      "count": 5
     },
     "@typescript-eslint/restrict-template-expressions": {
       "count": 1

--- a/packages/zod-openapi/src/index.test.ts
+++ b/packages/zod-openapi/src/index.test.ts
@@ -1105,6 +1105,101 @@ describe('Routers', () => {
     expect(res.status).toBe(422)
     expect(await res.json()).toEqual({ ok: false, source: 'parentDefaultHook' })
   })
+
+  const invalidPostsRequest = {
+    method: 'POST',
+    body: JSON.stringify({ id: 'not-a-number' }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }
+
+  it('Should apply the root defaultHook across multiple nesting levels regardless of composition order', async () => {
+    const leaf = new OpenAPIHono().openapi(route, (c) => c.json({ id: 123 }))
+    // Mount bottom-up: the middle app has no defaultHook when the leaf is mounted
+    const mid = new OpenAPIHono().route('/nested', leaf)
+    const app = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) {
+          return c.json({ ok: false, source: 'rootDefaultHook' }, 422)
+        }
+      },
+    }).route('/api', mid)
+
+    const res = await app.request('/api/nested/posts', invalidPostsRequest)
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({ ok: false, source: 'rootDefaultHook' })
+  })
+
+  it('Should prefer the nearest ancestor defaultHook', async () => {
+    const leaf = new OpenAPIHono().openapi(route, (c) => c.json({ id: 123 }))
+    const mid = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) {
+          return c.json({ ok: false, source: 'midDefaultHook' }, 422)
+        }
+      },
+    }).route('/nested', leaf)
+    const app = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) {
+          return c.json({ ok: false, source: 'rootDefaultHook' }, 422)
+        }
+      },
+    }).route('/api', mid)
+
+    const res = await app.request('/api/nested/posts', invalidPostsRequest)
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({ ok: false, source: 'midDefaultHook' })
+  })
+
+  it('Should prefer the sub-app own defaultHook over ancestors', async () => {
+    const leaf = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) {
+          return c.json({ ok: false, source: 'leafDefaultHook' }, 422)
+        }
+      },
+    }).openapi(route, (c) => c.json({ id: 123 }))
+    const app = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) {
+          return c.json({ ok: false, source: 'rootDefaultHook' }, 422)
+        }
+      },
+    }).route('/api', leaf)
+
+    const res = await app.request('/api/posts', invalidPostsRequest)
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({ ok: false, source: 'leafDefaultHook' })
+  })
+
+  it('Should inherit the defaultHook from the first parent when mounted onto multiple parents', async () => {
+    const shared = new OpenAPIHono().openapi(route, (c) => c.json({ id: 123 }))
+    const parent1 = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) {
+          return c.json({ ok: false, source: 'parent1' }, 422)
+        }
+      },
+    }).route('/p1', shared)
+    const parent2 = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) {
+          return c.json({ ok: false, source: 'parent2' }, 422)
+        }
+      },
+    }).route('/p2', shared)
+
+    const res1 = await parent1.request('/p1/posts', invalidPostsRequest)
+    expect(await res1.json()).toEqual({ ok: false, source: 'parent1' })
+
+    // Documented limitation: the sub-app remembers the first parent it was
+    // mounted onto, so requests through the second parent use the first
+    // parent's defaultHook.
+    const res2 = await parent2.request('/p2/posts', invalidPostsRequest)
+    expect(await res2.json()).toEqual({ ok: false, source: 'parent1' })
+  })
 })
 
 describe('Multi params', () => {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -487,11 +487,28 @@ export class OpenAPIHono<
 > extends Hono<E, S, BasePath> {
   openAPIRegistry: OpenAPIRegistry
   defaultHook?: OpenAPIHonoOptions<E>['defaultHook']
+  #parentApp?: OpenAPIHono<any, any, any>
 
   constructor(init?: HonoInit<E>) {
     super(init)
     this.openAPIRegistry = new OpenAPIRegistry()
     this.defaultHook = init?.defaultHook
+  }
+
+  #resolveDefaultHook(): OpenAPIHonoOptions<any>['defaultHook'] {
+    if (this.defaultHook) {
+      return this.defaultHook
+    }
+    const seen = new Set<OpenAPIHono<any, any, any>>([this])
+    let parent = this.#parentApp
+    while (parent && !seen.has(parent)) {
+      if (parent.defaultHook) {
+        return parent.defaultHook
+      }
+      seen.add(parent)
+      parent = parent.#parentApp
+    }
+    return undefined
   }
 
   /**
@@ -583,14 +600,12 @@ export class OpenAPIHono<
       this.openAPIRegistry.registerPath(route)
     }
 
-    // Resolve the defaultHook lazily so nested apps mounted via `route()`
-    // can inherit the parent's defaultHook. See #1306.
-    /* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
     const effectiveHook =
       hook ??
-      ((result: any, c: any) =>
-        this.defaultHook ? (this.defaultHook as any)(result, c) : undefined)
-    /* eslint-enable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+      ((result: any, c: any) => {
+        const resolved = this.#resolveDefaultHook()
+        return resolved ? resolved(result, c) : undefined
+      })
 
     const validators: MiddlewareHandler[] = []
 
@@ -800,9 +815,7 @@ export class OpenAPIHono<
       return this as any
     }
 
-    if (app.defaultHook === undefined && this.defaultHook !== undefined) {
-      app.defaultHook = this.defaultHook
-    }
+    app.#parentApp ??= this
 
     app.openAPIRegistry.definitions.forEach((def) => {
       switch (def.type) {


### PR DESCRIPTION
Fixes #1306

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
