### PR TITLE
docs(standard-validator): add `Grouping errors` section

### DIFF
--- a/.changeset/wet-paths-design.md
+++ b/.changeset/wet-paths-design.md
@@ -1,0 +1,5 @@
+---
+'@hono/standard-validator': minor
+---
+
+Document `flattenErrors`

--- a/.changeset/wet-paths-design.md
+++ b/.changeset/wet-paths-design.md
@@ -1,5 +1,0 @@
----
-'@hono/standard-validator': minor
----
-
-Document `flattenErrors`

--- a/packages/standard-validator/README.md
+++ b/packages/standard-validator/README.md
@@ -118,25 +118,21 @@ This validator returns ungrouped errors, which can be inconvenient when mapping 
 To group them, use `flattenErrors` inside a `sValidator` hook:
 
 ```ts
-/*
-  Install the Standard Schema interface from npm or JSR,
-  or copy it from https://standardschema.dev/schema
-*/
-import type { StandardSchemaV1 } from '@standard-schema/spec'
-
-import type { ValidationTargets } from 'hono'
 import { flattenErrors, sValidator } from '@hono/standard-validator'
 
-export const validate = <Target extends keyof ValidationTargets, Schema extends StandardSchemaV1>(
-  target: Target,
-  schema: Schema
-) =>
-  sValidator(target, schema, (result, c) => {
+// ...schema
+
+app.post(
+  '/author',
+  sValidator('json', schema, (result, c) => {
     if (!result.success) {
-      const flattenedError = flattenErrors(result.error)
-      return c.json(flattenedError, 400)
+      return c.json(flattenErrors(result.error), 400)
     }
-  })
+  }),
+  (c) => {
+    // ...
+  }
+)
 ```
 
 Now, error messages are grouped by field as arrays under the `fieldErrors` property. As for unknown keys or root-level issues, they go inside `fieldErrors` or `formErrors`, depending on the validation library you use:

--- a/packages/standard-validator/README.md
+++ b/packages/standard-validator/README.md
@@ -70,6 +70,98 @@ To infer the input type of a validated target, import `InferInput` from `hono/va
 import type { InferInput } from 'hono/validator'
 ```
 
+## Grouping errors
+
+This validator returns ungrouped errors, which can be inconvenient when mapping errors to form fields:
+
+```json
+{
+  "data": {
+    "name": "john doe",
+    "age": "twenty",
+    "role": "admin"
+  },
+  "error": [
+    {
+      "origin": "string",
+      "code": "too_big",
+      "maximum": 4,
+      "inclusive": true,
+      "path": ["name"],
+      "message": "Name is too long"
+    },
+    {
+      "origin": "string",
+      "code": "invalid_format",
+      "format": "regex",
+      "pattern": "/^[0-9A-Za-z_]+$/",
+      "path": ["name"],
+      "message": "Name must only contain alphanumeric characters"
+    },
+    {
+      "expected": "number",
+      "code": "invalid_type",
+      "path": ["age"],
+      "message": "Age must be a number"
+    },
+    {
+      "code": "unrecognized_keys",
+      "keys": ["role"],
+      "path": [],
+      "message": "Unrecognized key: \"role\""
+    }
+  ],
+  "success": false
+}
+```
+
+To group them, use `flattenErrors` inside a `sValidator` hook:
+
+```ts
+/*
+  Install the Standard Schema interface from npm or JSR,
+  or copy it from https://standardschema.dev/schema
+*/
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
+import type { ValidationTargets } from 'hono'
+import { flattenErrors, sValidator } from '@hono/standard-validator'
+
+export const validate = <Target extends keyof ValidationTargets, Schema extends StandardSchemaV1>(
+  target: Target,
+  schema: Schema
+) =>
+  sValidator(target, schema, (result, c) => {
+    if (!result.success) {
+      const flattenedError = flattenErrors(result.error)
+      return c.json(flattenedError, 400)
+    }
+  })
+```
+
+Now, error messages are grouped by field as arrays under the `fieldErrors` property. As for unknown keys or root-level issues, they go inside `fieldErrors` or `formErrors`, depending on the validation library you use:
+
+```jsonc
+// Zod
+{
+  "formErrors": ["Unrecognized key: \"role\""],
+  "fieldErrors": {
+    "name": ["Name is too long", "Name must only contain alphanumeric characters"],
+    "age": ["Age must be a number"],
+  },
+}
+
+// Valibot
+{
+  "formErrors": [],
+  "fieldErrors": {
+    "name": ["Name is too long", "Name must only contain alphanumeric characters"],
+    "age": ["Age must be a number"],
+    "role": ["Invalid key: Expected never but received \"role\""]
+  },
+}
+```
+
 ## Author
 
 Rokas Muningis <https://github.com/muningis>


### PR DESCRIPTION
### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)

Document the new `flattenErrors` utility.