### PR TITLE
feat(structured-logger)!: correct types for hooks and other libraries

### DIFF
--- a/.changeset/salty-experts-itch.md
+++ b/.changeset/salty-experts-itch.md
@@ -1,0 +1,20 @@
+---
+'@hono/structured-logger': major
+---
+
+Redesign the public API.
+
+**Breaking changes:**
+
+- Removed `BaseLogger` export. The middleware no longer constrains the logger type — pass any logger via `createLogger` and TypeScript infers `L` from its return type.
+- Removed default `onRequest`, `onResponse`, and `onError` implementations. Hooks must now be provided explicitly; requests with no hooks configured pass through without any logging side effects.
+- Hook signatures are now inferred from `StructuredLoggerOptions`.
+- The `L` type parameter now defaults to `unknown` instead of `BaseLogger`.
+
+**New features:**
+
+- Added `skip` option: `(c: Context) => boolean`. When it returns `true`, the request bypasses `createLogger` and all hooks entirely.
+
+**Behaviour change:**
+
+- `elapsedMs` now measures handler duration only. The timer starts after `onRequest` returns, so `onRequest` processing time is excluded.

--- a/.changeset/salty-experts-itch.md
+++ b/.changeset/salty-experts-itch.md
@@ -7,13 +7,13 @@ Redesign the public API.
 **Breaking changes:**
 
 - Removed `BaseLogger` export. The middleware no longer constrains the logger type — pass any logger via `createLogger` and TypeScript infers `L` from its return type.
-- Removed default `onRequest`, `onResponse`, and `onError` implementations. Hooks must now be provided explicitly; requests with no hooks configured pass through without any logging side effects.
+- Removed default `onRequest`, `onResponse`, and `onError` implementations. `onResponse` is now required; `onRequest` and `onError` are optional.
 - Hook signatures are now inferred from `StructuredLoggerOptions`.
 - The `L` type parameter now defaults to `unknown` instead of `BaseLogger`.
 
 **New features:**
 
-- Added `skip` option: `(c: Context) => boolean`. When it returns `true`, the request bypasses `createLogger` and all hooks entirely.
+- Added `skip` option: `(c: Context) => boolean`. When it returns `true`, hooks are suppressed but the logger is still created and available on `c.var`.
 
 **Behaviour change:**
 

--- a/packages/structured-logger/README.md
+++ b/packages/structured-logger/README.md
@@ -28,8 +28,8 @@ app.use(requestId())
 app.use(
   structuredLogger({
     createLogger: (c) => rootLogger.child({ requestId: c.var.requestId }),
-    onRequest: (logger, c) =>
-      logger.info({ method: c.req.method, path: c.req.path }, 'incoming request'),
+    onResponse: (logger, c, elapsedMs) =>
+      logger.info({ method: c.req.method, path: c.req.path, elapsedMs }, 'request completed'),
   })
 )
 
@@ -53,8 +53,8 @@ const app = new Hono()
 app.use(
   structuredLogger({
     createLogger: (c) => rootLogger.child({ requestId: c.var.requestId }),
-    onRequest: (logger, c) =>
-      logger.info({ method: c.req.method, path: c.req.path }, 'incoming request'),
+    onResponse: (logger, c, elapsedMs) =>
+      logger.info({ method: c.req.method, path: c.req.path, elapsedMs }, 'request completed'),
   })
 )
 ```
@@ -70,14 +70,14 @@ const app = new Hono()
 app.use(
   structuredLogger({
     createLogger: () => console,
-    onRequest: (_logger, c) => console.info(c.req.method, c.req.path),
+    onResponse: (_logger, c, elapsedMs) => console.info(c.req.method, c.req.path, elapsedMs),
   })
 )
 ```
 
 ### Skipping routes
 
-Pass a `skip` function to opt specific requests out of logging entirely. Called before `createLogger`, so skipped requests incur no logger allocation:
+Pass a `skip` function to suppress hooks for specific requests. The logger is still created and available on `c.var` — only `onRequest`, `onResponse`, and `onError` are skipped:
 
 ```typescript
 import { Hono } from 'hono'
@@ -89,7 +89,7 @@ app.use(
   structuredLogger({
     createLogger: () => console,
     skip: (c) => c.req.path === '/health',
-    onRequest: (_logger, c) => console.info(c.req.method, c.req.path),
+    onResponse: (_logger, c, elapsedMs) => console.info(c.req.method, c.req.path, elapsedMs),
   })
 )
 ```
@@ -156,8 +156,8 @@ app.use(
   structuredLogger({
     createLogger: () => myLogger,
     contextKey: 'log',
-    onRequest: (logger, c) =>
-      logger.info({ method: c.req.method, path: c.req.path }, 'incoming request'),
+    onResponse: (logger, c, elapsedMs) =>
+      logger.info({ method: c.req.method, path: c.req.path, elapsedMs }, 'request completed'),
   })
 )
 
@@ -180,7 +180,7 @@ const app = new Hono<StructuredLoggerEnv<pino.Logger>>()
 
 // Custom key — pass the same literal to both
 const app = new Hono<StructuredLoggerEnv<pino.Logger, 'log'>>()
-app.use(structuredLogger({ createLogger: ..., contextKey: 'log', onRequest: ... }))
+app.use(structuredLogger({ createLogger: ..., contextKey: 'log', onResponse: ... }))
 ```
 
 `c.var.logger` (or the custom key) will then be typed as `pino.Logger` throughout the app.
@@ -188,17 +188,18 @@ app.use(structuredLogger({ createLogger: ..., contextKey: 'log', onRequest: ... 
 To get typed access to other context variables inside `structuredLogger`, set the type argument with your app's env type:
 
 ```typescript
-import type { Context } from 'hono'
+import pino from 'pino'
 
 type AppEnv = { Variables: { tenantId: string } }
 
-app.use(
-  structuredLogger<AppEnv>({
-    createLogger: (c) => rootLogger.child({ tenantId: c.var.tenantId }),
-    onRequest: (logger, c) =>
-      logger.info({ method: c.req.method, path: c.req.path }, 'incoming request'),
-  })
-)
+const rootLogger = pino()
+
+structuredLogger<AppEnv, pino.BaseLogger>({
+  createLogger: (c) => rootLogger.child({ tenantId: c.var.tenantId }),
+  onResponse: (logger, c, elapsedMs) => {
+    logger.info({ path: c.req.path, elapsedMs }, 'request completed')
+  },
+})
 ```
 
 TypeScript infers `E = AppEnv` from the annotation, so the middleware's return type enforces that the app declares `tenantId` in its env.
@@ -211,20 +212,20 @@ Returns a Hono `MiddlewareHandler`.
 
 #### Options
 
-| Option         | Type                                                                              | Required | Default    | Description                                           |
-| -------------- | --------------------------------------------------------------------------------- | -------- | ---------- | ----------------------------------------------------- |
-| `createLogger` | `(c: Context) => L`                                                               | Yes      |            | Factory that creates a request scoped logger instance |
-| `contextKey`   | `K extends string`                                                                | No       | `'logger'` | Key used to store the logger on `c.var`               |
-| `skip`         | `(c: Context) => boolean`                                                         | No       | —          | When true, request passes through without logging     |
-| `onRequest`    | `(logger: L, c: Context) => void \| Promise<void>`                                | Yes      | —          | Called before handler execution                       |
-| `onResponse`   | `(logger: L, c: Context, elapsedMs: number) => void \| Promise<void>`             | No       | —          | Called after handler execution                        |
-| `onError`      | `(logger: L, err: Error, c: Context, elapsedMs: number) => void \| Promise<void>` | No       | —          | Called when handler throws                            |
+| Option         | Type                                                                              | Required | Default    | Description                                                     |
+| -------------- | --------------------------------------------------------------------------------- | -------- | ---------- | --------------------------------------------------------------- |
+| `createLogger` | `(c: Context) => L`                                                               | Yes      |            | Factory that creates a request scoped logger instance           |
+| `contextKey`   | `K extends string`                                                                | No       | `'logger'` | Key used to store the logger on `c.var`                         |
+| `skip`         | `(c: Context) => boolean`                                                         | No       | —          | When true, hooks are suppressed; logger is still set on `c.var` |
+| `onRequest`    | `(logger: L, c: Context) => void \| Promise<void>`                                | No       | —          | Called before handler execution                                 |
+| `onResponse`   | `(logger: L, c: Context, elapsedMs: number) => void \| Promise<void>`             | Yes      | —          | Called after handler execution                                  |
+| `onError`      | `(logger: L, err: Error, c: Context, elapsedMs: number) => void \| Promise<void>` | No       | —          | Called when handler throws                                      |
 
 ## Behavior
 
-1. `createLogger(c)` is called once per request.
-2. The logger is stored on `c.var[contextKey]`.
-3. `onRequest` fires before handler execution.
+1. `createLogger(c)` is called once per request and the logger is stored on `c.var[contextKey]`.
+2. If `skip` returns `true`, hooks are suppressed and the request passes through.
+3. If provided, `onRequest` fires before handler execution.
 4. After handler completes, `onResponse` fires with elapsed time in milliseconds (measured via `performance.now()` immediately after `onRequest` returns, so `elapsedMs` reflects handler duration only).
 5. If the handler throws, Hono's `app.onError()` runs first to shape the response, then `onError` fires with elapsed time. By the time `onError` runs, `c.res` already holds the final response — including the correct status for `HTTPException`. `onResponse` is skipped when an error occurred.
 6. `onError` and `onResponse` are mutually exclusive per request.

--- a/packages/structured-logger/README.md
+++ b/packages/structured-logger/README.md
@@ -2,7 +2,7 @@
 
 Structured Logger middleware for [Hono](https://hono.dev).
 
-Library agnostic: works with pino, winston, bunyan, console, or any logger that implements the `BaseLogger` interface. Zero dependencies. Provides a request scoped logger on `c.var.logger` with full type safety, automatic response time measurement, and native integration with `hono/request-id`.
+Library agnostic: works with pino, winston, bunyan, console, or any structured logging library. Zero dependencies. Provides a request scoped logger on `c.var.logger` with full type safety, automatic response time measurement, and native integration with `hono/request-id`.
 
 ## Install
 
@@ -70,6 +70,24 @@ app.use(
 )
 ```
 
+### Skipping routes
+
+Pass a `skip` function to opt specific requests out of logging entirely. Called before `createLogger`, so skipped requests incur no logger allocation:
+
+```typescript
+import { Hono } from 'hono'
+import { structuredLogger } from '@hono/structured-logger'
+
+const app = new Hono()
+
+app.use(
+  structuredLogger({
+    createLogger: () => console,
+    skip: (c) => c.req.path === '/health',
+  })
+)
+```
+
 ### Custom hooks
 
 ```typescript
@@ -104,12 +122,13 @@ app.use(
         'request completed'
       )
     },
-    onError: (logger, err, c) => {
+    onError: (logger, err, c, elapsedMs) => {
       logger.error(
         {
           err,
           method: c.req.method,
           path: c.req.path,
+          elapsedMs,
         },
         'request failed'
       )
@@ -120,9 +139,13 @@ app.use(
 
 ### Custom context key
 
-If you already have a `logger` variable on your context, use `contextKey` to pick a different name:
+If you already have a `logger` variable on your context, use `contextKey` to pick a different name. Pass the same key to `StructuredLoggerEnv` to keep `c.var` fully typed:
 
 ```typescript
+import { structuredLogger, type StructuredLoggerEnv } from '@hono/structured-logger'
+
+const app = new Hono<StructuredLoggerEnv<MyLogger, 'log'>>()
+
 app.use(
   structuredLogger({
     createLogger: () => myLogger,
@@ -138,19 +161,37 @@ app.get('/', (c) => {
 
 ### Type safe context
 
-Declare the logger type on your Hono app for full type safety:
+Use `StructuredLoggerEnv` to declare the logger type on your Hono app. The second type parameter matches `contextKey` and defaults to `'logger'`:
 
 ```typescript
-import type { pino } from 'pino'
+import type pino from 'pino'
+import { structuredLogger, type StructuredLoggerEnv } from '@hono/structured-logger'
 
-type Env = {
-  Variables: {
-    logger: pino.Logger
-  }
-}
+// Default key ('logger')
+const app = new Hono<StructuredLoggerEnv<pino.Logger>>()
 
-const app = new Hono<Env>()
+// Custom key — pass the same literal to both
+const app = new Hono<StructuredLoggerEnv<pino.Logger, 'log'>>()
+app.use(structuredLogger({ createLogger: ..., contextKey: 'log' }))
 ```
+
+`c.var.logger` (or the custom key) will then be typed as `pino.Logger` throughout the app.
+
+To get typed access to other context variables inside `structuredLogger`, set the type argument with your app's env type:
+
+```typescript
+import type { Context } from 'hono'
+
+type AppEnv = { Variables: { tenantId: string } }
+
+app.use(
+  structuredLogger<AppEnv>({
+    createLogger: (c) => rootLogger.child({ tenantId: c.var.tenantId }),
+  })
+)
+```
+
+TypeScript infers `E = AppEnv` from the annotation, so the middleware's return type enforces that the app declares `tenantId` in its env.
 
 ## API
 
@@ -160,37 +201,26 @@ Returns a Hono `MiddlewareHandler`.
 
 #### Options
 
-| Option         | Type                                                                  | Required | Default                                                  | Description                                           |
-| -------------- | --------------------------------------------------------------------- | -------- | -------------------------------------------------------- | ----------------------------------------------------- |
-| `createLogger` | `(c: Context) => L`                                                   | Yes      |                                                          | Factory that creates a request scoped logger instance |
-| `contextKey`   | `string`                                                              | No       | `'logger'`                                               | Key used to store the logger on `c.var`               |
-| `onRequest`    | `(logger: L, c: Context) => void \| Promise<void>`                    | No       | Logs method + path at info level                         | Called before handler execution                       |
-| `onResponse`   | `(logger: L, c: Context, elapsedMs: number) => void \| Promise<void>` | No       | Logs method, path, status and elapsed time at info level | Called after handler execution                        |
-| `onError`      | `(logger: L, err: Error, c: Context) => void \| Promise<void>`        | No       | Logs error, method, path and status at error level       | Called when handler throws                            |
-
-### `BaseLogger`
-
-Minimal interface your logger must implement:
-
-```typescript
-interface BaseLogger {
-  info(obj: unknown, msg?: string, ...args: unknown[]): void
-  warn(obj: unknown, msg?: string, ...args: unknown[]): void
-  error(obj: unknown, msg?: string, ...args: unknown[]): void
-  debug(obj: unknown, msg?: string, ...args: unknown[]): void
-}
-```
-
-Compatible with pino, winston, bunyan, console, and most logging libraries out of the box.
+| Option         | Type                                                                              | Required | Default                                                          | Description                                           |
+| -------------- | --------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------- | ----------------------------------------------------- |
+| `createLogger` | `(c: Context) => L`                                                               | Yes      |                                                                  | Factory that creates a request scoped logger instance |
+| `contextKey`   | `K extends string`                                                                | No       | `'logger'`                                                       | Key used to store the logger on `c.var`               |
+| `skip`         | `(c: Context) => boolean`                                                         | No       | —                                                                | When true, request passes through without logging     |
+| `onRequest`    | `(logger: L, c: Context) => void \| Promise<void>`                                | No       | —                                                                | Called before handler execution                       |
+| `onResponse`   | `(logger: L, c: Context, elapsedMs: number) => void \| Promise<void>`             | No       | —                                                                | Called after handler execution                        |
+| `onError`      | `(logger: L, err: Error, c: Context, elapsedMs: number) => void \| Promise<void>` | No       | —                                                                | Called when handler throws                            |
 
 ## Behavior
 
 1. `createLogger(c)` is called once per request.
 2. The logger is stored on `c.var[contextKey]`.
 3. `onRequest` fires before handler execution.
-4. After handler completes, `onResponse` fires with elapsed time in milliseconds (measured via `performance.now()`).
-5. If the handler throws, Hono's error handler runs first, then `onError` fires (checking `c.error`). `onResponse` is skipped when an error occurred.
+4. After handler completes, `onResponse` fires with elapsed time in milliseconds (measured via `performance.now()` immediately after `onRequest` returns, so `elapsedMs` reflects handler duration only).
+5. If the handler throws, Hono's `app.onError()` runs first to shape the response, then `onError` fires with elapsed time. By the time `onError` runs, `c.res` already holds the final response — including the correct status for `HTTPException`. `onResponse` is skipped when an error occurred.
 6. `onError` and `onResponse` are mutually exclusive per request.
+
+> [!WARNING]
+> **Avoid logging in both `onError` and `app.onError()`.** Since `app.onError()` always runs before this middleware's `onError` hook, logging in both places produces a duplicate log line for every error. The recommended pattern is to log only here and keep `app.onError()` focused on shaping the response. Note that errors handled via `HTTPException` never reach the error branch of `app.onError()`, so logging there would also silently drop those.
 
 ## Runtime compatibility
 

--- a/packages/structured-logger/README.md
+++ b/packages/structured-logger/README.md
@@ -28,6 +28,8 @@ app.use(requestId())
 app.use(
   structuredLogger({
     createLogger: (c) => rootLogger.child({ requestId: c.var.requestId }),
+    onRequest: (logger, c) =>
+      logger.info({ method: c.req.method, path: c.req.path }, 'incoming request'),
   })
 )
 
@@ -51,6 +53,8 @@ const app = new Hono()
 app.use(
   structuredLogger({
     createLogger: (c) => rootLogger.child({ requestId: c.var.requestId }),
+    onRequest: (logger, c) =>
+      logger.info({ method: c.req.method, path: c.req.path }, 'incoming request'),
   })
 )
 ```
@@ -66,6 +70,7 @@ const app = new Hono()
 app.use(
   structuredLogger({
     createLogger: () => console,
+    onRequest: (_logger, c) => console.info(c.req.method, c.req.path),
   })
 )
 ```
@@ -84,6 +89,7 @@ app.use(
   structuredLogger({
     createLogger: () => console,
     skip: (c) => c.req.path === '/health',
+    onRequest: (_logger, c) => console.info(c.req.method, c.req.path),
   })
 )
 ```
@@ -150,6 +156,8 @@ app.use(
   structuredLogger({
     createLogger: () => myLogger,
     contextKey: 'log',
+    onRequest: (logger, c) =>
+      logger.info({ method: c.req.method, path: c.req.path }, 'incoming request'),
   })
 )
 
@@ -172,7 +180,7 @@ const app = new Hono<StructuredLoggerEnv<pino.Logger>>()
 
 // Custom key — pass the same literal to both
 const app = new Hono<StructuredLoggerEnv<pino.Logger, 'log'>>()
-app.use(structuredLogger({ createLogger: ..., contextKey: 'log' }))
+app.use(structuredLogger({ createLogger: ..., contextKey: 'log', onRequest: ... }))
 ```
 
 `c.var.logger` (or the custom key) will then be typed as `pino.Logger` throughout the app.
@@ -187,6 +195,8 @@ type AppEnv = { Variables: { tenantId: string } }
 app.use(
   structuredLogger<AppEnv>({
     createLogger: (c) => rootLogger.child({ tenantId: c.var.tenantId }),
+    onRequest: (logger, c) =>
+      logger.info({ method: c.req.method, path: c.req.path }, 'incoming request'),
   })
 )
 ```
@@ -206,7 +216,7 @@ Returns a Hono `MiddlewareHandler`.
 | `createLogger` | `(c: Context) => L`                                                               | Yes      |            | Factory that creates a request scoped logger instance |
 | `contextKey`   | `K extends string`                                                                | No       | `'logger'` | Key used to store the logger on `c.var`               |
 | `skip`         | `(c: Context) => boolean`                                                         | No       | —          | When true, request passes through without logging     |
-| `onRequest`    | `(logger: L, c: Context) => void \| Promise<void>`                                | No       | —          | Called before handler execution                       |
+| `onRequest`    | `(logger: L, c: Context) => void \| Promise<void>`                                | Yes      | —          | Called before handler execution                       |
 | `onResponse`   | `(logger: L, c: Context, elapsedMs: number) => void \| Promise<void>`             | No       | —          | Called after handler execution                        |
 | `onError`      | `(logger: L, err: Error, c: Context, elapsedMs: number) => void \| Promise<void>` | No       | —          | Called when handler throws                            |
 

--- a/packages/structured-logger/README.md
+++ b/packages/structured-logger/README.md
@@ -201,14 +201,14 @@ Returns a Hono `MiddlewareHandler`.
 
 #### Options
 
-| Option         | Type                                                                              | Required | Default                                                          | Description                                           |
-| -------------- | --------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------- | ----------------------------------------------------- |
-| `createLogger` | `(c: Context) => L`                                                               | Yes      |                                                                  | Factory that creates a request scoped logger instance |
-| `contextKey`   | `K extends string`                                                                | No       | `'logger'`                                                       | Key used to store the logger on `c.var`               |
-| `skip`         | `(c: Context) => boolean`                                                         | No       | —                                                                | When true, request passes through without logging     |
-| `onRequest`    | `(logger: L, c: Context) => void \| Promise<void>`                                | No       | —                                                                | Called before handler execution                       |
-| `onResponse`   | `(logger: L, c: Context, elapsedMs: number) => void \| Promise<void>`             | No       | —                                                                | Called after handler execution                        |
-| `onError`      | `(logger: L, err: Error, c: Context, elapsedMs: number) => void \| Promise<void>` | No       | —                                                                | Called when handler throws                            |
+| Option         | Type                                                                              | Required | Default    | Description                                           |
+| -------------- | --------------------------------------------------------------------------------- | -------- | ---------- | ----------------------------------------------------- |
+| `createLogger` | `(c: Context) => L`                                                               | Yes      |            | Factory that creates a request scoped logger instance |
+| `contextKey`   | `K extends string`                                                                | No       | `'logger'` | Key used to store the logger on `c.var`               |
+| `skip`         | `(c: Context) => boolean`                                                         | No       | —          | When true, request passes through without logging     |
+| `onRequest`    | `(logger: L, c: Context) => void \| Promise<void>`                                | No       | —          | Called before handler execution                       |
+| `onResponse`   | `(logger: L, c: Context, elapsedMs: number) => void \| Promise<void>`             | No       | —          | Called after handler execution                        |
+| `onError`      | `(logger: L, err: Error, c: Context, elapsedMs: number) => void \| Promise<void>` | No       | —          | Called when handler throws                            |
 
 ## Behavior
 

--- a/packages/structured-logger/package.json
+++ b/packages/structured-logger/package.json
@@ -44,9 +44,11 @@
   },
   "devDependencies": {
     "hono": "^4.11.5",
+    "pino": "^10.3.1",
     "tsdown": "^0.22.3",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "winston": "^3.19.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/structured-logger/src/index.test.ts
+++ b/packages/structured-logger/src/index.test.ts
@@ -1,19 +1,12 @@
 import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
-import type { BaseLogger } from './index'
+import type { StructuredLoggerEnv } from './index'
 import { structuredLogger } from './index'
 
-type MockLogger = {
-  [K in keyof BaseLogger]: BaseLogger[K] & ReturnType<typeof vi.fn>
-}
+type MockLogger = ReturnType<typeof createMockLogger>
 
-function createMockLogger(): MockLogger {
-  return {
-    info: vi.fn() as MockLogger['info'],
-    warn: vi.fn() as MockLogger['warn'],
-    error: vi.fn() as MockLogger['error'],
-    debug: vi.fn() as MockLogger['debug'],
-  }
+function createMockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
 }
 
 describe('structuredLogger', () => {
@@ -37,7 +30,7 @@ describe('structuredLogger', () => {
       const mockLogger = createMockLogger()
       let capturedLogger: unknown = null
 
-      const app = new Hono<{ Variables: { logger: BaseLogger } }>()
+      const app = new Hono<StructuredLoggerEnv<MockLogger>>()
       app.use(structuredLogger({ createLogger: () => mockLogger }))
       app.get('/', (c) => {
         capturedLogger = c.var.logger
@@ -53,7 +46,7 @@ describe('structuredLogger', () => {
       const mockLogger = createMockLogger()
       let capturedLogger: unknown = null
 
-      const app = new Hono<{ Variables: { log: BaseLogger } }>()
+      const app = new Hono<StructuredLoggerEnv<MockLogger, 'log'>>()
       app.use(structuredLogger({ createLogger: () => mockLogger, contextKey: 'log' }))
       app.get('/', (c) => {
         capturedLogger = c.var.log
@@ -132,8 +125,33 @@ describe('structuredLogger', () => {
       await app.request('/')
 
       expect(onError).toHaveBeenCalledTimes(1)
-      expect(onError.mock.calls[0]?.[0]).toBe(mockLogger)
       expect(onError.mock.calls[0]?.[1]).toBe(handlerError)
+      expect(onError.mock.calls[0]?.[3]).toBeTypeOf('number')
+      expect(onError.mock.calls[0]?.[3] as number).toBeGreaterThanOrEqual(0)
+    })
+
+    it('passes elapsedMs as a number >= 0 to onError', async () => {
+      const mockLogger = createMockLogger()
+      let capturedElapsed: number | null = null
+
+      const app = new Hono()
+      app.use(
+        structuredLogger({
+          createLogger: () => mockLogger,
+          onError: (_logger, _err, _c, elapsedMs) => {
+            capturedElapsed = elapsedMs
+          },
+        })
+      )
+      app.get('/', () => {
+        throw new Error('fail')
+      })
+      app.onError((_err, c) => c.text('error', 500))
+
+      await app.request('/')
+
+      expect(capturedElapsed).toBeTypeOf('number')
+      expect(capturedElapsed).toBeGreaterThanOrEqual(0)
     })
 
     it('the error is still handled by app.onError', async () => {
@@ -192,65 +210,13 @@ describe('structuredLogger', () => {
     })
   })
 
-  describe('default hooks', () => {
-    it('default onRequest logs method and path via logger.info', async () => {
-      const mockLogger = createMockLogger()
-
-      const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger }))
-      app.get('/test', (c) => c.text('ok'))
-
-      await app.request('/test')
-
-      const infoCall = mockLogger.info.mock.calls[0]
-      expect(infoCall?.[0]).toEqual({ method: 'GET', path: '/test' })
-      expect(infoCall?.[1]).toBe('request start')
-    })
-
-    it('default onResponse logs status and elapsed via logger.info', async () => {
-      const mockLogger = createMockLogger()
-
-      const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger }))
-      app.get('/', (c) => c.text('ok'))
-
-      await app.request('/')
-
-      const lastInfoCall = mockLogger.info.mock.calls[mockLogger.info.mock.calls.length - 1]
-      expect(lastInfoCall?.[0]).toHaveProperty('method', 'GET')
-      expect(lastInfoCall?.[0]).toHaveProperty('path', '/')
-      expect(lastInfoCall?.[0]).toHaveProperty('status', 200)
-      expect(lastInfoCall?.[0]).toHaveProperty('elapsedMs')
-      expect(lastInfoCall?.[1]).toBe('request end')
-    })
-
-    it('default onError logs the error via logger.error', async () => {
-      const mockLogger = createMockLogger()
-
-      const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger }))
-      app.get('/', () => {
-        throw new Error('something broke')
-      })
-      app.onError((_err, c) => c.text('error', 500))
-
-      await app.request('/')
-
-      expect(mockLogger.error).toHaveBeenCalledTimes(1)
-      const errorCall = mockLogger.error.mock.calls[0]
-      expect(errorCall?.[0]).toHaveProperty('err')
-      expect(errorCall?.[0]).toHaveProperty('method', 'GET')
-      expect(errorCall?.[0]).toHaveProperty('path', '/')
-      expect(errorCall?.[0]).toHaveProperty('status', 500)
-      expect(errorCall?.[1]).toBe('request error')
-    })
-  })
-
   describe('integration', () => {
     it('requestId is accessible inside createLogger', async () => {
       let capturedRequestId: string | undefined
 
-      const app = new Hono<{ Variables: { requestId: string; logger: BaseLogger } }>()
+      type TestEnv = { Variables: { requestId: string } }
+
+      const app = new Hono<TestEnv>()
 
       // Simulate requestId middleware
       app.use(async (c, next) => {
@@ -259,9 +225,9 @@ describe('structuredLogger', () => {
       })
 
       app.use(
-        structuredLogger({
+        structuredLogger<TestEnv>({
           createLogger: (c) => {
-            capturedRequestId = c.var['requestId'] as string
+            capturedRequestId = c.var.requestId
             return createMockLogger()
           },
         })
@@ -278,8 +244,24 @@ describe('structuredLogger', () => {
       const adminLogger = createMockLogger()
 
       const app = new Hono()
-      app.use('/api/*', structuredLogger({ createLogger: () => apiLogger }))
-      app.use('/admin/*', structuredLogger({ createLogger: () => adminLogger }))
+      app.use(
+        '/api/*',
+        structuredLogger({
+          createLogger: () => apiLogger,
+          onRequest: (logger) => {
+            logger.info({}, 'request')
+          },
+        })
+      )
+      app.use(
+        '/admin/*',
+        structuredLogger({
+          createLogger: () => adminLogger,
+          onRequest: (logger) => {
+            logger.info({}, 'request')
+          },
+        })
+      )
 
       app.get('/api/data', (c) => c.text('api'))
       app.get('/admin/panel', (c) => c.text('admin'))
@@ -323,7 +305,7 @@ describe('structuredLogger', () => {
     })
 
     it('concurrent requests get separate logger instances', async () => {
-      const loggers: BaseLogger[] = []
+      const loggers: MockLogger[] = []
 
       const app = new Hono()
       app.use(
@@ -420,6 +402,57 @@ describe('structuredLogger', () => {
 
       expect(res.status).toBe(500)
       expect(await res.text()).toBe('onResponse blew up')
+    })
+  })
+
+  describe('skip', () => {
+    it('skips logging when skip returns true', async () => {
+      const createLogger = vi.fn(() => createMockLogger())
+
+      const app = new Hono()
+      app.use(structuredLogger({ createLogger, skip: () => true }))
+      app.get('/', (c) => c.text('ok'))
+
+      await app.request('/')
+
+      expect(createLogger).not.toHaveBeenCalled()
+    })
+
+    it('logs normally when skip returns false', async () => {
+      const createLogger = vi.fn(() => createMockLogger())
+
+      const app = new Hono()
+      app.use(structuredLogger({ createLogger, skip: () => false }))
+      app.get('/', (c) => c.text('ok'))
+
+      await app.request('/')
+
+      expect(createLogger).toHaveBeenCalledTimes(1)
+    })
+
+    it('still processes the request when skipped', async () => {
+      const app = new Hono()
+      app.use(structuredLogger({ createLogger: () => createMockLogger(), skip: () => true }))
+      app.get('/', (c) => c.text('ok'))
+
+      const res = await app.request('/')
+
+      expect(res.status).toBe(200)
+    })
+
+    it('can skip based on path', async () => {
+      const createLogger = vi.fn(() => createMockLogger())
+
+      const app = new Hono()
+      app.use(structuredLogger({ createLogger, skip: (c) => c.req.path === '/health' }))
+      app.get('/health', (c) => c.json({ status: 'ok' }))
+      app.get('/api/data', (c) => c.text('data'))
+
+      await app.request('/health')
+      expect(createLogger).not.toHaveBeenCalled()
+
+      await app.request('/api/data')
+      expect(createLogger).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/structured-logger/src/index.test.ts
+++ b/packages/structured-logger/src/index.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import type { StructuredLoggerEnv } from './index'
 import { structuredLogger } from './index'
 
@@ -16,7 +16,7 @@ describe('structuredLogger', () => {
       const createLogger = vi.fn(() => mockLogger)
       const app = new Hono()
 
-      app.use(structuredLogger({ createLogger, onRequest: vi.fn() }))
+      app.use(structuredLogger({ createLogger, onResponse: vi.fn() }))
       app.get('/', (c) => c.text('ok'))
 
       await app.request('/')
@@ -31,7 +31,7 @@ describe('structuredLogger', () => {
       let capturedLogger: unknown = null
 
       const app = new Hono<StructuredLoggerEnv<MockLogger>>()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn() }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onResponse: vi.fn() }))
       app.get('/', (c) => {
         capturedLogger = c.var.logger
         return c.text('ok')
@@ -48,7 +48,7 @@ describe('structuredLogger', () => {
 
       const app = new Hono<StructuredLoggerEnv<MockLogger, 'log'>>()
       app.use(
-        structuredLogger({ createLogger: () => mockLogger, contextKey: 'log', onRequest: vi.fn() })
+        structuredLogger({ createLogger: () => mockLogger, contextKey: 'log', onResponse: vi.fn() })
       )
       app.get('/', (c) => {
         capturedLogger = c.var.log
@@ -68,7 +68,6 @@ describe('structuredLogger', () => {
       app.use(
         structuredLogger({
           createLogger: () => mockLogger,
-          onRequest: vi.fn(),
           onResponse: (_logger, _c, elapsedMs) => {
             capturedElapsed = elapsedMs
           },
@@ -119,7 +118,7 @@ describe('structuredLogger', () => {
       const handlerError = new Error('handler failed')
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn(), onError }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onResponse: vi.fn(), onError }))
       app.get('/', () => {
         throw handlerError
       })
@@ -141,7 +140,7 @@ describe('structuredLogger', () => {
       app.use(
         structuredLogger({
           createLogger: () => mockLogger,
-          onRequest: vi.fn(),
+          onResponse: vi.fn(),
           onError: (_logger, _err, _c, elapsedMs) => {
             capturedElapsed = elapsedMs
           },
@@ -164,7 +163,7 @@ describe('structuredLogger', () => {
       let caughtError: unknown = null
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn() }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onResponse: vi.fn() }))
       app.get('/', () => {
         throw handlerError
       })
@@ -183,7 +182,7 @@ describe('structuredLogger', () => {
       const onError = vi.fn()
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn(), onError }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onResponse: vi.fn(), onError }))
       app.get('/', () => {
         throw new Error('typed error')
       })
@@ -202,7 +201,7 @@ describe('structuredLogger', () => {
       const onResponse = vi.fn()
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn(), onResponse }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onResponse }))
       app.get('/', () => {
         throw new Error('fail')
       })
@@ -230,7 +229,7 @@ describe('structuredLogger', () => {
 
       app.use(
         structuredLogger<TestEnv>({
-          onRequest: vi.fn(),
+          onResponse: vi.fn(),
           createLogger: (c) => {
             capturedRequestId = c.var.requestId
             return createMockLogger()
@@ -253,7 +252,7 @@ describe('structuredLogger', () => {
         '/api/*',
         structuredLogger({
           createLogger: () => apiLogger,
-          onRequest: (logger) => {
+          onResponse: (logger) => {
             logger.info({}, 'request')
           },
         })
@@ -262,7 +261,7 @@ describe('structuredLogger', () => {
         '/admin/*',
         structuredLogger({
           createLogger: () => adminLogger,
-          onRequest: (logger) => {
+          onResponse: (logger) => {
             logger.info({}, 'request')
           },
         })
@@ -315,7 +314,7 @@ describe('structuredLogger', () => {
       const app = new Hono()
       app.use(
         structuredLogger({
-          onRequest: vi.fn(),
+          onResponse: vi.fn(),
           createLogger: () => {
             const logger = createMockLogger()
             loggers.push(logger)
@@ -339,7 +338,7 @@ describe('structuredLogger', () => {
       const onResponse = vi.fn()
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn(), onResponse }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onResponse }))
       app.get('/', (c) => {
         return c.text('streamed content')
       })
@@ -357,7 +356,7 @@ describe('structuredLogger', () => {
           createLogger: () => {
             throw new Error('factory failed')
           },
-          onRequest: vi.fn(),
+          onResponse: vi.fn(),
         })
       )
       app.get('/', (c) => c.text('ok'))
@@ -379,6 +378,7 @@ describe('structuredLogger', () => {
           onRequest: () => {
             throw new Error('onRequest blew up')
           },
+          onResponse: vi.fn(),
         })
       )
       app.get('/', (c) => c.text('ok'))
@@ -397,7 +397,6 @@ describe('structuredLogger', () => {
       app.use(
         structuredLogger({
           createLogger: () => mockLogger,
-          onRequest: vi.fn(),
           onResponse: () => {
             throw new Error('onResponse blew up')
           },
@@ -413,29 +412,64 @@ describe('structuredLogger', () => {
     })
   })
 
-  describe('skip', () => {
-    it('skips logging when skip returns true', async () => {
-      const createLogger = vi.fn(() => createMockLogger())
-
-      const app = new Hono()
-      app.use(structuredLogger({ createLogger, skip: () => true, onRequest: vi.fn() }))
-      app.get('/', (c) => c.text('ok'))
-
-      await app.request('/')
-
-      expect(createLogger).not.toHaveBeenCalled()
+  describe('types', () => {
+    it('infers all logger type in hooks when type args are fully inferred', () => {
+      structuredLogger({
+        createLogger: () => createMockLogger(),
+        onRequest: (logger) => {
+          expectTypeOf(logger).toEqualTypeOf<MockLogger>()
+        },
+        onResponse: (logger) => {
+          expectTypeOf(logger).toEqualTypeOf<MockLogger>()
+        },
+        onError: (logger) => {
+          expectTypeOf(logger).toEqualTypeOf<MockLogger>()
+        },
+      })
     })
 
-    it('logs normally when skip returns false', async () => {
-      const createLogger = vi.fn(() => createMockLogger())
+    it('infers logger type in hooks when E and L are explicitly provided', () => {
+      type AppEnv = { Variables: { tenantId: string } }
+
+      structuredLogger<AppEnv, MockLogger>({
+        createLogger: (c) => {
+          expectTypeOf(c.var.tenantId).toEqualTypeOf<string>()
+          return createMockLogger()
+        },
+        onResponse: (logger) => {
+          expectTypeOf(logger).toEqualTypeOf<MockLogger>()
+        },
+      })
+    })
+  })
+
+  describe('skip', () => {
+    it('skips hooks when skip returns true', async () => {
+      const onResponse = vi.fn()
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger, skip: () => false, onRequest: vi.fn() }))
+      app.use(
+        structuredLogger({ createLogger: () => createMockLogger(), skip: () => true, onResponse })
+      )
       app.get('/', (c) => c.text('ok'))
 
       await app.request('/')
 
-      expect(createLogger).toHaveBeenCalledTimes(1)
+      expect(onResponse).not.toHaveBeenCalled()
+    })
+
+    it('calls hooks normally when skip returns false', async () => {
+      const onResponse = vi.fn()
+
+      const app = new Hono()
+      app.use(
+        structuredLogger({ createLogger: () => createMockLogger(), skip: () => false, onResponse })
+      )
+      app.get('/', (c) => c.text('ok'))
+
+      await app.request('/')
+
+      expect(onResponse).toHaveBeenCalledTimes(1)
     })
 
     it('still processes the request when skipped', async () => {
@@ -444,7 +478,7 @@ describe('structuredLogger', () => {
         structuredLogger({
           createLogger: () => createMockLogger(),
           skip: () => true,
-          onRequest: vi.fn(),
+          onResponse: vi.fn(),
         })
       )
       app.get('/', (c) => c.text('ok'))
@@ -454,25 +488,43 @@ describe('structuredLogger', () => {
       expect(res.status).toBe(200)
     })
 
-    it('can skip based on path', async () => {
-      const createLogger = vi.fn(() => createMockLogger())
+    it('c.var.logger is still set when skip returns true', async () => {
+      let capturedLogger: unknown = null
+
+      const app = new Hono<StructuredLoggerEnv<MockLogger>>()
+      const mockLogger = createMockLogger()
+      app.use(
+        structuredLogger({ createLogger: () => mockLogger, skip: () => true, onResponse: vi.fn() })
+      )
+      app.get('/', (c) => {
+        capturedLogger = c.var.logger
+        return c.text('ok')
+      })
+
+      await app.request('/')
+
+      expect(capturedLogger).toBe(mockLogger)
+    })
+
+    it('can skip hooks based on path', async () => {
+      const onResponse = vi.fn()
 
       const app = new Hono()
       app.use(
         structuredLogger({
-          createLogger,
+          createLogger: () => createMockLogger(),
           skip: (c) => c.req.path === '/health',
-          onRequest: vi.fn(),
+          onResponse,
         })
       )
       app.get('/health', (c) => c.json({ status: 'ok' }))
       app.get('/api/data', (c) => c.text('data'))
 
       await app.request('/health')
-      expect(createLogger).not.toHaveBeenCalled()
+      expect(onResponse).not.toHaveBeenCalled()
 
       await app.request('/api/data')
-      expect(createLogger).toHaveBeenCalledTimes(1)
+      expect(onResponse).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/structured-logger/src/index.test.ts
+++ b/packages/structured-logger/src/index.test.ts
@@ -16,7 +16,7 @@ describe('structuredLogger', () => {
       const createLogger = vi.fn(() => mockLogger)
       const app = new Hono()
 
-      app.use(structuredLogger({ createLogger }))
+      app.use(structuredLogger({ createLogger, onRequest: vi.fn() }))
       app.get('/', (c) => c.text('ok'))
 
       await app.request('/')
@@ -31,7 +31,7 @@ describe('structuredLogger', () => {
       let capturedLogger: unknown = null
 
       const app = new Hono<StructuredLoggerEnv<MockLogger>>()
-      app.use(structuredLogger({ createLogger: () => mockLogger }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn() }))
       app.get('/', (c) => {
         capturedLogger = c.var.logger
         return c.text('ok')
@@ -47,7 +47,9 @@ describe('structuredLogger', () => {
       let capturedLogger: unknown = null
 
       const app = new Hono<StructuredLoggerEnv<MockLogger, 'log'>>()
-      app.use(structuredLogger({ createLogger: () => mockLogger, contextKey: 'log' }))
+      app.use(
+        structuredLogger({ createLogger: () => mockLogger, contextKey: 'log', onRequest: vi.fn() })
+      )
       app.get('/', (c) => {
         capturedLogger = c.var.log
         return c.text('ok')
@@ -66,6 +68,7 @@ describe('structuredLogger', () => {
       app.use(
         structuredLogger({
           createLogger: () => mockLogger,
+          onRequest: vi.fn(),
           onResponse: (_logger, _c, elapsedMs) => {
             capturedElapsed = elapsedMs
           },
@@ -116,7 +119,7 @@ describe('structuredLogger', () => {
       const handlerError = new Error('handler failed')
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onError }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn(), onError }))
       app.get('/', () => {
         throw handlerError
       })
@@ -138,6 +141,7 @@ describe('structuredLogger', () => {
       app.use(
         structuredLogger({
           createLogger: () => mockLogger,
+          onRequest: vi.fn(),
           onError: (_logger, _err, _c, elapsedMs) => {
             capturedElapsed = elapsedMs
           },
@@ -160,7 +164,7 @@ describe('structuredLogger', () => {
       let caughtError: unknown = null
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn() }))
       app.get('/', () => {
         throw handlerError
       })
@@ -179,7 +183,7 @@ describe('structuredLogger', () => {
       const onError = vi.fn()
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onError }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn(), onError }))
       app.get('/', () => {
         throw new Error('typed error')
       })
@@ -198,7 +202,7 @@ describe('structuredLogger', () => {
       const onResponse = vi.fn()
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onResponse }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn(), onResponse }))
       app.get('/', () => {
         throw new Error('fail')
       })
@@ -226,6 +230,7 @@ describe('structuredLogger', () => {
 
       app.use(
         structuredLogger<TestEnv>({
+          onRequest: vi.fn(),
           createLogger: (c) => {
             capturedRequestId = c.var.requestId
             return createMockLogger()
@@ -310,6 +315,7 @@ describe('structuredLogger', () => {
       const app = new Hono()
       app.use(
         structuredLogger({
+          onRequest: vi.fn(),
           createLogger: () => {
             const logger = createMockLogger()
             loggers.push(logger)
@@ -333,7 +339,7 @@ describe('structuredLogger', () => {
       const onResponse = vi.fn()
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => mockLogger, onResponse }))
+      app.use(structuredLogger({ createLogger: () => mockLogger, onRequest: vi.fn(), onResponse }))
       app.get('/', (c) => {
         return c.text('streamed content')
       })
@@ -351,6 +357,7 @@ describe('structuredLogger', () => {
           createLogger: () => {
             throw new Error('factory failed')
           },
+          onRequest: vi.fn(),
         })
       )
       app.get('/', (c) => c.text('ok'))
@@ -390,6 +397,7 @@ describe('structuredLogger', () => {
       app.use(
         structuredLogger({
           createLogger: () => mockLogger,
+          onRequest: vi.fn(),
           onResponse: () => {
             throw new Error('onResponse blew up')
           },
@@ -410,7 +418,7 @@ describe('structuredLogger', () => {
       const createLogger = vi.fn(() => createMockLogger())
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger, skip: () => true }))
+      app.use(structuredLogger({ createLogger, skip: () => true, onRequest: vi.fn() }))
       app.get('/', (c) => c.text('ok'))
 
       await app.request('/')
@@ -422,7 +430,7 @@ describe('structuredLogger', () => {
       const createLogger = vi.fn(() => createMockLogger())
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger, skip: () => false }))
+      app.use(structuredLogger({ createLogger, skip: () => false, onRequest: vi.fn() }))
       app.get('/', (c) => c.text('ok'))
 
       await app.request('/')
@@ -432,7 +440,13 @@ describe('structuredLogger', () => {
 
     it('still processes the request when skipped', async () => {
       const app = new Hono()
-      app.use(structuredLogger({ createLogger: () => createMockLogger(), skip: () => true }))
+      app.use(
+        structuredLogger({
+          createLogger: () => createMockLogger(),
+          skip: () => true,
+          onRequest: vi.fn(),
+        })
+      )
       app.get('/', (c) => c.text('ok'))
 
       const res = await app.request('/')
@@ -444,7 +458,13 @@ describe('structuredLogger', () => {
       const createLogger = vi.fn(() => createMockLogger())
 
       const app = new Hono()
-      app.use(structuredLogger({ createLogger, skip: (c) => c.req.path === '/health' }))
+      app.use(
+        structuredLogger({
+          createLogger,
+          skip: (c) => c.req.path === '/health',
+          onRequest: vi.fn(),
+        })
+      )
       app.get('/health', (c) => c.json({ status: 'ok' }))
       app.get('/api/data', (c) => c.text('data'))
 

--- a/packages/structured-logger/src/index.ts
+++ b/packages/structured-logger/src/index.ts
@@ -36,7 +36,7 @@ export interface StructuredLoggerOptions<
   skip?: (c: Context<E>) => boolean
 
   /** Called after logger creation, before handler execution. */
-  onRequest?: (logger: L, c: LoggedContext<E, L, K>) => void | Promise<void>
+  onRequest: (logger: L, c: LoggedContext<E, L, K>) => void | Promise<void>
 
   /** Called after handler execution with elapsed time in ms. */
   onResponse?: (logger: L, c: LoggedContext<E, L, K>, elapsedMs: number) => void | Promise<void>
@@ -66,9 +66,7 @@ export function structuredLogger<E extends Env = {}, L = unknown, K extends stri
     c.set(contextKey as never, logger as never)
     const ctx = c as LoggedContext<E, L, K>
 
-    if (onRequest) {
-      await onRequest(logger, ctx)
-    }
+    await onRequest(logger, ctx)
 
     const start = now()
 

--- a/packages/structured-logger/src/index.ts
+++ b/packages/structured-logger/src/index.ts
@@ -32,14 +32,14 @@ export interface StructuredLoggerOptions<
    */
   contextKey?: K
 
-  /** Called before createLogger, when this returns true the request is not logged. */
+  /** When this returns true, hooks are suppressed but the logger is still created and set on context. */
   skip?: (c: Context<E>) => boolean
 
   /** Called after logger creation, before handler execution. */
-  onRequest: (logger: L, c: LoggedContext<E, L, K>) => void | Promise<void>
+  onRequest?: (logger: L, c: LoggedContext<E, L, K>) => void | Promise<void>
 
   /** Called after handler execution with elapsed time in ms. */
-  onResponse?: (logger: L, c: LoggedContext<E, L, K>, elapsedMs: number) => void | Promise<void>
+  onResponse: (logger: L, c: LoggedContext<E, L, K>, elapsedMs: number) => void | Promise<void>
 
   /** Called when an error occurs during handler execution, with elapsed time in ms. */
   onError?: (
@@ -58,15 +58,17 @@ export function structuredLogger<E extends Env = {}, L = unknown, K extends stri
   const { createLogger, contextKey = defaultKey, skip, onRequest, onResponse, onError } = options
 
   return async (c, next) => {
-    if (skip && skip(c)) {
-      return next()
-    }
-
     const logger = createLogger(c)
     c.set(contextKey as never, logger as never)
     const ctx = c as LoggedContext<E, L, K>
 
-    await onRequest(logger, ctx)
+    if (skip && skip(c)) {
+      return next()
+    }
+
+    if (onRequest) {
+      await onRequest(logger, ctx)
+    }
 
     const start = now()
 
@@ -78,7 +80,7 @@ export function structuredLogger<E extends Env = {}, L = unknown, K extends stri
       if (onError) {
         await onError(logger, c.error, ctx, elapsed)
       }
-    } else if (onResponse) {
+    } else {
       await onResponse(logger, ctx, elapsed)
     }
   }

--- a/packages/structured-logger/src/index.ts
+++ b/packages/structured-logger/src/index.ts
@@ -3,99 +3,85 @@
  * Structured Logger Middleware for Hono.
  */
 
-import type { Context, MiddlewareHandler } from 'hono'
+import type { Context, Env, MiddlewareHandler } from 'hono'
 
-/**
- * Minimal logger interface compatible with pino, winston, console, bunyan, etc.
- */
-export interface BaseLogger {
-  info(obj: unknown, msg?: string, ...args: unknown[]): void
-  warn(obj: unknown, msg?: string, ...args: unknown[]): void
-  error(obj: unknown, msg?: string, ...args: unknown[]): void
-  debug(obj: unknown, msg?: string, ...args: unknown[]): void
+const defaultKey = 'logger' as const
+
+type DefaultKey = typeof defaultKey
+
+export type StructuredLoggerEnv<L, K extends string = DefaultKey> = Env & {
+  Variables: { [P in K]: L }
 }
 
-export interface StructuredLoggerOptions<L extends BaseLogger = BaseLogger> {
+type LoggedContext<E extends Env, L, K extends string> = Context<StructuredLoggerEnv<L, K> & E>
+
+export interface StructuredLoggerOptions<
+  E extends Env = {},
+  L = unknown,
+  K extends string = DefaultKey,
+> {
   /**
    * Factory function that creates a request scoped logger.
    * Receives the Hono context so you can inject requestId, headers, etc.
    */
-  createLogger: (c: Context) => L
+  createLogger: (c: Context<E>) => L
 
   /**
    * Key used to store the logger instance on c.var.
    * @default 'logger'
    */
-  contextKey?: string
+  contextKey?: K
 
-  /**
-   * Called after logger creation, before handler execution.
-   * Use for logging request start, incoming headers, etc.
-   * Default: logs method + path at info level.
-   */
-  onRequest?: (logger: L, c: Context) => void | Promise<void>
+  /** Called before createLogger, when this returns true the request is not logged. */
+  skip?: (c: Context<E>) => boolean
 
-  /**
-   * Called after handler execution with elapsed time in ms.
-   * Use for logging response status, duration, etc.
-   * Default: logs status + elapsed at info level.
-   */
-  onResponse?: (logger: L, c: Context, elapsedMs: number) => void | Promise<void>
+  /** Called after logger creation, before handler execution. */
+  onRequest?: (logger: L, c: LoggedContext<E, L, K>) => void | Promise<void>
 
-  /**
-   * Called when an error occurs during handler execution.
-   * Default: logs error at error level.
-   */
-  onError?: (logger: L, err: Error, c: Context) => void | Promise<void>
+  /** Called after handler execution with elapsed time in ms. */
+  onResponse?: (logger: L, c: LoggedContext<E, L, K>, elapsedMs: number) => void | Promise<void>
+
+  /** Called when an error occurs during handler execution, with elapsed time in ms. */
+  onError?: (
+    logger: L,
+    err: Error,
+    c: LoggedContext<E, L, K>,
+    elapsedMs: number
+  ) => void | Promise<void>
 }
 
 const now = typeof performance !== 'undefined' ? () => performance.now() : () => Date.now()
 
-function defaultOnRequest(logger: BaseLogger, c: Context): void {
-  logger.info({ method: c.req.method, path: c.req.path }, 'request start')
-}
-
-function defaultOnResponse(logger: BaseLogger, c: Context, elapsedMs: number): void {
-  logger.info(
-    { method: c.req.method, path: c.req.path, status: c.res.status, elapsedMs },
-    'request end'
-  )
-}
-
-function defaultOnError(logger: BaseLogger, err: Error, c: Context): void {
-  logger.error(
-    { err, method: c.req.method, path: c.req.path, status: c.res.status },
-    'request error'
-  )
-}
-
-export function structuredLogger<L extends BaseLogger = BaseLogger>(
-  options: StructuredLoggerOptions<L>
-): MiddlewareHandler {
-  const {
-    createLogger,
-    contextKey = 'logger',
-    onRequest = defaultOnRequest,
-    onResponse = defaultOnResponse,
-    onError = defaultOnError,
-  } = options
+export function structuredLogger<E extends Env = {}, L = unknown, K extends string = DefaultKey>(
+  options: StructuredLoggerOptions<E, L, K>
+): MiddlewareHandler<E> {
+  const { createLogger, contextKey = defaultKey, skip, onRequest, onResponse, onError } = options
 
   return async (c, next) => {
+    if (skip && skip(c)) {
+      return next()
+    }
+
     const logger = createLogger(c)
     c.set(contextKey as never, logger as never)
+    const ctx = c as LoggedContext<E, L, K>
+
+    if (onRequest) {
+      await onRequest(logger, ctx)
+    }
 
     const start = now()
-
-    await onRequest(logger, c)
 
     await next()
 
     const elapsed = now() - start
 
     if (c.error) {
-      await onError(logger, c.error instanceof Error ? c.error : new Error(String(c.error)), c)
-    } else {
-      await onResponse(logger, c, elapsed)
+      if (onError) {
+        await onError(logger, c.error, ctx, elapsed)
+      }
+    } else if (onResponse) {
+      await onResponse(logger, ctx, elapsed)
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,9 @@ importers:
       hono:
         specifier: ^4.11.5
         version: 4.12.28
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       tsdown:
         specifier: ^0.22.3
         version: 0.22.4(@arethetypeswrong/core@0.18.4)(@typescript/typescript6@6.0.2)(publint@0.3.21)
@@ -833,6 +836,9 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(msw@2.15.0(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(yaml@2.9.0))
+      winston:
+        specifier: ^3.19.0
+        version: 3.19.0
 
   packages/stytch-auth:
     devDependencies:
@@ -2181,6 +2187,9 @@ packages:
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -3319,6 +3328,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   await-lock@2.2.2:
     resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
@@ -5534,6 +5547,10 @@ packages:
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -5744,6 +5761,16 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -5819,6 +5846,9 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process-warning@5.1.0:
+    resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -5890,6 +5920,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -5963,6 +5996,13 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -6211,6 +6251,9 @@ packages:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -6402,6 +6445,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -8337,6 +8384,8 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -9249,6 +9298,8 @@ snapshots:
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
 
   await-lock@2.2.2: {}
 
@@ -11859,6 +11910,8 @@ snapshots:
       node-fetch-native: 1.6.7
       ufo: 1.6.4
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -12070,6 +12123,26 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
+
   pkce-challenge@5.0.1: {}
 
   pkg-dir@7.0.0:
@@ -12132,6 +12205,8 @@ snapshots:
     optional: true
 
   process-nextick-args@2.0.1: {}
+
+  process-warning@5.1.0: {}
 
   process@0.11.10: {}
 
@@ -12213,6 +12288,8 @@ snapshots:
   quansync@1.0.0: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   radix3@1.1.2: {}
 
@@ -12307,6 +12384,10 @@ snapshots:
       picomatch: 2.3.2
 
   readdirp@5.0.0: {}
+
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -12673,6 +12754,10 @@ snapshots:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.6.1:
@@ -12909,6 +12994,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
 
   through@2.3.8: {}
 


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

Using this middleware, I noticed a handful of rough edges..

- `BaseLogger` doesn't allow libraries that use a different log signature
- Hooks aren't typed; `onRequest`, `onResponse`, `onError` do not pass `Context<Env>` so types go missing
- The default hooks don't provide much value so are nearly always overridden

After playing around with a few different approaches, I landed on the following breaking changes

- Removing the `BaseLogger` interface, it was only needed because the default hooks used it. Without the default hooks, we no longer need the interface, allowing any kind of logging library to be used.
- The default hooks used properties such as `{ method, path, status, elapsedMs, err,  }`, but I think most consumers would provide their own hooks

With those two changes, the middleware now has the correct types, with the one caveat that consumers now have to provide their own hooks.

The one feature I did add is a `skip` method to not log certain requests. I included all the changes in one PR so others can see the whole thing.

Also @gabry-ts and @jansepke, if you're interested in having a look