### PR TITLE
fix(zod-openapi): export local z binding so OpenAPI patch is not tree-shaken

### DIFF
--- a/.changeset/zod-openapi-local-z-export.md
+++ b/.changeset/zod-openapi-local-z-export.md
@@ -1,0 +1,13 @@
+---
+"@hono/zod-openapi": patch
+---
+
+fix(zod-openapi): keep the `z` import edge so `.openapi()` survives bundling
+
+Re-exporting zod's `z` as a pass-through let esbuild code-splitting resolve
+`import { z } from '@hono/zod-openapi'` straight to zod and drop the edge to the
+module that runs `extendZodWithOpenApi(z)`, so schemas could be built before the
+patch applied and `.openapi()` was undefined at runtime. Export `z` as an alias
+declaration instead: it compiles to a binding local to the module, which keeps
+that edge, while still carrying zod's type namespace so `z.infer`, `z.ZodType`
+and the rest continue to work. Fixes #2051.

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -41,7 +41,7 @@ import { mergePath } from 'hono/utils/url'
 import type { OpenAPIObject } from 'openapi3-ts/oas30'
 import type { OpenAPIObject as OpenAPIV31bject } from 'openapi3-ts/oas31'
 import type { ZodType, ZodError } from 'zod'
-import { z } from 'zod'
+import * as zodModule from 'zod'
 import { isZod } from './zod-typeguard'
 
 type MaybePromise<T> = Promise<T> | T
@@ -913,8 +913,18 @@ export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'
   return Object.defineProperty(route, 'getRoutingPath', { enumerable: false })
 }
 
-extendZodWithOpenApi(z)
-export { extendZodWithOpenApi, z }
+// `zodModule.z`, not the `z` alias below: the alias compiles to a binding
+// declared at that point, which this call precedes.
+extendZodWithOpenApi(zodModule.z)
+// An alias declaration, not `export { z }`: re-exporting the imported binding
+// lets a bundler resolve `import { z } from '@hono/zod-openapi'` straight to zod
+// and drop the edge to this module, so the `extendZodWithOpenApi` call above can
+// evaluate after the schemas that need it — `.openapi()` is then undefined at
+// runtime under esbuild code splitting (#2051). This compiles to a binding local
+// to this module, which keeps that edge, while an alias — unlike `const z = zod`
+// — still carries zod's type namespace, so `z.infer` and friends keep working.
+export import z = zodModule.z
+export { extendZodWithOpenApi }
 
 function addBasePathToDocument(document: Record<string, any>, basePath: string) {
   const updatedPaths: Record<string, any> = {}


### PR DESCRIPTION
## Summary
- `@hono/zod-openapi` called `extendZodWithOpenApi(z)` then re-exported the same zod import binding.
- With esbuild `splitting: true`, `import { z } from '@hono/zod-openapi'` can resolve straight to `zod`, dropping this module — so schemas throw `...openapi is not a function` (issue #2051).
- Export a local `const z = zod` (still after the patch) so the side effect is not elidable.
- Follow-up: avoid importing type `z` alongside that value export (TS2395/TS2440), and annotate the export for `--isolatedDeclarations`.

## Test plan
- [x] `pnpm --filter @hono/zod-openapi typecheck`
- [x] `pnpm --filter @hono/zod-openapi build`
- [x] Changeset for `@hono/zod-openapi`

Fixes #2051