### PR TITLE
feat(zod-openapi): support schemas from any Standard JSON Schema library

### DIFF
--- a/.changeset/tender-pots-attack.md
+++ b/.changeset/tender-pots-attack.md
@@ -2,4 +2,4 @@
 '@hono/zod-openapi': patch
 ---
 
-Accept schemas from any library implementing [Standard JSON Schema](https://standardschema.dev/json-schema), such as ArkType, alongside Zod. A route can mix libraries: non-Zod schemas are validated through their Standard Schema interface and documented with the JSON Schema they generate, while Zod schemas keep going through `@asteasolutions/zod-to-openapi` untouched.
+Accept schemas from any library implementing [Standard JSON Schema](https://standardschema.dev/json-schema), such as ArkType, alongside Zod. A route can mix libraries: non-Zod schemas are validated through their Standard Schema interface and documented with the JSON Schema they generate, while Zod schemas keep going through `@asteasolutions/zod-to-openapi` untouched. Configure which JSON Schema dialect to request via `jsonSchemaTargets` when a library only supports specific targets.

--- a/.changeset/tender-pots-attack.md
+++ b/.changeset/tender-pots-attack.md
@@ -1,5 +1,5 @@
 ---
-'@hono/zod-openapi': minor
+'@hono/zod-openapi': patch
 ---
 
 Accept schemas from any library implementing [Standard JSON Schema](https://standardschema.dev/json-schema), such as ArkType, alongside Zod. A route can mix libraries: non-Zod schemas are validated through their Standard Schema interface and documented with the JSON Schema they generate, while Zod schemas keep going through `@asteasolutions/zod-to-openapi` untouched.

--- a/.changeset/tender-pots-attack.md
+++ b/.changeset/tender-pots-attack.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+Accept schemas from any library implementing [Standard JSON Schema](https://standardschema.dev/json-schema), such as ArkType, alongside Zod. A route can mix libraries: non-Zod schemas are validated through their Standard Schema interface and documented with the JSON Schema they generate, while Zod schemas keep going through `@asteasolutions/zod-to-openapi` untouched.

--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -322,6 +322,47 @@ app.getOpenAPI31Document(
 
 The second parameter is optional and accepts generator options as supported by the `@asteasolutions/zod-to-openapi` library. Refer to their documentation for the complete list of available options and their usage.
 
+### Other schema libraries
+
+Besides Zod, you can use any schema library that implements [Standard JSON Schema](https://standardschema.dev/json-schema), such as ArkType. These schemas describe themselves, so this package needs no adapter for each one: it validates them through their Standard Schema interface and documents them with the JSON Schema they generate.
+
+```ts
+import { type } from 'arktype'
+import { OpenAPIHono, createRoute } from '@hono/zod-openapi'
+
+const UserSchema = type({ name: 'string', age: 'number' })
+
+const route = createRoute({
+  method: 'post',
+  path: '/users',
+  request: {
+    body: {
+      required: true,
+      content: { 'application/json': { schema: UserSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Created',
+      content: { 'application/json': { schema: type({ id: 'string' }) } },
+    },
+  },
+})
+
+const app = new OpenAPIHono()
+
+app.openapi(route, (c) => {
+  const { name } = c.req.valid('json') // typed as { name: string; age: number }
+  return c.json({ id: name }, 200)
+})
+```
+
+You can mix libraries within a route — an ArkType request body next to a Zod response, for example. Zod schemas keep going through `@asteasolutions/zod-to-openapi` untouched, so `.openapi()` metadata and registered components behave exactly as they did before.
+
+Valibot does not implement the interface directly — wrap its schemas with [`toStandardJsonSchema()`](https://valibot.dev/api/toStandardJsonSchema/) from `@valibot/to-json-schema` first.
+
+Request bodies and parameters are documented from a schema's **input** type and responses from its **output** type, so a field with a default is optional in a request body and guaranteed in a response.
+
 ### The Registry
 
 You can access the [`OpenAPIRegistry`](https://github.com/asteasolutions/zod-to-openapi#the-registry) object via `app.openAPIRegistry`:
@@ -602,10 +643,18 @@ const HeadersSchema = z.object({
 })
 ```
 
+### Non-Zod schemas
+
+Two things behave differently for schemas from other libraries:
+
+- **`app.doc()` and OpenAPI 3.0.** A library is allowed to throw for a JSON Schema target it does not implement, and ArkType implements only the drafts. Those schemas fall back to `draft-07`, which OpenAPI 3.0 is close to but not identical with, so constructs 3.0 lacks pass through unconverted. `app.doc31()` needs no fallback, since OpenAPI 3.1 already is `draft-2020-12`.
+- **Validation hooks.** `result.error` is a `ZodError` for Zod schemas but an array of Standard Schema issues for other libraries, while the `Hook` type still calls it a `ZodError`.
+
 ## References
 
 - [Hono](https://hono.dev/)
 - [Zod](https://zod.dev/)
+- [Standard JSON Schema](https://standardschema.dev/json-schema)
 - [Zod to OpenAPI](https://github.com/asteasolutions/zod-to-openapi)
 
 ## Authors

--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -363,6 +363,18 @@ Valibot does not implement the interface directly — wrap its schemas with [`to
 
 Request bodies and parameters are documented from a schema's **input** type and responses from its **output** type, so a field with a default is optional in a request body and guaranteed in a response.
 
+Libraries may only support certain JSON Schema dialects. By default OpenAPI 3.0 tries `openapi-3.0` then falls back to `draft-07`, and OpenAPI 3.1 asks for `draft-2020-12`. Override that when you know what your validators support:
+
+```ts
+const app = new OpenAPIHono({
+  // ArkType rejects openapi-3.0 — ask for draft-07 directly.
+  jsonSchemaTargets: { '3.0': ['draft-07'] },
+})
+
+// Or per document:
+app.getOpenAPIDocument(config, undefined, { jsonSchemaTargets: ['draft-07'] })
+```
+
 ### The Registry
 
 You can access the [`OpenAPIRegistry`](https://github.com/asteasolutions/zod-to-openapi#the-registry) object via `app.openAPIRegistry`:
@@ -647,7 +659,7 @@ const HeadersSchema = z.object({
 
 Two things behave differently for schemas from other libraries:
 
-- **`app.doc()` and OpenAPI 3.0.** A library is allowed to throw for a JSON Schema target it does not implement, and ArkType implements only the drafts. Those schemas fall back to `draft-07`, which OpenAPI 3.0 is close to but not identical with, so constructs 3.0 lacks pass through unconverted. `app.doc31()` needs no fallback, since OpenAPI 3.1 already is `draft-2020-12`.
+- **`app.doc()` and OpenAPI 3.0.** A library is allowed to throw for a JSON Schema target it does not implement, and ArkType implements only the drafts. By default those schemas fall back to `draft-07`, which OpenAPI 3.0 is close to but not identical with, so constructs 3.0 lacks pass through unconverted. Set `jsonSchemaTargets` (on the app or per `getOpenAPIDocument` / `doc` call) to pick the dialect yourself — e.g. `{ '3.0': ['draft-07'] }` for ArkType. `app.doc31()` needs no fallback, since OpenAPI 3.1 already is `draft-2020-12`.
 - **Validation hooks.** `result.error` is a `ZodError` for Zod schemas but an array of Standard Schema issues for other libraries, while the `Hook` type still calls it a `ZodError`.
 
 ## References

--- a/packages/zod-openapi/eslint-suppressions.json
+++ b/packages/zod-openapi/eslint-suppressions.json
@@ -46,7 +46,7 @@
       "count": 2
     },
     "@typescript-eslint/no-unsafe-argument": {
-      "count": 14
+      "count": 11
     },
     "@typescript-eslint/no-unsafe-assignment": {
       "count": 1

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -44,6 +44,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "arktype": "^2.2.3",
     "hono": "^4.11.5",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3",
@@ -53,7 +54,9 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",
+    "@hono/standard-validator": "workspace:^",
     "@hono/zod-validator": "workspace:^",
+    "@standard-schema/spec": "^1.1.0",
     "openapi3-ts": "^4.5.0"
   },
   "engines": {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -43,7 +43,7 @@ import type { OpenAPIObject } from 'openapi3-ts/oas30'
 import type { OpenAPIObject as OpenAPIV31bject } from 'openapi3-ts/oas31'
 import type { ZodType, ZodError } from 'zod'
 import { z } from 'zod'
-import type { StandardOpenAPISchema } from './standard-schema'
+import type { StandardOpenAPISchema, JSONSchemaTarget } from './standard-schema'
 import {
   TARGETS,
   convertRouteSchemas,
@@ -286,6 +286,16 @@ type ConvertPathType<T extends string> = T extends `${infer Start}/{${infer Para
 
 export type OpenAPIHonoOptions<E extends Env> = {
   defaultHook?: Hook<any, E, any, any>
+  /**
+   * JSON Schema dialects to try when converting Standard Schema libraries into an OpenAPI
+   * document. Defaults try OpenAPI-native targets first, then draft fallbacks. Override when
+   * a library only supports specific dialects — e.g. ArkType with OpenAPI 3.0:
+   * `{ '3.0': ['draft-07'] }`.
+   */
+  jsonSchemaTargets?: {
+    '3.0'?: JSONSchemaTarget[]
+    '3.1'?: JSONSchemaTarget[]
+  }
 }
 type HonoInit<E extends Env> = ConstructorParameters<typeof Hono>[0] & OpenAPIHonoOptions<E>
 
@@ -413,6 +423,15 @@ export type OpenAPIGeneratorOptions = ConstructorParameters<typeof OpenApiGenera
 
 export type OpenAPIGeneratorConfigure<E extends Env, P extends string> =
   OpenAPIGeneratorOptions | ((context: Context<E, P>) => OpenAPIGeneratorOptions)
+
+/** Per-call options for document generation beyond `@asteasolutions/zod-to-openapi`. */
+export type OpenAPIDocumentOptions = {
+  /**
+   * JSON Schema dialects to try for non-Zod schemas on this document. Overrides the app's
+   * `jsonSchemaTargets` for the matching OpenAPI version.
+   */
+  jsonSchemaTargets?: JSONSchemaTarget[]
+}
 
 /**
  * Utility type to convert Hono types to OpenAPIHono types.
@@ -552,11 +571,13 @@ export class OpenAPIHono<
   defaultHook?: OpenAPIHonoOptions<E>['defaultHook']
   #parentApp?: OpenAPIHono<any, any, any>
   #standardRoutes: RouteConfig[] = []
+  #jsonSchemaTargets: NonNullable<OpenAPIHonoOptions<E>['jsonSchemaTargets']>
 
   constructor(init?: HonoInit<E>) {
     super(init)
     this.openAPIRegistry = new OpenAPIRegistry()
     this.defaultHook = init?.defaultHook
+    this.#jsonSchemaTargets = init?.jsonSchemaTargets ?? {}
   }
 
   #resolveDefaultHook(): OpenAPIHonoOptions<any>['defaultHook'] {
@@ -796,24 +817,32 @@ export class OpenAPIHono<
    * the version being generated. When there are none, the existing registry is handed back
    * untouched so a Zod-only app behaves exactly as it did before.
    */
-  #definitionsFor(version: '3.0' | '3.1'): OpenAPIRegistry['definitions'] {
+  #definitionsFor(
+    version: '3.0' | '3.1',
+    jsonSchemaTargets?: JSONSchemaTarget[]
+  ): OpenAPIRegistry['definitions'] {
     if (this.#standardRoutes.length === 0) {
       return this.openAPIRegistry.definitions
     }
 
+    const targets = jsonSchemaTargets ?? this.#jsonSchemaTargets[version] ?? TARGETS[version]
     const registry = new OpenAPIRegistry()
     registry.definitions.push(...this.openAPIRegistry.definitions)
     for (const route of this.#standardRoutes) {
-      registry.registerPath(convertRouteSchemas(route, TARGETS[version]) as RouteConfigBase)
+      registry.registerPath(convertRouteSchemas(route, targets) as RouteConfigBase)
     }
     return registry.definitions
   }
 
   getOpenAPIDocument = (
     objectConfig: OpenAPIObjectConfig,
-    generatorConfig?: OpenAPIGeneratorOptions
+    generatorConfig?: OpenAPIGeneratorOptions,
+    documentOptions?: OpenAPIDocumentOptions
   ): OpenAPIObject => {
-    const generator = new OpenApiGeneratorV3(this.#definitionsFor('3.0'), generatorConfig)
+    const generator = new OpenApiGeneratorV3(
+      this.#definitionsFor('3.0', documentOptions?.jsonSchemaTargets),
+      generatorConfig
+    )
     const document = generator.generateDocument(objectConfig)
     // @ts-expect-error the _basePath is a private property
     return this._basePath ? addBasePathToDocument(document, this._basePath) : document
@@ -821,9 +850,13 @@ export class OpenAPIHono<
 
   getOpenAPI31Document = (
     objectConfig: OpenAPIObjectConfig,
-    generatorConfig?: OpenAPIGeneratorOptions
+    generatorConfig?: OpenAPIGeneratorOptions,
+    documentOptions?: OpenAPIDocumentOptions
   ): OpenAPIV31bject => {
-    const generator = new OpenApiGeneratorV31(this.#definitionsFor('3.1'), generatorConfig)
+    const generator = new OpenApiGeneratorV31(
+      this.#definitionsFor('3.1', documentOptions?.jsonSchemaTargets),
+      generatorConfig
+    )
     const document = generator.generateDocument(objectConfig)
     // @ts-expect-error the _basePath is a private property
     return this._basePath ? addBasePathToDocument(document, this._basePath) : document
@@ -832,7 +865,8 @@ export class OpenAPIHono<
   doc = <P extends string>(
     path: P,
     configureObject: OpenAPIObjectConfigure<E, P>,
-    configureGenerator?: OpenAPIGeneratorConfigure<E, P>
+    configureGenerator?: OpenAPIGeneratorConfigure<E, P>,
+    documentOptions?: OpenAPIDocumentOptions
   ): OpenAPIHono<E, S & ToSchema<'get', MergePath<BasePath, P>, {}, {}>, BasePath> => {
     return this.get(path, (c) => {
       const objectConfig =
@@ -840,7 +874,7 @@ export class OpenAPIHono<
       const generatorConfig =
         typeof configureGenerator === 'function' ? configureGenerator(c) : configureGenerator
       try {
-        const document = this.getOpenAPIDocument(objectConfig, generatorConfig)
+        const document = this.getOpenAPIDocument(objectConfig, generatorConfig, documentOptions)
         return c.json(document)
       } catch (e: any) {
         return c.json(e, 500)
@@ -851,7 +885,8 @@ export class OpenAPIHono<
   doc31 = <P extends string>(
     path: P,
     configureObject: OpenAPIObjectConfigure<E, P>,
-    configureGenerator?: OpenAPIGeneratorConfigure<E, P>
+    configureGenerator?: OpenAPIGeneratorConfigure<E, P>,
+    documentOptions?: OpenAPIDocumentOptions
   ): OpenAPIHono<E, S & ToSchema<'get', MergePath<BasePath, P>, {}, {}>, BasePath> => {
     return this.get(path, (c) => {
       const objectConfig =
@@ -859,7 +894,7 @@ export class OpenAPIHono<
       const generatorConfig =
         typeof configureGenerator === 'function' ? configureGenerator(c) : configureGenerator
       try {
-        const document = this.getOpenAPI31Document(objectConfig, generatorConfig)
+        const document = this.getOpenAPI31Document(objectConfig, generatorConfig, documentOptions)
         return c.json(document)
       } catch (e: any) {
         return c.json(e, 500)
@@ -966,6 +1001,7 @@ export class OpenAPIHono<
     const cloned = super.basePath(path)
     const newApp = new OpenAPIHono<E, S, MergePath<BasePath, SubPath>>({
       defaultHook: this.defaultHook,
+      jsonSchemaTargets: this.#jsonSchemaTargets,
     })
     newApp.router = cloned.router
     newApp.routes = cloned.routes
@@ -1005,6 +1041,8 @@ export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'
 
 extendZodWithOpenApi(z)
 export { extendZodWithOpenApi, z }
+export type { JSONSchemaTarget }
+export { TARGETS }
 
 function addBasePathToDocument(document: Record<string, any>, basePath: string) {
   const updatedPaths: Record<string, any> = {}

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -54,10 +54,6 @@ import { isZod } from './zod-typeguard'
 
 type MaybePromise<T> = Promise<T> | T
 
-/**
- * Anything this package can both validate with and describe: a Zod type, or a schema from
- * a library implementing Standard JSON Schema.
- */
 type AnySchema = ZodType | StandardOpenAPISchema
 
 /**
@@ -65,17 +61,15 @@ type AnySchema = ZodType | StandardOpenAPISchema
  * every Zod schema would infer through `~standard.types` and lose what `z.input`/`z.output`
  * know about transforms, defaults and pipes.
  */
-type InferInput<S> = S extends ZodType
-  ? z.input<S>
-  : S extends StandardOpenAPISchema<infer I, any>
-    ? I
-    : never
+type InferInput<S> =
+  S extends ZodType ? z.input<S>
+  : S extends StandardOpenAPISchema<infer Input, unknown> ? Input
+  : never
 
-type InferOutput<S> = S extends ZodType
-  ? z.output<S>
-  : S extends StandardOpenAPISchema<any, infer O>
-    ? O
-    : never
+type InferOutput<S> =
+  S extends ZodType ? z.output<S>
+  : S extends StandardOpenAPISchema<unknown, infer Output> ? Output
+  : never
 
 type RouteParameterBase = NonNullable<RouteConfigBase['request']>['params']
 
@@ -557,14 +551,6 @@ export class OpenAPIHono<
   openAPIRegistry: OpenAPIRegistry
   defaultHook?: OpenAPIHonoOptions<E>['defaultHook']
   #parentApp?: OpenAPIHono<any, any, any>
-  /**
-   * Routes carrying a non-Zod schema, held unconverted until a document is asked for.
-   *
-   * They cannot go into `openAPIRegistry` at `openapi()` time: converting a schema needs a
-   * JSON Schema target, and which target applies is not known until the caller picks
-   * `getOpenAPIDocument` (3.0) or `getOpenAPI31Document` (3.1). Zod routes have no such
-   * problem and are registered eagerly, exactly as before.
-   */
   #standardRoutes: RouteConfig[] = []
 
   constructor(init?: HonoInit<E>) {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
+  ResponseConfig as ResponseConfigBase,
   RouteConfig as RouteConfigBase,
-  ZodContentObject,
   ZodMediaTypeObject,
   ZodRequestBody,
 } from '@asteasolutions/zod-to-openapi'
@@ -12,6 +12,7 @@ import {
   extendZodWithOpenApi,
   getOpenApiMetadata,
 } from '@asteasolutions/zod-to-openapi'
+import { sValidator } from '@hono/standard-validator'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import type {
@@ -42,21 +43,74 @@ import type { OpenAPIObject } from 'openapi3-ts/oas30'
 import type { OpenAPIObject as OpenAPIV31bject } from 'openapi3-ts/oas31'
 import type { ZodType, ZodError } from 'zod'
 import { z } from 'zod'
+import type { StandardOpenAPISchema } from './standard-schema'
+import {
+  TARGETS,
+  convertRouteSchemas,
+  needsConversion,
+  routeUsesStandardSchema,
+} from './standard-schema'
 import { isZod } from './zod-typeguard'
 
 type MaybePromise<T> = Promise<T> | T
 
-export type RouteConfig = RouteConfigBase & {
+/**
+ * Anything this package can both validate with and describe: a Zod type, or a schema from
+ * a library implementing Standard JSON Schema.
+ */
+type AnySchema = ZodType | StandardOpenAPISchema
+
+/**
+ * Zod types implement Standard Schema too, so `ZodType` has to be checked first — otherwise
+ * every Zod schema would infer through `~standard.types` and lose what `z.input`/`z.output`
+ * know about transforms, defaults and pipes.
+ */
+type InferInput<S> = S extends ZodType
+  ? z.input<S>
+  : S extends StandardOpenAPISchema<infer I, any>
+    ? I
+    : never
+
+type InferOutput<S> = S extends ZodType
+  ? z.output<S>
+  : S extends StandardOpenAPISchema<any, infer O>
+    ? O
+    : never
+
+type RouteParameterBase = NonNullable<RouteConfigBase['request']>['params']
+
+type MediaTypeObject = Omit<ZodMediaTypeObject, 'schema'> & {
+  schema: ZodMediaTypeObject['schema'] | StandardOpenAPISchema
+}
+type ContentObject = Partial<Record<string, MediaTypeObject>>
+type RequestBody = Omit<ZodRequestBody, 'content'> & { content: ContentObject }
+type ResponseConfig = Omit<ResponseConfigBase, 'content' | 'headers'> & {
+  content?: ContentObject
+  headers?: ResponseConfigBase['headers'] | StandardOpenAPISchema
+}
+
+export type RouteConfig = Omit<RouteConfigBase, 'request' | 'responses'> & {
+  request?: {
+    body?: RequestBody
+    params?: RouteParameterBase | StandardOpenAPISchema
+    query?: RouteParameterBase | StandardOpenAPISchema
+    cookies?: RouteParameterBase | StandardOpenAPISchema
+    headers?:
+      RouteParameterBase | ZodType<unknown>[] | StandardOpenAPISchema | StandardOpenAPISchema[]
+  }
+  responses: {
+    [statusCode: string]: ResponseConfig
+  }
   middleware?: H | H[]
   hide?: boolean
 }
 
 type RequestTypes = {
-  body?: ZodRequestBody
-  params?: ZodType
-  query?: ZodType
-  cookies?: ZodType
-  headers?: ZodType | ZodType[]
+  body?: RequestBody
+  params?: AnySchema
+  query?: AnySchema
+  cookies?: AnySchema
+  headers?: AnySchema | AnySchema[]
 }
 
 type IsJson<T> = T extends string
@@ -99,39 +153,41 @@ type InputTypeBase<
   Part extends string,
   Type extends keyof ValidationTargets,
 > = R['request'] extends RequestTypes
-  ? RequestPart<R, Part> extends ZodType
+  ? RequestPart<R, Part> extends AnySchema
     ? {
         in: {
           [K in Type]: HasUndefined<ValidationTargets[K]> extends true
             ? {
-                [K2 in keyof z.input<RequestPart<R, Part>>]?: z.input<RequestPart<R, Part>>[K2]
+                [K2 in keyof InferInput<RequestPart<R, Part>>]?: InferInput<
+                  RequestPart<R, Part>
+                >[K2]
               }
             : {
-                [K2 in keyof z.input<RequestPart<R, Part>>]: z.input<RequestPart<R, Part>>[K2]
+                [K2 in keyof InferInput<RequestPart<R, Part>>]: InferInput<RequestPart<R, Part>>[K2]
               }
         }
-        out: { [K in Type]: z.output<RequestPart<R, Part>> }
+        out: { [K in Type]: InferOutput<RequestPart<R, Part>> }
       }
     : {}
   : {}
 
 type InputTypeJson<R extends RouteConfig> = R['request'] extends RequestTypes
-  ? R['request']['body'] extends ZodRequestBody
-    ? R['request']['body']['content'] extends ZodContentObject
+  ? R['request']['body'] extends RequestBody
+    ? R['request']['body']['content'] extends ContentObject
       ? IsJson<keyof R['request']['body']['content']> extends never
         ? {}
         : R['request']['body']['content'][keyof R['request']['body']['content']] extends Record<
               'schema',
-              ZodType<any>
+              AnySchema
             >
           ? {
               in: {
-                json: z.input<
+                json: InferInput<
                   R['request']['body']['content'][keyof R['request']['body']['content']]['schema']
                 >
               }
               out: {
-                json: z.output<
+                json: InferOutput<
                   R['request']['body']['content'][keyof R['request']['body']['content']]['schema']
                 >
               }
@@ -142,22 +198,22 @@ type InputTypeJson<R extends RouteConfig> = R['request'] extends RequestTypes
   : {}
 
 type InputTypeForm<R extends RouteConfig> = R['request'] extends RequestTypes
-  ? R['request']['body'] extends ZodRequestBody
-    ? R['request']['body']['content'] extends ZodContentObject
+  ? R['request']['body'] extends RequestBody
+    ? R['request']['body']['content'] extends ContentObject
       ? IsForm<keyof R['request']['body']['content']> extends never
         ? {}
         : R['request']['body']['content'][keyof R['request']['body']['content']] extends Record<
               'schema',
-              ZodType<any>
+              AnySchema
             >
           ? {
               in: {
-                form: z.input<
+                form: InferInput<
                   R['request']['body']['content'][keyof R['request']['body']['content']]['schema']
                 >
               }
               out: {
-                form: z.output<
+                form: InferOutput<
                   R['request']['body']['content'][keyof R['request']['body']['content']]['schema']
                 >
               }
@@ -175,8 +231,8 @@ type InputTypeCookie<R extends RouteConfig> = InputTypeBase<R, 'cookies', 'cooki
 type ExtractContent<T> = T extends {
   [K in keyof T]: infer A
 }
-  ? A extends Record<'schema', ZodType>
-    ? z.infer<A['schema']>
+  ? A extends Record<'schema', AnySchema>
+    ? InferOutput<A['schema']>
     : never
   : never
 
@@ -326,7 +382,7 @@ export type RouteHandler<
     responses: {
       [statusCode: number]: {
         content: {
-          [mediaType: string]: ZodMediaTypeObject
+          [mediaType: string]: MediaTypeObject
         }
       }
     }
@@ -410,7 +466,7 @@ type HandlerFromRoute<R extends RouteConfig, E extends Env> = Handler<
     responses: {
       [statusCode: number]: {
         content: {
-          [mediaType: string]: ZodMediaTypeObject
+          [mediaType: string]: MediaTypeObject
         }
       }
     }
@@ -428,7 +484,7 @@ type HookFromRoute<R extends RouteConfig, E extends Env> =
         responses: {
           [statusCode: number]: {
             content: {
-              [mediaType: string]: ZodMediaTypeObject
+              [mediaType: string]: MediaTypeObject
             }
           }
         }
@@ -480,6 +536,19 @@ export const defineOpenAPIRoute = <
   return def
 }
 
+/**
+ * Picks the validator that understands the schema: Zod keeps going through `zValidator`,
+ * anything else validates through its Standard Schema interface via `sValidator`.
+ */
+const validatorFor = (
+  target: keyof ValidationTargets,
+  schema: AnySchema,
+  hook: any
+): MiddlewareHandler =>
+  needsConversion(schema)
+    ? (sValidator(target, schema, hook) as MiddlewareHandler)
+    : (zValidator(target as any, schema as any, hook) as MiddlewareHandler)
+
 export class OpenAPIHono<
   E extends Env = Env,
   S extends Schema = {},
@@ -488,6 +557,15 @@ export class OpenAPIHono<
   openAPIRegistry: OpenAPIRegistry
   defaultHook?: OpenAPIHonoOptions<E>['defaultHook']
   #parentApp?: OpenAPIHono<any, any, any>
+  /**
+   * Routes carrying a non-Zod schema, held unconverted until a document is asked for.
+   *
+   * They cannot go into `openAPIRegistry` at `openapi()` time: converting a schema needs a
+   * JSON Schema target, and which target applies is not known until the caller picks
+   * `getOpenAPIDocument` (3.0) or `getOpenAPI31Document` (3.1). Zod routes have no such
+   * problem and are registered eagerly, exactly as before.
+   */
+  #standardRoutes: RouteConfig[] = []
 
   constructor(init?: HonoInit<E>) {
     super(init)
@@ -565,7 +643,7 @@ export class OpenAPIHono<
         responses: {
           [statusCode: number]: {
             content: {
-              [mediaType: string]: ZodMediaTypeObject
+              [mediaType: string]: MediaTypeObject
             }
           }
         }
@@ -582,7 +660,7 @@ export class OpenAPIHono<
             responses: {
               [statusCode: number]: {
                 content: {
-                  [mediaType: string]: ZodMediaTypeObject
+                  [mediaType: string]: MediaTypeObject
                 }
               }
             }
@@ -597,7 +675,11 @@ export class OpenAPIHono<
     BasePath
   > => {
     if (!hide) {
-      this.openAPIRegistry.registerPath(route)
+      if (routeUsesStandardSchema(route)) {
+        this.#standardRoutes.push(route)
+      } else {
+        this.openAPIRegistry.registerPath(route as RouteConfigBase)
+      }
     }
 
     const effectiveHook =
@@ -610,23 +692,19 @@ export class OpenAPIHono<
     const validators: MiddlewareHandler[] = []
 
     if (route.request?.query) {
-      const validator = zValidator('query', route.request.query as any, effectiveHook as any)
-      validators.push(validator as any)
+      validators.push(validatorFor('query', route.request.query as AnySchema, effectiveHook))
     }
 
     if (route.request?.params) {
-      const validator = zValidator('param', route.request.params as any, effectiveHook as any)
-      validators.push(validator as any)
+      validators.push(validatorFor('param', route.request.params as AnySchema, effectiveHook))
     }
 
     if (route.request?.headers) {
-      const validator = zValidator('header', route.request.headers as any, effectiveHook as any)
-      validators.push(validator as any)
+      validators.push(validatorFor('header', route.request.headers as AnySchema, effectiveHook))
     }
 
     if (route.request?.cookies) {
-      const validator = zValidator('cookie', route.request.cookies as any, effectiveHook as any)
-      validators.push(validator as any)
+      validators.push(validatorFor('cookie', route.request.cookies as AnySchema, effectiveHook))
     }
 
     const bodyContent = route.request?.body?.content
@@ -636,14 +714,12 @@ export class OpenAPIHono<
         if (!bodyContent[mediaType]) {
           continue
         }
-        const schema = (bodyContent[mediaType] as ZodMediaTypeObject)['schema']
-        if (!isZod(schema)) {
+        const schema = (bodyContent[mediaType] as MediaTypeObject)['schema']
+        if (!isZod(schema) && !needsConversion(schema)) {
           continue
         }
         if (isJSONContentType(mediaType)) {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore we can ignore the type error since Zod Validator's types are not used
-          const validator = zValidator('json', schema, effectiveHook as any) as MiddlewareHandler
+          const validator = validatorFor('json', schema as AnySchema, effectiveHook)
           if (route.request?.body?.required) {
             validators.push(validator)
           } else {
@@ -660,9 +736,7 @@ export class OpenAPIHono<
           }
         }
         if (isFormContentType(mediaType)) {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore we can ignore the type error since Zod Validator's types are not used
-          const validator = zValidator('form', schema, effectiveHook as any) as MiddlewareHandler
+          const validator = validatorFor('form', schema as AnySchema, effectiveHook)
           if (route.request?.body?.required) {
             validators.push(validator)
           } else {
@@ -731,11 +805,29 @@ export class OpenAPIHono<
     return this
   }
 
+  /**
+   * The definitions to generate from, with the schemas of any non-Zod route converted for
+   * the version being generated. When there are none, the existing registry is handed back
+   * untouched so a Zod-only app behaves exactly as it did before.
+   */
+  #definitionsFor(version: '3.0' | '3.1'): OpenAPIRegistry['definitions'] {
+    if (this.#standardRoutes.length === 0) {
+      return this.openAPIRegistry.definitions
+    }
+
+    const registry = new OpenAPIRegistry()
+    registry.definitions.push(...this.openAPIRegistry.definitions)
+    for (const route of this.#standardRoutes) {
+      registry.registerPath(convertRouteSchemas(route, TARGETS[version]) as RouteConfigBase)
+    }
+    return registry.definitions
+  }
+
   getOpenAPIDocument = (
     objectConfig: OpenAPIObjectConfig,
     generatorConfig?: OpenAPIGeneratorOptions
   ): OpenAPIObject => {
-    const generator = new OpenApiGeneratorV3(this.openAPIRegistry.definitions, generatorConfig)
+    const generator = new OpenApiGeneratorV3(this.#definitionsFor('3.0'), generatorConfig)
     const document = generator.generateDocument(objectConfig)
     // @ts-expect-error the _basePath is a private property
     return this._basePath ? addBasePathToDocument(document, this._basePath) : document
@@ -745,7 +837,7 @@ export class OpenAPIHono<
     objectConfig: OpenAPIObjectConfig,
     generatorConfig?: OpenAPIGeneratorOptions
   ): OpenAPIV31bject => {
-    const generator = new OpenApiGeneratorV31(this.openAPIRegistry.definitions, generatorConfig)
+    const generator = new OpenApiGeneratorV31(this.#definitionsFor('3.1'), generatorConfig)
     const document = generator.generateDocument(objectConfig)
     // @ts-expect-error the _basePath is a private property
     return this._basePath ? addBasePathToDocument(document, this._basePath) : document
@@ -816,6 +908,18 @@ export class OpenAPIHono<
     }
 
     app.#parentApp ??= this
+
+    const subBasePath = (app as unknown as { _basePath: string })._basePath.replaceAll(
+      /:([^\/]+)/g,
+      '{$1}'
+    )
+
+    for (const route of app.#standardRoutes) {
+      this.#standardRoutes.push({
+        ...route,
+        path: mergePath(pathForOpenAPI, subBasePath, route.path),
+      })
+    }
 
     app.openAPIRegistry.definitions.forEach((def) => {
       switch (def.type) {

--- a/packages/zod-openapi/src/standard-schema.test.ts
+++ b/packages/zod-openapi/src/standard-schema.test.ts
@@ -292,6 +292,57 @@ describe('target support', () => {
     })
   })
 
+  it('lets the user pick which JSON Schema dialect to request', () => {
+    const app = new OpenAPIHono({
+      // ArkType rejects openapi-3.0 — ask for draft-07 only, no silent fallback chain.
+      jsonSchemaTargets: { '3.0': ['draft-07'] },
+    })
+    app.openapi(
+      createRoute({
+        method: 'get',
+        path: '/ark',
+        request: { query: type({ name: 'string' }) },
+        responses: { 200: { description: 'ok' } },
+      }),
+      (c) => c.json({}, 200)
+    )
+
+    expect(app.getOpenAPIDocument(config)).toMatchObject({
+      paths: {
+        '/ark': {
+          get: {
+            parameters: [{ in: 'query', name: 'name', required: true, schema: { type: 'string' } }],
+          },
+        },
+      },
+    })
+  })
+
+  it('accepts a per-document override of the JSON Schema dialect', () => {
+    const app = new OpenAPIHono()
+    app.openapi(
+      createRoute({
+        method: 'get',
+        path: '/ark',
+        request: { query: type({ name: 'string' }) },
+        responses: { 200: { description: 'ok' } },
+      }),
+      (c) => c.json({}, 200)
+    )
+
+    expect(
+      app.getOpenAPIDocument(config, undefined, { jsonSchemaTargets: ['draft-07'] })
+    ).toMatchObject({
+      paths: {
+        '/ark': {
+          get: {
+            parameters: [{ in: 'query', name: 'name', required: true, schema: { type: 'string' } }],
+          },
+        },
+      },
+    })
+  })
+
   it('names the vendor when no target is supported', () => {
     const broken = {
       '~standard': {

--- a/packages/zod-openapi/src/standard-schema.test.ts
+++ b/packages/zod-openapi/src/standard-schema.test.ts
@@ -1,0 +1,372 @@
+import { type } from 'arktype'
+import { OpenAPIHono, createRoute, z } from './index'
+
+const info = { title: 'API', version: '1.0.0' }
+const config = { openapi: '3.0.0', info }
+const config31 = { openapi: '3.1.0', info }
+
+describe('non-Zod schemas', () => {
+  const app = new OpenAPIHono()
+
+  app.openapi(
+    createRoute({
+      method: 'post',
+      path: '/users/{id}',
+      summary: 'Update a user',
+      request: {
+        params: type({ id: 'string' }),
+        query: type({ 'dryRun?': 'string' }),
+        body: {
+          required: true,
+          content: {
+            'application/json': { schema: type({ name: 'string', age: 'number' }) },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: 'Updated',
+          content: { 'application/json': { schema: type({ id: 'string' }) } },
+        },
+      },
+    }),
+    (c) => {
+      const { name } = c.req.valid('json')
+      const { id } = c.req.valid('param')
+      return c.json({ id: `${id}:${name}` }, 200)
+    }
+  )
+
+  it('describes an ArkType body and response in the document', () => {
+    expect(app.getOpenAPIDocument(config)).toMatchObject({
+      paths: {
+        '/users/{id}': {
+          post: {
+            summary: 'Update a user',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' }, age: { type: 'number' } },
+                    // ArkType sorts `required` alphabetically — assert the set, not its order.
+                    required: expect.arrayContaining(['name', 'age']) as unknown as string[],
+                  },
+                },
+              },
+            },
+            responses: {
+              200: {
+                description: 'Updated',
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', properties: { id: { type: 'string' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('splits an ArkType object into individual parameters, preserving optionality', () => {
+    expect(app.getOpenAPIDocument(config)).toMatchObject({
+      paths: {
+        '/users/{id}': {
+          post: {
+            parameters: [
+              { in: 'path', name: 'id', required: true, schema: { type: 'string' } },
+              { in: 'query', name: 'dryRun', required: false, schema: { type: 'string' } },
+            ],
+          },
+        },
+      },
+    })
+  })
+
+  it('validates requests against a non-Zod schema', async () => {
+    const res = await app.request('/users/abc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Ada', age: 36 }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 'abc:Ada' })
+  })
+
+  it('rejects requests that do not match a non-Zod schema', async () => {
+    const res = await app.request('/users/abc', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Ada', age: 'not a number' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('generates a 3.1 document without leaking $schema into it', () => {
+    const doc = app.getOpenAPI31Document(config31)
+
+    expect(doc.openapi).toBe('3.1.0')
+    expect(doc).toMatchObject({
+      paths: {
+        '/users/{id}': {
+          post: {
+            requestBody: { content: { 'application/json': { schema: { type: 'object' } } } },
+          },
+        },
+      },
+    })
+    expect(doc).not.toHaveProperty([
+      'paths',
+      '/users/{id}',
+      'post',
+      'requestBody',
+      'content',
+      'application/json',
+      'schema',
+      '$schema',
+    ])
+  })
+})
+
+describe('mixing schema libraries', () => {
+  it('accepts Zod and ArkType schemas on the same route', () => {
+    const app = new OpenAPIHono()
+
+    app.openapi(
+      createRoute({
+        method: 'post',
+        path: '/mixed',
+        request: {
+          body: {
+            required: true,
+            content: { 'application/json': { schema: type({ name: 'string' }) } },
+          },
+        },
+        responses: {
+          200: {
+            description: 'ok',
+            content: { 'application/json': { schema: z.object({ id: z.string() }) } },
+          },
+        },
+      }),
+      (c) => c.json({ id: c.req.valid('json').name }, 200)
+    )
+
+    expect(app.getOpenAPIDocument(config)).toMatchObject({
+      paths: {
+        '/mixed': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                    required: ['name'],
+                  },
+                },
+              },
+            },
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', properties: { id: { type: 'string' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('keeps Zod-only apps on the existing registry path', () => {
+    const app = new OpenAPIHono()
+    const Schema = z.object({ id: z.string() }).openapi('User')
+
+    app.openapi(
+      createRoute({
+        method: 'get',
+        path: '/users',
+        responses: {
+          200: { description: 'ok', content: { 'application/json': { schema: Schema } } },
+        },
+      }),
+      (c) => c.json({ id: '1' }, 200)
+    )
+
+    // A Zod-only app must not notice any of this: refs still resolve to components instead
+    // of being inlined, which is what breaks if the route stops reaching the registry.
+    expect(app.getOpenAPIDocument(config)).toMatchObject({
+      paths: {
+        '/users': {
+          get: {
+            responses: {
+              200: {
+                content: { 'application/json': { schema: { $ref: '#/components/schemas/User' } } },
+              },
+            },
+          },
+        },
+      },
+      components: { schemas: { User: { type: 'object' } } },
+    })
+  })
+})
+
+describe('input and output types', () => {
+  it('describes the request body with the input type and the response with the output type', () => {
+    const app = new OpenAPIHono()
+    // `role` has a default, so it is optional coming in and guaranteed going out — the
+    // request body and the response should not describe it the same way.
+    const schema = type({ name: 'string', role: 'string = "user"' })
+
+    app.openapi(
+      createRoute({
+        method: 'post',
+        path: '/echo',
+        request: {
+          body: { required: true, content: { 'application/json': { schema } } },
+        },
+        responses: {
+          200: { description: 'ok', content: { 'application/json': { schema } } },
+        },
+      }),
+      (c) => c.json(c.req.valid('json'), 200)
+    )
+
+    expect(app.getOpenAPI31Document(config31)).toMatchObject({
+      paths: {
+        '/echo': {
+          post: {
+            requestBody: {
+              content: { 'application/json': { schema: { required: ['name'] } } },
+            },
+            responses: {
+              200: {
+                content: { 'application/json': { schema: { required: ['name', 'role'] } } },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+})
+
+describe('target support', () => {
+  it('falls back to draft-07 for a 3.0 document when a library rejects openapi-3.0', () => {
+    // ArkType implements only the drafts — `doc()` would be unusable for it without the
+    // `draft-07` fallback, so pin the throw that makes the fallback necessary.
+    expect(() =>
+      type({ name: 'string' })['~standard'].jsonSchema.input({ target: 'openapi-3.0' })
+    ).toThrow()
+
+    const app = new OpenAPIHono()
+    app.openapi(
+      createRoute({
+        method: 'get',
+        path: '/ark',
+        request: { query: type({ name: 'string' }) },
+        responses: { 200: { description: 'ok' } },
+      }),
+      (c) => c.json({}, 200)
+    )
+
+    expect(app.getOpenAPIDocument(config)).toMatchObject({
+      paths: {
+        '/ark': {
+          get: {
+            parameters: [{ in: 'query', name: 'name', required: true, schema: { type: 'string' } }],
+          },
+        },
+      },
+    })
+  })
+
+  it('names the vendor when no target is supported', () => {
+    const broken = {
+      '~standard': {
+        version: 1 as const,
+        vendor: 'broken-lib',
+        validate: (value: unknown) => ({ value }),
+        jsonSchema: {
+          input: () => {
+            throw new Error('unsupported target')
+          },
+          output: () => {
+            throw new Error('unsupported target')
+          },
+        },
+      },
+    }
+
+    const app = new OpenAPIHono()
+    app.openapi(
+      createRoute({
+        method: 'get',
+        path: '/broken',
+        request: { query: broken },
+        responses: { 200: { description: 'ok' } },
+      }),
+      (c) => c.json({}, 200)
+    )
+
+    expect(() => app.getOpenAPIDocument(config)).toThrow(/"broken-lib" could not convert a schema/)
+  })
+})
+
+describe('response headers', () => {
+  it('describes non-Zod response headers instead of leaking library internals', () => {
+    const app = new OpenAPIHono()
+    app.openapi(
+      createRoute({
+        method: 'get',
+        path: '/rh',
+        responses: {
+          200: { description: 'ok', headers: type({ 'x-total': 'string' }) },
+        },
+      }),
+      (c) => c.json({}, 200)
+    )
+
+    expect(app.getOpenAPIDocument(config)).toMatchObject({
+      paths: {
+        '/rh': {
+          get: {
+            responses: {
+              200: { headers: { 'x-total': { schema: { type: 'string' }, required: true } } },
+            },
+          },
+        },
+      },
+    })
+  })
+})
+
+describe('sub apps', () => {
+  it('merges non-Zod routes from a mounted app', () => {
+    const books = new OpenAPIHono()
+    books.openapi(
+      createRoute({
+        method: 'get',
+        path: '/{id}',
+        request: { params: type({ id: 'string' }) },
+        responses: { 200: { description: 'ok' } },
+      }),
+      (c) => c.json({}, 200)
+    )
+
+    const app = new OpenAPIHono().route('/books', books)
+
+    expect(Object.keys(app.getOpenAPIDocument(config).paths)).toEqual(['/books/{id}'])
+  })
+})

--- a/packages/zod-openapi/src/standard-schema.ts
+++ b/packages/zod-openapi/src/standard-schema.ts
@@ -15,7 +15,8 @@ export interface StandardOpenAPISchema<Input = unknown, Output = Input> {
     StandardJSONSchemaV1.Props<Input, Output>
 }
 
-type StandardOpenAPISchemaTarget = StandardJSONSchemaV1.Target
+/** A JSON Schema dialect a Standard Schema library may be asked to emit. */
+export type JSONSchemaTarget = StandardJSONSchemaV1.Target
 
 type JSONSchema = Record<string, unknown>
 
@@ -23,7 +24,7 @@ type JSONSchema = Record<string, unknown>
 type OpenApiMetadata = ReturnType<typeof getOpenApiMetadata>
 
 /**
- * Targets to try per OpenAPI version, in order.
+ * Default targets to try per OpenAPI version, in order.
  *
  * The spec lets a library throw for targets it does not implement, and support is uneven:
  * Zod emits `openapi-3.0`, while ArkType throws `JSONSchema target 'openapi-3.0' is not
@@ -31,8 +32,11 @@ type OpenApiMetadata = ReturnType<typeof getOpenApiMetadata>
  * `doc()` would be unusable for those libraries — draft-07 is close to the draft-04 that
  * OpenAPI 3.0 builds on, so most schemas survive, but constructs 3.0 lacks pass through
  * unconverted. 3.1 already is draft-2020-12, so it needs no fallback.
+ *
+ * Override per app with `jsonSchemaTargets` on `OpenAPIHono` when a library only supports
+ * a specific dialect (e.g. ArkType → `{ '3.0': ['draft-07'] }`).
  */
-export const TARGETS: Record<'3.0' | '3.1', StandardOpenAPISchemaTarget[]> = {
+export const TARGETS: Record<'3.0' | '3.1', JSONSchemaTarget[]> = {
   '3.0': ['openapi-3.0', 'draft-07'],
   '3.1': ['draft-2020-12'],
 }
@@ -63,7 +67,7 @@ const isStandardJSONSchema = (x: unknown): x is StandardOpenAPISchema => {
 const toJSONSchema = (
   schema: StandardOpenAPISchema,
   kind: 'input' | 'output',
-  targets: StandardOpenAPISchemaTarget[]
+  targets: JSONSchemaTarget[]
 ): JSONSchema => {
   const errors: string[] = []
 
@@ -104,7 +108,7 @@ const carry = (jsonSchema: JSONSchema): z.ZodString =>
 const toContentSchema = (
   schema: StandardOpenAPISchema,
   kind: 'input' | 'output',
-  targets: StandardOpenAPISchemaTarget[]
+  targets: JSONSchemaTarget[]
 ): z.ZodString => carry(toJSONSchema(schema, kind, targets))
 
 /**
@@ -117,7 +121,7 @@ const toContentSchema = (
  */
 const toParameterSchema = (
   schema: StandardOpenAPISchema,
-  targets: StandardOpenAPISchemaTarget[]
+  targets: JSONSchemaTarget[]
 ): z.ZodObject<Record<string, z.ZodString | z.ZodOptional<z.ZodString>>> => {
   // Parameters describe what the client sends, so they reflect the input type.
   const jsonSchema = toJSONSchema(schema, 'input', targets)
@@ -182,7 +186,7 @@ export const routeUsesStandardSchema = (route: RouteLike): boolean =>
 const convertContent = (
   content: Record<string, { schema?: unknown } | undefined> | undefined,
   kind: 'input' | 'output',
-  targets: StandardOpenAPISchemaTarget[]
+  targets: JSONSchemaTarget[]
 ) =>
   content &&
   Object.fromEntries(
@@ -194,7 +198,7 @@ const convertContent = (
     ])
   )
 
-const convertParameter = (schema: unknown, targets: StandardOpenAPISchemaTarget[]) =>
+const convertParameter = (schema: unknown, targets: JSONSchemaTarget[]) =>
   needsConversion(schema) ? toParameterSchema(schema, targets) : schema
 
 /**
@@ -204,7 +208,7 @@ const convertParameter = (schema: unknown, targets: StandardOpenAPISchemaTarget[
  */
 export const convertRouteSchemas = <R extends RouteLike>(
   route: R,
-  targets: StandardOpenAPISchemaTarget[]
+  targets: JSONSchemaTarget[]
 ): R => {
   const { request, responses } = route
 

--- a/packages/zod-openapi/src/standard-schema.ts
+++ b/packages/zod-openapi/src/standard-schema.ts
@@ -1,0 +1,258 @@
+import type { getOpenApiMetadata } from '@asteasolutions/zod-to-openapi'
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from '@standard-schema/spec'
+import { z } from 'zod'
+import { isZod } from './zod-typeguard'
+
+/**
+ * A schema with both halves this package needs: `validate` for the request middleware and
+ * `jsonSchema` for the document. See https://standardschema.dev/json-schema.
+ *
+ * Zod 4 and ArkType ship both natively; Valibot only gets `jsonSchema` once it is wrapped
+ * with `toStandardJsonSchema()` from `@valibot/to-json-schema`.
+ */
+export interface StandardOpenAPISchema<Input = unknown, Output = Input> {
+  readonly '~standard': StandardSchemaV1.Props<Input, Output> &
+    StandardJSONSchemaV1.Props<Input, Output>
+}
+
+type StandardOpenAPISchemaTarget = StandardJSONSchemaV1.Target
+
+type JSONSchema = Record<string, unknown>
+
+/** The metadata `.openapi()` accepts, which is merged over the schema Zod generates. */
+type OpenApiMetadata = ReturnType<typeof getOpenApiMetadata>
+
+/**
+ * Targets to try per OpenAPI version, in order.
+ *
+ * The spec lets a library throw for targets it does not implement, and support is uneven:
+ * Zod emits `openapi-3.0`, while ArkType throws `JSONSchema target 'openapi-3.0' is not
+ * supported (must be "draft-2020-12" or "draft-07")`. Without the `draft-07` fallback,
+ * `doc()` would be unusable for those libraries — draft-07 is close to the draft-04 that
+ * OpenAPI 3.0 builds on, so most schemas survive, but constructs 3.0 lacks pass through
+ * unconverted. 3.1 already is draft-2020-12, so it needs no fallback.
+ */
+export const TARGETS: Record<'3.0' | '3.1', StandardOpenAPISchemaTarget[]> = {
+  '3.0': ['openapi-3.0', 'draft-07'],
+  '3.1': ['draft-2020-12'],
+}
+
+/**
+ * Whether the value validates and describes itself as JSON Schema, so we never have to know
+ * which library produced it.
+ */
+const isStandardJSONSchema = (x: unknown): x is StandardOpenAPISchema => {
+  // `typeof` has to allow 'function': `type({ ... })` returns a callable with `~standard`
+  // hung off it, so an object-only check silently misses every ArkType schema.
+  if ((typeof x !== 'object' && typeof x !== 'function') || x === null) {
+    return false
+  }
+  const standard = (x as StandardOpenAPISchema)['~standard'] as
+    Partial<StandardOpenAPISchema['~standard']> | undefined
+  return (
+    typeof standard?.validate === 'function' &&
+    typeof standard?.jsonSchema?.input === 'function' &&
+    typeof standard?.jsonSchema?.output === 'function'
+  )
+}
+
+/**
+ * Converts to JSON Schema, trying each target until one is accepted and keeping the
+ * rejections so the error at the end can say what was tried and why each failed.
+ */
+const toJSONSchema = (
+  schema: StandardOpenAPISchema,
+  kind: 'input' | 'output',
+  targets: StandardOpenAPISchemaTarget[]
+): JSONSchema => {
+  const errors: string[] = []
+
+  for (const target of targets) {
+    try {
+      // Drop `$schema`: it means something for a standalone schema document, but not for
+      // one embedded in an operation (ArkType and Valibot both emit it on the drafts).
+      const { $schema, ...jsonSchema } = schema['~standard'].jsonSchema[kind]({ target })
+      return jsonSchema
+    } catch (e) {
+      errors.push(`${target}: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  }
+
+  throw new Error(
+    `"${schema['~standard'].vendor}" could not convert a schema to any target supported by this ` +
+      `OpenAPI version (tried ${targets.join(', ')}).\n${errors.join('\n')}`
+  )
+}
+
+/**
+ * Hides a foreign JSON Schema inside a Zod carrier, so `@asteasolutions/zod-to-openapi` —
+ * which reads Zod internals and understands nothing else — emits a schema it never produced.
+ *
+ * The carrier's own type never reaches the document: the generator merges `.openapi()`
+ * metadata over whatever it generated, so every key in the output comes from `jsonSchema`.
+ */
+const carry = (jsonSchema: JSONSchema): z.ZodString =>
+  // `z.string()` and not `z.any()`: Zod counts `any` as accepting `undefined`, so the
+  // generator reads the property as optional and every required parameter rebuilt by
+  // `toParameterSchema` would come out `required: false`.
+  z.string().openapi(jsonSchema as OpenApiMetadata)
+
+/**
+ * Converts a request-body or response schema into a single carrier — content schemas are
+ * emitted whole, so there is nothing to take apart.
+ */
+const toContentSchema = (
+  schema: StandardOpenAPISchema,
+  kind: 'input' | 'output',
+  targets: StandardOpenAPISchemaTarget[]
+): z.ZodString => carry(toJSONSchema(schema, kind, targets))
+
+/**
+ * Rebuilds an object schema as a Zod object of carriers, one per property, for parameters
+ * (path, query, header, cookie).
+ *
+ * These cannot reuse the flat carrier from `carry`: the generator splits the object into
+ * one parameter per property and reads that shape off the Zod type, so a flat carrier dies
+ * with "Missing parameter data, please specify `name` and other OpenAPI parameter props".
+ */
+const toParameterSchema = (
+  schema: StandardOpenAPISchema,
+  targets: StandardOpenAPISchemaTarget[]
+): z.ZodObject<Record<string, z.ZodString | z.ZodOptional<z.ZodString>>> => {
+  // Parameters describe what the client sends, so they reflect the input type.
+  const jsonSchema = toJSONSchema(schema, 'input', targets)
+  const properties = (jsonSchema.properties ?? {}) as Record<string, JSONSchema>
+  const required = (jsonSchema.required ?? []) as string[]
+
+  return z.object(
+    Object.fromEntries(
+      Object.entries(properties).map(([name, property]) => [
+        name,
+        required.includes(name) ? carry(property) : carry(property).optional(),
+      ])
+    )
+  )
+}
+
+/**
+ * Whether the schema has to be converted before the registry sees it. Zod schemas never are
+ * — they reach `@asteasolutions/zod-to-openapi` untouched, so registered refs
+ * (`.openapi('User')`) and existing metadata keep resolving exactly as they did before.
+ */
+export const needsConversion = (schema: unknown): schema is StandardOpenAPISchema =>
+  !isZod(schema) && isStandardJSONSchema(schema)
+
+/** Only the parts of a route this module reads. Structural so `index.ts` can import from
+ * here without the two files importing each other. */
+type RouteLike = {
+  request?: {
+    body?: { content?: Record<string, { schema?: unknown } | undefined> }
+    params?: unknown
+    query?: unknown
+    cookies?: unknown
+    headers?: unknown
+  }
+  responses?: Record<
+    string,
+    { content?: Record<string, { schema?: unknown } | undefined>; headers?: unknown }
+  >
+}
+
+const schemasOf = (route: RouteLike): unknown[] => [
+  route.request?.params,
+  route.request?.query,
+  route.request?.cookies,
+  ...(Array.isArray(route.request?.headers)
+    ? (route.request.headers as unknown[])
+    : [route.request?.headers]),
+  ...Object.values(route.request?.body?.content ?? {}).map((media) => media?.schema),
+  ...Object.values(route.responses ?? {}).flatMap((response) => [
+    ...Object.values(response?.content ?? {}).map((media) => media?.schema),
+    response?.headers,
+  ]),
+]
+
+/**
+ * Whether the route carries a schema from some library other than Zod, which decides
+ * whether it can be registered eagerly or has to wait for a target (see `#standardRoutes`).
+ */
+export const routeUsesStandardSchema = (route: RouteLike): boolean =>
+  schemasOf(route).some(needsConversion)
+
+const convertContent = (
+  content: Record<string, { schema?: unknown } | undefined> | undefined,
+  kind: 'input' | 'output',
+  targets: StandardOpenAPISchemaTarget[]
+) =>
+  content &&
+  Object.fromEntries(
+    Object.entries(content).map(([mediaType, media]) => [
+      mediaType,
+      media && needsConversion(media.schema)
+        ? { ...media, schema: toContentSchema(media.schema, kind, targets) }
+        : media,
+    ])
+  )
+
+const convertParameter = (schema: unknown, targets: StandardOpenAPISchemaTarget[]) =>
+  needsConversion(schema) ? toParameterSchema(schema, targets) : schema
+
+/**
+ * Returns the route with every non-Zod schema swapped for a Zod carrier, so the whole route
+ * can go through `@asteasolutions/zod-to-openapi` unchanged. Zod schemas are passed along
+ * as they are.
+ */
+export const convertRouteSchemas = <R extends RouteLike>(
+  route: R,
+  targets: StandardOpenAPISchemaTarget[]
+): R => {
+  const { request, responses } = route
+
+  return {
+    ...route,
+    ...(request
+      ? {
+          request: {
+            ...request,
+            ...(request.params ? { params: convertParameter(request.params, targets) } : {}),
+            ...(request.query ? { query: convertParameter(request.query, targets) } : {}),
+            ...(request.cookies ? { cookies: convertParameter(request.cookies, targets) } : {}),
+            ...(request.headers
+              ? {
+                  headers: Array.isArray(request.headers)
+                    ? request.headers.map((header) => convertParameter(header, targets))
+                    : convertParameter(request.headers, targets),
+                }
+              : {}),
+            ...(request.body
+              ? {
+                  body: {
+                    ...request.body,
+                    // A request body is what the client sends, so it is the input type —
+                    // a field with a default is optional here and guaranteed on the way out.
+                    content: convertContent(request.body.content, 'input', targets),
+                  },
+                }
+              : {}),
+          },
+        }
+      : {}),
+    ...(responses
+      ? {
+          responses: Object.fromEntries(
+            Object.entries(responses).map(([status, response]) => [
+              status,
+              {
+                ...response,
+                // A response is what the server sends, so it is the output type.
+                content: convertContent(response?.content, 'output', targets),
+                ...(response?.headers
+                  ? { headers: convertParameter(response.headers, targets) }
+                  : {}),
+              },
+            ])
+          ),
+        }
+      : {}),
+  } as R
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1034,13 +1034,22 @@ importers:
       '@asteasolutions/zod-to-openapi':
         specifier: ^8.5.0
         version: 8.5.0(zod@4.4.3)
+      '@hono/standard-validator':
+        specifier: workspace:^
+        version: link:../standard-validator
       '@hono/zod-validator':
         specifier: workspace:^
         version: link:../zod-validator
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       openapi3-ts:
         specifier: ^4.5.0
         version: 4.6.0
     devDependencies:
+      arktype:
+        specifier: ^2.2.3
+        version: 2.2.3
       hono:
         specifier: ^4.11.5
         version: 4.12.28


### PR DESCRIPTION
Hey everyone, that PR should be close #1763.

## Summary

`@hono/zod-openapi` takes Zod and nothing else today. This makes it take schemas from any library implementing [Standard JSON Schema](https://standardschema.dev/json-schema) — ArkType, Valibot once wrapped with `toStandardJsonSchema()`, and Zod 4, which ships it natively. A route can mix them.

```ts
import { type } from 'arktype'

app.openapi(
  createRoute({
    method: 'post',
    path: '/users',
    request: {
      body: {
        required: true,
        content: { 'application/json': { schema: type({ name: 'string' }) } },
      },
    },
    responses: { 200: { description: 'Created' } },
  }),
  (c) => c.json({ name: c.req.valid('json').name }, 200)
)
```

## Solution

`@asteasolutions/zod-to-openapi` reads Zod internals, so a foreign schema cannot go to it directly. Non-Zod schemas are hidden inside a Zod carrier (`z.string().openapi(jsonSchema)`) — the generator merges `.openapi()` metadata over whatever it generated, so the output comes entirely from `~standard.jsonSchema`. Zod schemas are never converted and behave exactly as before.

## Test

`pnpm test` in `packages/zod-openapi` — 123 pass, the 111 existing ones untouched. The 12 new tests cover ArkType and mixed routes: validation, parameters, input vs output, response headers and sub-apps.

## Caveats

- **`doc()` and OpenAPI 3.0.** ArkType implements only the JSON Schema drafts, so those schemas fall back to `draft-07` and constructs 3.0 lacks pass through unconverted. `doc31()` needs no fallback.
- **Validation hooks.** `result.error` is an array of Standard Schema issues for non-Zod schemas, while `Hook` still calls it a `ZodError`. Widening it would break every hook reading `.issues`, so I left it — tell me if you would rather take the break.

Both are documented under Limitations in the README.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
