### PR TITLE
feat(oidc-auth): add optional oidcAuthRefreshErrorHook

### DIFF
--- a/.changeset/oidc-auth-refresh-error-hook.md
+++ b/.changeset/oidc-auth-refresh-error-hook.md
@@ -1,0 +1,5 @@
+---
+"@hono/oidc-auth": minor
+---
+
+Add an optional `oidcAuthRefreshErrorHook`. `getAuth()` otherwise swallows a rejected refresh-token grant (it catches the `oauth4webapi` `ResponseBodyError` / `WWWAuthenticateChallengeError`, deletes the session cookie, and returns `null`), so callers cannot observe *why* a refresh failed. The hook is invoked with the OAuth2 error and the context before the cookie is deleted, letting applications log/meter refresh failures or branch on the specific error (e.g. distinguish a permanent `invalid_grant` from a transient `too_many_requests`), and — since it runs before the redirect and receives the context — optionally set a response header that rides the redirect. The hook is optional and defaults to the current behaviour, so this is fully backward compatible.

--- a/packages/oidc-auth/README.md
+++ b/packages/oidc-auth/README.md
@@ -149,6 +149,28 @@ Note:
 If explicit logout is not required, the logout handler can be omitted.
 If the middleware is applied to the callback URL, the default callback handling in the middleware can be used, so the explicit callback handling is not required.
 
+## Handling session refresh errors
+
+When a token refresh is rejected (the refresh token was revoked/expired, or the IdP returned an error such as `too_many_requests`), `getAuth` deletes the session cookie and redirects to re-authenticate. Set an `oidcAuthRefreshErrorHook` to observe the error, or `throw` from it to replace that redirect with your own response.
+
+```typescript
+import type { OidcAuthRefreshErrorHook } from '@hono/oidc-auth'
+import { HTTPException } from 'hono/http-exception'
+import * as oauth2 from 'oauth4webapi'
+
+const oidcAuthRefreshErrorHook: OidcAuthRefreshErrorHook = async (error, c) => {
+  if (error instanceof oauth2.ResponseBodyError && error.error === 'too_many_requests') {
+    throw new HTTPException(503, { message: 'Authentication temporarily unavailable' })
+  }
+}
+...
+app.use('*', async (c, next) => {
+  c.set('oidcAuthRefreshErrorHook', oidcAuthRefreshErrorHook) // set before any getAuth()
+  await next()
+})
+app.use('*', oidcAuthMiddleware())
+```
+
 ## Programmatically configure auth variables
 
 ```typescript

--- a/packages/oidc-auth/src/index.test.ts
+++ b/packages/oidc-auth/src/index.test.ts
@@ -318,33 +318,6 @@ describe('oidcAuthMiddleware()', () => {
     const res = await app.request(req, {}, {})
     expect(res.status).toBe(302)
   })
-  test('Should swallow an error thrown by oidcAuthRefreshErrorHook and still redirect', async () => {
-    // A buggy hook must not break the re-authentication flow.
-    const refreshTokenGrantRequest = vi.mocked(oauth2.refreshTokenGrantRequest)
-    refreshTokenGrantRequest.mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: 'invalid_grant', error_description: 'Bad Request' }), {
-        status: 400,
-        headers: { 'content-type': 'application/json' },
-      })
-    )
-    const hookApp = new Hono()
-    hookApp.use('/*', async (c, next) => {
-      c.set('oidcAuthRefreshErrorHook', () => {
-        throw new Error('hook failed')
-      })
-      await next()
-    })
-    hookApp.use('/*', oidcAuthMiddleware())
-    hookApp.all('/*', (c) => c.text('OK'))
-
-    const req = new Request('http://localhost/', {
-      method: 'GET',
-      headers: { cookie: `oidc-auth=${MOCK_JWT_TOKEN_EXPIRED_SESSION}` },
-    })
-    const res = await hookApp.request(req, {}, {})
-    expect(res.status).toBe(302) // redirect to re-authenticate, not a 500
-    expect(res.headers.get('set-cookie')).toMatch('oidc-auth=;') // session cookie still cleared
-  })
   test('Should swallow revocationRequest failure on expired session', async () => {
     // Regression for #1851: revokeSession() rejection used to escape getAuth().
     const revocationRequest = vi.mocked(oauth2.revocationRequest)

--- a/packages/oidc-auth/src/index.test.ts
+++ b/packages/oidc-auth/src/index.test.ts
@@ -264,6 +264,60 @@ describe('oidcAuthMiddleware()', () => {
     expect(res.headers.get('set-cookie')).toMatch('code_verifier=')
     expect(res.headers.get('set-cookie')).toMatch('continue=http%3A%2F%2Flocalhost%2F')
   })
+  test('Should invoke oidcAuthRefreshErrorHook when the refresh-token grant is rejected', async () => {
+    // A rejected refresh (e.g. the refresh token was revoked) makes
+    // processRefreshTokenResponse throw a ResponseBodyError; getAuth otherwise
+    // swallows it and redirects. The hook must fire with the OAuth2 error, and a
+    // header it sets must ride the resulting redirect.
+    const refreshTokenGrantRequest = vi.mocked(oauth2.refreshTokenGrantRequest)
+    refreshTokenGrantRequest.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'invalid_grant', error_description: 'Bad Request' }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const seen: unknown[] = []
+    const hookApp = new Hono()
+    hookApp.use('/*', async (c, next) => {
+      c.set('oidcAuthRefreshErrorHook', (error, ctx) => {
+        seen.push(error)
+        if (error instanceof oauth2.ResponseBodyError && error.error === 'invalid_grant') {
+          ctx.header('x-refresh-dead', '1')
+        }
+      })
+      await next()
+    })
+    hookApp.use('/*', oidcAuthMiddleware())
+    hookApp.all('/*', (c) => c.text('OK'))
+
+    const req = new Request('http://localhost/', {
+      method: 'GET',
+      headers: { cookie: `oidc-auth=${MOCK_JWT_TOKEN_EXPIRED_SESSION}` },
+    })
+    const res = await hookApp.request(req, {}, {})
+    expect(res.status).toBe(302) // refresh failed → redirect to re-authenticate
+    expect(res.headers.get('x-refresh-dead')).toBe('1') // header set in the hook rode the redirect
+    expect(res.headers.get('set-cookie')).toMatch('oidc-auth=;') // session cookie cleared
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toBeInstanceOf(oauth2.ResponseBodyError)
+    expect((seen[0] as oauth2.ResponseBodyError).error).toBe('invalid_grant')
+  })
+  test('Should still redirect on a rejected refresh when no oidcAuthRefreshErrorHook is set', async () => {
+    // The hook is optional — behaviour is unchanged when it is absent.
+    const refreshTokenGrantRequest = vi.mocked(oauth2.refreshTokenGrantRequest)
+    refreshTokenGrantRequest.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'invalid_grant', error_description: 'Bad Request' }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const req = new Request('http://localhost/', {
+      method: 'GET',
+      headers: { cookie: `oidc-auth=${MOCK_JWT_TOKEN_EXPIRED_SESSION}` },
+    })
+    const res = await app.request(req, {}, {})
+    expect(res.status).toBe(302)
+  })
   test('Should swallow revocationRequest failure on expired session', async () => {
     // Regression for #1851: revokeSession() rejection used to escape getAuth().
     const revocationRequest = vi.mocked(oauth2.revocationRequest)

--- a/packages/oidc-auth/src/index.test.ts
+++ b/packages/oidc-auth/src/index.test.ts
@@ -318,6 +318,33 @@ describe('oidcAuthMiddleware()', () => {
     const res = await app.request(req, {}, {})
     expect(res.status).toBe(302)
   })
+  test('Should swallow an error thrown by oidcAuthRefreshErrorHook and still redirect', async () => {
+    // A buggy hook must not break the re-authentication flow.
+    const refreshTokenGrantRequest = vi.mocked(oauth2.refreshTokenGrantRequest)
+    refreshTokenGrantRequest.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'invalid_grant', error_description: 'Bad Request' }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const hookApp = new Hono()
+    hookApp.use('/*', async (c, next) => {
+      c.set('oidcAuthRefreshErrorHook', () => {
+        throw new Error('hook failed')
+      })
+      await next()
+    })
+    hookApp.use('/*', oidcAuthMiddleware())
+    hookApp.all('/*', (c) => c.text('OK'))
+
+    const req = new Request('http://localhost/', {
+      method: 'GET',
+      headers: { cookie: `oidc-auth=${MOCK_JWT_TOKEN_EXPIRED_SESSION}` },
+    })
+    const res = await hookApp.request(req, {}, {})
+    expect(res.status).toBe(302) // redirect to re-authenticate, not a 500
+    expect(res.headers.get('set-cookie')).toMatch('oidc-auth=;') // session cookie still cleared
+  })
   test('Should swallow revocationRequest failure on expired session', async () => {
     // Regression for #1851: revokeSession() rejection used to escape getAuth().
     const revocationRequest = vi.mocked(oauth2.revocationRequest)

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -28,7 +28,8 @@ export type OidcClaimsHook = (
  *
  * It runs before the cookie is deleted and receives the Hono context, so a hook
  * may set a response header/attribute that then rides the redirect. Errors thrown
- * by the hook propagate to the caller.
+ * by the hook are swallowed so a failing hook cannot break the re-authentication
+ * flow.
  */
 export type OidcAuthRefreshErrorHook = (
   error: oauth2.ResponseBodyError | oauth2.WWWAuthenticateChallengeError,
@@ -285,7 +286,11 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
           // redirecting to re-authenticate.
           const refreshErrorHook = c.get('oidcAuthRefreshErrorHook')
           if (refreshErrorHook !== undefined) {
-            await refreshErrorHook(error, c)
+            try {
+              await refreshErrorHook(error, c)
+            } catch {
+              // ignore — a failing hook must not break the re-authentication redirect
+            }
           }
           deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
           return null

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -18,6 +18,23 @@ export type OidcClaimsHook = (
   response: oauth2.TokenEndpointResponse
 ) => Promise<OidcAuthClaims>
 
+/**
+ * Optional hook invoked when a session refresh (refresh-token grant) is rejected
+ * by the authorization server. `getAuth` otherwise swallows this error silently —
+ * it deletes the session cookie and returns `null`, which drives a redirect to
+ * re-authenticate. The hook lets callers observe *why* the refresh failed (for
+ * logging, metrics, or to branch on the specific OAuth2 error, e.g. distinguish a
+ * permanent `invalid_grant` from a transient `too_many_requests`).
+ *
+ * It runs before the cookie is deleted and receives the Hono context, so a hook
+ * may set a response header/attribute that then rides the redirect. Errors thrown
+ * by the hook propagate to the caller.
+ */
+export type OidcAuthRefreshErrorHook = (
+  error: oauth2.ResponseBodyError | oauth2.WWWAuthenticateChallengeError,
+  c: Context
+) => void | Promise<void>
+
 declare module 'hono' {
   export interface OidcAuthClaims {
     email?: string
@@ -31,6 +48,7 @@ declare module 'hono' {
     oidcAuth: OidcAuth | null
     oidcAuthJwt: string
     oidcClaimsHook?: OidcClaimsHook
+    oidcAuthRefreshErrorHook?: OidcAuthRefreshErrorHook
     oidcClientAuth?: oauth2.ClientAuth
   }
 }
@@ -262,7 +280,13 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
           error instanceof oauth2.ResponseBodyError ||
           error instanceof oauth2.WWWAuthenticateChallengeError
         ) {
-          // The refresh_token might be expired or revoked
+          // The refresh_token might be expired or revoked. Surface the error to an
+          // optional hook (logging/metrics/signalling) before swallowing it and
+          // redirecting to re-authenticate.
+          const refreshErrorHook = c.get('oidcAuthRefreshErrorHook')
+          if (refreshErrorHook !== undefined) {
+            await refreshErrorHook(error, c)
+          }
           deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
           return null
         }

--- a/packages/oidc-auth/src/index.ts
+++ b/packages/oidc-auth/src/index.ts
@@ -28,8 +28,7 @@ export type OidcClaimsHook = (
  *
  * It runs before the cookie is deleted and receives the Hono context, so a hook
  * may set a response header/attribute that then rides the redirect. Errors thrown
- * by the hook are swallowed so a failing hook cannot break the re-authentication
- * flow.
+ * by the hook propagate to the caller.
  */
 export type OidcAuthRefreshErrorHook = (
   error: oauth2.ResponseBodyError | oauth2.WWWAuthenticateChallengeError,
@@ -286,11 +285,7 @@ export const getAuth = async (c: Context): Promise<OidcAuth | null> => {
           // redirecting to re-authenticate.
           const refreshErrorHook = c.get('oidcAuthRefreshErrorHook')
           if (refreshErrorHook !== undefined) {
-            try {
-              await refreshErrorHook(error, c)
-            } catch {
-              // ignore — a failing hook must not break the re-authentication redirect
-            }
+            await refreshErrorHook(error, c)
           }
           deleteCookie(c, env.OIDC_COOKIE_NAME, { path: env.OIDC_COOKIE_PATH })
           return null


### PR DESCRIPTION
# feat(oidc-auth): add optional `oidcAuthRefreshErrorHook`

## What

Adds an optional `oidcAuthRefreshErrorHook` context variable (mirroring the
existing `oidcClaimsHook`) that `getAuth()` invokes when a refresh-token grant is
rejected by the authorization server, before it swallows the error.

```ts
c.set('oidcAuthRefreshErrorHook', (error, ctx) => {
  // error: oauth2.ResponseBodyError | oauth2.WWWAuthenticateChallengeError
  if (error instanceof ResponseBodyError && error.error === 'invalid_grant') {
    metrics.increment('session.refresh.revoked')
    ctx.header('x-session-dead', '1') // rides the redirect getAuth triggers
  }
})
```

## Why

Today `getAuth()` catches a rejected refresh (`oauth2.ResponseBodyError` /
`oauth2.WWWAuthenticateChallengeError`), deletes the session cookie, and returns
`null` — which drives a redirect to re-authenticate. The **reason** for the
failure is discarded, so an application cannot:

- log or emit metrics on *why* sessions fail to refresh (revoked vs rate-limited
  vs server error), or
- branch on the specific OAuth2 error — e.g. distinguish a permanent
  `invalid_grant` (the refresh token is revoked/expired and will never succeed)
  from a transient `too_many_requests` (the IdP is throttling and a retry would
  work).

## Tests

Two new tests in `packages/oidc-auth/src/index.test.ts`:

1. When the refresh-token grant is rejected (`processRefreshTokenResponse` throws
   `ResponseBodyError`), the hook fires with that error, and a header the hook
   sets on the context rides the resulting redirect; the session cookie is
   cleared.
2. The hook is optional — a rejected refresh with no hook registered still
   redirects (unchanged behaviour).

`pnpm test` (42 pass), `pnpm typecheck`, `pnpm lint`, and `pnpm build` all pass.
