### PR TITLE
feat(standard-validator): Add flattenErrors utility to @hono/standard-validator

### DIFF
--- a/.changeset/tricky-socks-rule.md
+++ b/.changeset/tricky-socks-rule.md
@@ -1,0 +1,5 @@
+---
+'@hono/standard-validator': minor
+---
+
+Add a new sortErrors utility that allows errors to be sorted by form and field errors, with field errors also being sorted by path.

--- a/.changeset/tricky-socks-rule.md
+++ b/.changeset/tricky-socks-rule.md
@@ -2,4 +2,4 @@
 '@hono/standard-validator': minor
 ---
 
-Add a new sortErrors utility that allows errors to be sorted by form and field errors, with field errors also being sorted by path.
+Add a new flattenErrors utility that allows errors to be sorted by form and field errors, with field errors also being sorted by path.

--- a/packages/standard-validator/__schemas__/arktype.ts
+++ b/packages/standard-validator/__schemas__/arktype.ts
@@ -30,6 +30,15 @@ const headerSchema = type({
   'user-agent': 'string',
 })
 
+const userSchema = type({
+  username: type('string')
+    .atMostLength(10)
+    .configure({ message: 'Username cannot be longer than 10 characters' })
+    .matching(/^[\p{L}\p{N}_]+$/u)
+    .configure({ message: 'Username must contain only alphanumeric characters' }),
+  password: type.pipe(type.string, (s) => s.trim(), type.string.atLeastLength(4)),
+})
+
 export {
   headerSchema,
   idJSONSchema,
@@ -38,4 +47,5 @@ export {
   queryNameSchema,
   queryPaginationSchema,
   querySortSchema,
+  userSchema,
 }

--- a/packages/standard-validator/__schemas__/arktype.ts
+++ b/packages/standard-validator/__schemas__/arktype.ts
@@ -31,12 +31,8 @@ const headerSchema = type({
 })
 
 const userSchema = type({
-  username: type('string')
-    .atMostLength(10)
-    .configure({ message: 'Username cannot be longer than 10 characters' })
-    .matching(/^[\p{L}\p{N}_]+$/u)
-    .configure({ message: 'Username must contain only alphanumeric characters' }),
-  password: type.pipe(type.string, (s) => s.trim(), type.string.atLeastLength(4)),
+  username: type('string.alphanumeric <= 10'),
+  password: type('string >= 4').pipe((value) => value.trim()),
 })
 
 export {

--- a/packages/standard-validator/__schemas__/arktype.ts
+++ b/packages/standard-validator/__schemas__/arktype.ts
@@ -33,6 +33,7 @@ const headerSchema = type({
 const userSchema = type({
   username: type('string.alphanumeric <= 10'),
   password: type('string >= 4').pipe((value) => value.trim()),
+  '+': 'reject',
 })
 
 export {

--- a/packages/standard-validator/__schemas__/valibot.ts
+++ b/packages/standard-validator/__schemas__/valibot.ts
@@ -1,4 +1,18 @@
-import { object, string, number, optional, pipe, unknown, transform, picklist, strictObject, maxLength, minLength, regex, trim } from 'valibot'
+import {
+  object,
+  string,
+  number,
+  optional,
+  pipe,
+  unknown,
+  transform,
+  picklist,
+  strictObject,
+  maxLength,
+  minLength,
+  regex,
+  trim,
+} from 'valibot'
 
 const personJSONSchema = object({
   name: string(),
@@ -36,14 +50,10 @@ const userSchema = strictObject({
   username: pipe(
     string(),
     maxLength(10, 'Username cannot be longer than 10 characters'),
-    regex(/^[\p{L}\p{N}_]+$/u, 'Username must contain only alphanumeric characters'),
+    regex(/^[\p{L}\p{N}_]+$/u, 'Username must contain only alphanumeric characters')
   ),
-  password: pipe(
-    string(),
-    trim(),
-    minLength(4, 'Password must be at least 4 characters long'),
-  ),
-});
+  password: pipe(string(), trim(), minLength(4, 'Password must be at least 4 characters long')),
+})
 
 export {
   headerSchema,

--- a/packages/standard-validator/__schemas__/valibot.ts
+++ b/packages/standard-validator/__schemas__/valibot.ts
@@ -1,4 +1,4 @@
-import { object, string, number, optional, pipe, unknown, transform, picklist } from 'valibot'
+import { object, string, number, optional, pipe, unknown, transform, picklist, strictObject, maxLength, minLength, regex, trim } from 'valibot'
 
 const personJSONSchema = object({
   name: string(),
@@ -32,6 +32,19 @@ const headerSchema = object({
   'user-agent': string(),
 })
 
+const userSchema = strictObject({
+  username: pipe(
+    string(),
+    maxLength(10, 'Username cannot be longer than 10 characters'),
+    regex(/^[\p{L}\p{N}_]+$/u, 'Username must contain only alphanumeric characters'),
+  ),
+  password: pipe(
+    string(),
+    trim(),
+    minLength(4, 'Password must be at least 4 characters long'),
+  ),
+});
+
 export {
   headerSchema,
   idJSONSchema,
@@ -40,4 +53,5 @@ export {
   queryNameSchema,
   queryPaginationSchema,
   querySortSchema,
+  userSchema,
 }

--- a/packages/standard-validator/__schemas__/zod.ts
+++ b/packages/standard-validator/__schemas__/zod.ts
@@ -32,6 +32,14 @@ const headerSchema = z.object({
   'user-agent': z.string(),
 })
 
+const userSchema = z.strictObject({
+  username: z
+    .string()
+    .max(10, 'Username cannot be longer than 10 characters')
+    .regex(/^[\p{L}\p{N}_]+$/u, 'Username must contain only alphanumeric characters'),
+  password: z.string().trim().min(4, 'Password must be at least 4 characters long'),
+});
+
 export {
   headerSchema,
   idJSONSchema,
@@ -40,4 +48,5 @@ export {
   queryNameSchema,
   queryPaginationSchema,
   querySortSchema,
+  userSchema,
 }

--- a/packages/standard-validator/__schemas__/zod.ts
+++ b/packages/standard-validator/__schemas__/zod.ts
@@ -38,7 +38,7 @@ const userSchema = z.strictObject({
     .max(10, 'Username cannot be longer than 10 characters')
     .regex(/^[\p{L}\p{N}_]+$/u, 'Username must contain only alphanumeric characters'),
   password: z.string().trim().min(4, 'Password must be at least 4 characters long'),
-});
+})
 
 export {
   headerSchema,

--- a/packages/standard-validator/src/index.test.ts
+++ b/packages/standard-validator/src/index.test.ts
@@ -497,17 +497,6 @@ describe('sortErrors', () => {
     role: 'admin',
   }
 
-  const testResult = {
-    formErrors: ['Unrecognized key: "role"'],
-    fieldErrors: {
-      username: [
-        'Username cannot be longer than 10 characters',
-        'Username must contain only alphanumeric characters',
-      ],
-      password: ['Password must be at least 4 characters long'],
-    },
-  }
-
   it('sorts Zod validation errors by path', async () => {
     // Arrange
     const { issues = [] } = await zodSchemas.userSchema['~standard'].validate(testData)
@@ -516,7 +505,16 @@ describe('sortErrors', () => {
     const sortedErrors = sortErrors(issues)
 
     // Assert
-    expect(sortedErrors).toStrictEqual(testResult)
+    expect(sortedErrors).toStrictEqual({
+      formErrors: ['Unrecognized key: "role"'],
+      fieldErrors: {
+        username: [
+          'Username cannot be longer than 10 characters',
+          'Username must contain only alphanumeric characters',
+        ],
+        password: ['Password must be at least 4 characters long'],
+      },
+    })
   })
 
   it('sorts Valibot validation errors by path', async () => {
@@ -527,15 +525,36 @@ describe('sortErrors', () => {
     const sortedErrors = sortErrors(issues)
 
     // Assert
-    expect(sortedErrors).toStrictEqual(testResult)
+    expect(sortedErrors).toStrictEqual({
+      formErrors: [],
+      fieldErrors: {
+        username: [
+          'Username cannot be longer than 10 characters',
+          'Username must contain only alphanumeric characters',
+        ],
+        password: ['Password must be at least 4 characters long'],
+        role: ['Invalid key: Expected never but received "role"'],
+      },
+    })
   })
 
   it('sorts ArkType validation errors by path', async () => {
     // Arrange
     const { issues = [] } = await arktypeSchemas.userSchema['~standard'].validate(testData)
+
     // Act
     const sortedErrors = sortErrors(issues)
+
     // Assert
-    expect(sortedErrors).toStrictEqual(testResult)
+    expect(sortedErrors).toStrictEqual({
+      formErrors: [],
+      fieldErrors: {
+        username: [
+          expect.stringMatching(/username.*must be.*only letters and digits.*at most length 10/s),
+        ],
+        password: ['password must be at least length 4 (was 3)'],
+        role: ['role must be removed'],
+      },
+    })
   })
 })

--- a/packages/standard-validator/src/index.test.ts
+++ b/packages/standard-validator/src/index.test.ts
@@ -8,7 +8,7 @@ import { vi } from 'vitest'
 import * as arktypeSchemas from '../__schemas__/arktype'
 import * as valibotSchemas from '../__schemas__/valibot'
 import * as zodSchemas from '../__schemas__/zod'
-import { sValidator, sortErrors } from '.'
+import { sValidator, flattenErrors } from '.'
 
 type MergeDiscriminatedUnion<U> =
   UnionToIntersection<U> extends infer O ? { [K in keyof O]: O[K] } : never
@@ -502,7 +502,7 @@ describe('sortErrors', () => {
     const { issues = [] } = await zodSchemas.userSchema['~standard'].validate(testData)
 
     // Act
-    const sortedErrors = sortErrors(issues)
+    const sortedErrors = flattenErrors(issues)
 
     // Assert
     expect(sortedErrors).toStrictEqual({
@@ -522,7 +522,7 @@ describe('sortErrors', () => {
     const { issues = [] } = await valibotSchemas.userSchema['~standard'].validate(testData)
 
     // Act
-    const sortedErrors = sortErrors(issues)
+    const sortedErrors = flattenErrors(issues)
 
     // Assert
     expect(sortedErrors).toStrictEqual({
@@ -543,7 +543,7 @@ describe('sortErrors', () => {
     const { issues = [] } = await arktypeSchemas.userSchema['~standard'].validate(testData)
 
     // Act
-    const sortedErrors = sortErrors(issues)
+    const sortedErrors = flattenErrors(issues)
 
     // Assert
     expect(sortedErrors).toStrictEqual({

--- a/packages/standard-validator/src/index.test.ts
+++ b/packages/standard-validator/src/index.test.ts
@@ -8,7 +8,7 @@ import { vi } from 'vitest'
 import * as arktypeSchemas from '../__schemas__/arktype'
 import * as valibotSchemas from '../__schemas__/valibot'
 import * as zodSchemas from '../__schemas__/zod'
-import { sValidator } from '.'
+import { sValidator, sortErrors } from '.'
 
 type MergeDiscriminatedUnion<U> =
   UnionToIntersection<U> extends infer O ? { [K in keyof O]: O[K] } : never
@@ -489,3 +489,55 @@ describe('Standard Schema Validation', () => {
     })
   })
 })
+
+describe('sortErrors', () => {
+
+	it('sorts Zod validation errors by path', () => {
+		// Arrange
+		const { error: { issues = [] } = {} } = zodSchemas.userSchema.safeParse({
+			username: 'Super John Doe',
+			password: '123',
+			role: 'admin',
+		});
+
+		// Act
+		const sortedErrors = sortErrors(issues);
+
+		// Assert
+		expect(sortedErrors).toStrictEqual({
+			formErrors: ['Unrecognized key: "role"'],
+			fieldErrors: {
+				username: [
+					'Username cannot be longer than 10 characters',
+					'Username must contain only alphanumeric characters',
+				],
+				password: ['Password must be at least 4 characters long'],
+			},
+		});
+	});
+
+	it('sorts Valibot validation errors by path', async () => {
+		// Arrange
+		const { issues = [] } = await valibotSchemas.userSchema['~standard'].validate({
+			username: 'Super John Doe',
+			password: '123',
+			role: 'admin',
+		});
+
+		// Act
+		const sortedErrors = sortErrors(issues);
+
+		// Assert
+		expect(sortedErrors).toStrictEqual({
+			formErrors: [],
+			fieldErrors: {
+				username: [
+					'Username cannot be longer than 10 characters',
+					'Username must contain only alphanumeric characters',
+				],
+				password: ['Password must be at least 4 characters long'],
+				role: ['Invalid key: Expected never but received "role"'],
+			},
+		});
+	});
+});

--- a/packages/standard-validator/src/index.test.ts
+++ b/packages/standard-validator/src/index.test.ts
@@ -491,53 +491,51 @@ describe('Standard Schema Validation', () => {
 })
 
 describe('sortErrors', () => {
+  const testData = {
+    username: 'Super John Doe',
+    password: '123',
+    role: 'admin',
+  }
 
-	it('sorts Zod validation errors by path', () => {
-		// Arrange
-		const { error: { issues = [] } = {} } = zodSchemas.userSchema.safeParse({
-			username: 'Super John Doe',
-			password: '123',
-			role: 'admin',
-		});
+  const testResult = {
+    formErrors: ['Unrecognized key: "role"'],
+    fieldErrors: {
+      username: [
+        'Username cannot be longer than 10 characters',
+        'Username must contain only alphanumeric characters',
+      ],
+      password: ['Password must be at least 4 characters long'],
+    },
+  }
 
-		// Act
-		const sortedErrors = sortErrors(issues);
+  it('sorts Zod validation errors by path', async () => {
+    // Arrange
+    const { issues = [] } = await zodSchemas.userSchema['~standard'].validate(testData)
 
-		// Assert
-		expect(sortedErrors).toStrictEqual({
-			formErrors: ['Unrecognized key: "role"'],
-			fieldErrors: {
-				username: [
-					'Username cannot be longer than 10 characters',
-					'Username must contain only alphanumeric characters',
-				],
-				password: ['Password must be at least 4 characters long'],
-			},
-		});
-	});
+    // Act
+    const sortedErrors = sortErrors(issues)
 
-	it('sorts Valibot validation errors by path', async () => {
-		// Arrange
-		const { issues = [] } = await valibotSchemas.userSchema['~standard'].validate({
-			username: 'Super John Doe',
-			password: '123',
-			role: 'admin',
-		});
+    // Assert
+    expect(sortedErrors).toStrictEqual(testResult)
+  })
 
-		// Act
-		const sortedErrors = sortErrors(issues);
+  it('sorts Valibot validation errors by path', async () => {
+    // Arrange
+    const { issues = [] } = await valibotSchemas.userSchema['~standard'].validate(testData)
 
-		// Assert
-		expect(sortedErrors).toStrictEqual({
-			formErrors: [],
-			fieldErrors: {
-				username: [
-					'Username cannot be longer than 10 characters',
-					'Username must contain only alphanumeric characters',
-				],
-				password: ['Password must be at least 4 characters long'],
-				role: ['Invalid key: Expected never but received "role"'],
-			},
-		});
-	});
-});
+    // Act
+    const sortedErrors = sortErrors(issues)
+
+    // Assert
+    expect(sortedErrors).toStrictEqual(testResult)
+  })
+
+  it('sorts ArkType validation errors by path', async () => {
+    // Arrange
+    const { issues = [] } = await arktypeSchemas.userSchema['~standard'].validate(testData)
+    // Act
+    const sortedErrors = sortErrors(issues)
+    // Assert
+    expect(sortedErrors).toStrictEqual(testResult)
+  })
+})

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -172,26 +172,28 @@ interface SortedIssues {
  * @param issues An array of {@link StandardSchemaV1.Issue validation issues}.
  * @returns An object with sorted form and field errors.
  */
-export const sortErrors = (issues: readonly StandardSchemaV1.Issue[]): {
-  formErrors: string[];
-  fieldErrors: SortedIssues;
+export const sortErrors = (
+  issues: readonly StandardSchemaV1.Issue[]
+): {
+  formErrors: string[]
+  fieldErrors: SortedIssues
 } => {
-  const formErrors: string[] = [];
-  const fieldErrors: SortedIssues = {};
+  const formErrors: string[] = []
+  const fieldErrors: SortedIssues = {}
 
-  const hasKey = (key?: PropertyKey) => key != undefined;
+  const hasKey = (key?: PropertyKey) => key != undefined
 
   for (const { path = [], message } of issues) {
-    const [issuePath] = path;
-    const key = typeof issuePath === 'object' ? issuePath.key : issuePath;
+    const [issuePath] = path
+    const key = typeof issuePath === 'object' ? issuePath.key : issuePath
 
     if (hasKey(key) && !fieldErrors[key]) {
       fieldErrors[key] = []
-    };
+    }
 
-    const errors = hasKey(key) ? fieldErrors[key] : formErrors;
-    errors?.push(message);
+    const errors = hasKey(key) ? fieldErrors[key] : formErrors
+    errors?.push(message)
   }
 
-  return { formErrors, fieldErrors };
+  return { formErrors, fieldErrors }
 }

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -163,8 +163,9 @@ const sValidator = <
 export type { Hook }
 export { sValidator }
 
-interface SortedIssues {
-  [path: PropertyKey]: string[]
+interface FlattenedErrorObject {
+  formErrors: string[];
+  fieldErrors: Record<string, string[]>;
 }
 
 /**
@@ -174,24 +175,19 @@ interface SortedIssues {
  */
 export const flattenErrors = (
   issues: readonly StandardSchemaV1.Issue[]
-): {
-  formErrors: string[]
-  fieldErrors: SortedIssues
-} => {
+): FlattenedErrorObject => {
   const formErrors: string[] = []
-  const fieldErrors: SortedIssues = {}
-
-  const hasKey = (key?: PropertyKey) => key != undefined
+  const fieldErrors: Record<PropertyKey, string[]> = {}
 
   for (const { path = [], message } of issues) {
     const [issuePath] = path
     const key = typeof issuePath === 'object' ? issuePath.key : issuePath
 
-    if (hasKey(key) && !fieldErrors[key]) {
+    if (typeof key !== 'undefined' && !fieldErrors[key]) {
       fieldErrors[key] = []
     }
 
-    const errors = hasKey(key) ? fieldErrors[key] : formErrors
+    const errors = typeof key !== 'undefined' ? fieldErrors[key] : formErrors
     errors?.push(message)
   }
 

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -162,3 +162,36 @@ const sValidator = <
 
 export type { Hook }
 export { sValidator }
+
+interface SortedIssues {
+  [path: PropertyKey]: string[]
+}
+
+/**
+ * Sorts validation errors by their paths.
+ * @param issues An array of {@link StandardSchemaV1.Issue validation issues}.
+ * @returns An object with sorted form and field errors.
+ */
+export const sortErrors = (issues: readonly StandardSchemaV1.Issue[]): {
+  formErrors: string[];
+  fieldErrors: SortedIssues;
+} => {
+  const formErrors: string[] = [];
+  const fieldErrors: SortedIssues = {};
+
+  const hasKey = (key?: PropertyKey) => key != undefined;
+
+  for (const { path = [], message } of issues) {
+    const [issuePath] = path;
+    const key = typeof issuePath === 'object' ? issuePath.key : issuePath;
+
+    if (hasKey(key) && !fieldErrors[key]) {
+      fieldErrors[key] = []
+    };
+
+    const errors = hasKey(key) ? fieldErrors[key] : formErrors;
+    errors?.push(message);
+  }
+
+  return { formErrors, fieldErrors };
+}

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -172,7 +172,7 @@ interface SortedIssues {
  * @param issues An array of {@link StandardSchemaV1.Issue validation issues}.
  * @returns An object with sorted form and field errors.
  */
-export const sortErrors = (
+export const flattenErrors = (
   issues: readonly StandardSchemaV1.Issue[]
 ): {
   formErrors: string[]

--- a/packages/standard-validator/src/index.ts
+++ b/packages/standard-validator/src/index.ts
@@ -164,8 +164,8 @@ export type { Hook }
 export { sValidator }
 
 interface FlattenedErrorObject {
-  formErrors: string[];
-  fieldErrors: Record<string, string[]>;
+  formErrors: string[]
+  fieldErrors: Record<string, string[]>
 }
 
 /**
@@ -173,9 +173,7 @@ interface FlattenedErrorObject {
  * @param issues An array of {@link StandardSchemaV1.Issue validation issues}.
  * @returns An object with sorted form and field errors.
  */
-export const flattenErrors = (
-  issues: readonly StandardSchemaV1.Issue[]
-): FlattenedErrorObject => {
+export const flattenErrors = (issues: readonly StandardSchemaV1.Issue[]): FlattenedErrorObject => {
   const formErrors: string[] = []
   const fieldErrors: Record<PropertyKey, string[]> = {}
 


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

### Description

See #1987 

This PR adds a new `flattenErrors` utility that sorts errors by form and field errors.
For field errors, they are also keyed by error path.
Should be directly usable by passing in the `result.data` array from a use of the middleware.

```ts
import { sValidator, flattenErrors } from '@hono/standard-validator'

sValidator('json', schema, (result) => {
    if (!result.success) {
        const sortedErrors = sortErrors(result.error)
        // use results
    }
})
```

thanks to @stebeus for testing initial implementation and offering an improved version of the utility