### PR TITLE
feat(oauth-providers): add OpenStreetMap OAuth 2.0 provider

### DIFF
--- a/.changeset/lucky-pandas-tickle.md
+++ b/.changeset/lucky-pandas-tickle.md
@@ -1,0 +1,7 @@
+---
+'@hono/oauth-providers': minor
+---
+
+Add an OpenStreetMap OAuth 2.0 provider, available as `@hono/oauth-providers/openstreetmap`. The
+flow always uses PKCE with the `S256` challenge method, and `revokeToken` is exported to invalidate
+tokens, which OpenStreetMap never expires on its own.

--- a/packages/oauth-providers/README.md
+++ b/packages/oauth-providers/README.md
@@ -1209,6 +1209,145 @@ app.get('/msentra/refresh', (c, next) => {
 })
 ```
 
+### OpenStreetMap
+
+```ts
+import { Hono } from 'hono'
+import { openstreetmapAuth } from '@hono/oauth-providers/openstreetmap'
+
+const app = new Hono()
+
+app.use(
+  '/openstreetmap',
+  openstreetmapAuth({
+    client_id: process.env.OPENSTREETMAP_ID,
+    client_secret: process.env.OPENSTREETMAP_SECRET,
+    scope: ['read_prefs'],
+  })
+)
+
+export default app
+```
+
+Register your application on the [OAuth 2 applications page](https://www.openstreetmap.org/oauth2/applications)
+of your OpenStreetMap account to obtain the client ID and secret.
+
+#### Parameters
+
+- `client_id`:
+  - Type: `string`.
+  - `Required`.
+  - Your app client ID. You can find this value on the [OAuth 2 applications page](https://www.openstreetmap.org/oauth2/applications).<br />When developing **Cloudflare Workers**, there's no need to send this parameter. Just declare it in the `wrangler.toml` file as `OPENSTREETMAP_ID=`.
+- `client_secret`:
+  - Type: `string`.
+  - `Required`.
+  - Your app client secret. You can find this value on the [OAuth 2 applications page](https://www.openstreetmap.org/oauth2/applications).<br />When developing **Cloudflare Workers**, there's no need to send this parameter. Just declare it in the `wrangler.toml` file as `OPENSTREETMAP_SECRET=`.
+    > ⚠️ Do **not** share your **client secret** to ensure the security of your app.
+- `scope`:
+  - Type: `OpenStreetMapScope[]`.
+  - `Required`.
+  - Set of **permissions** to request the user's authorization to access your app for retrieving user information and performing actions on their behalf. Review all the scopes OpenStreetMap offers on the [OAuth wiki page](https://wiki.openstreetmap.org/wiki/OAuth).
+    > `read_prefs` is required to read the user details, so `user-openstreetmap` stays `undefined` without it.
+    > `read_email` is a privileged scope that OpenStreetMap only offers to applications registered by a site administrator, so `user-openstreetmap.email` is usually `undefined`.
+- `state`:
+  - Type: `string`.
+  - `Optional`.
+  - A value to be returned unchanged in the redirect back to your app. Defaults to a random value used as the anti-CSRF token of the flow.
+- `redirect_uri`:
+  - Type: `string`.
+  - `Optional`.
+  - The URL OpenStreetMap redirects the user back to. Defaults to the route the middleware is used on, and has to match one of the redirect URIs registered for your application.
+
+The middleware always uses **PKCE** with the `S256` challenge method, so it works with both
+confidential and public OpenStreetMap applications.
+
+#### Authentication Flow
+
+After the completion of the OpenStreetMap OAuth flow, essential data has been prepared for use in
+the subsequent steps that your app needs to take.
+
+`openstreetmapAuth` method provides 3 set key data:
+
+- `token`:
+  - Access token to make requests to the OpenStreetMap API for retrieving user information and
+    performing actions on their behalf.
+  - Type:
+    ```
+    {
+      token: string
+    }
+    ```
+    > OpenStreetMap access tokens do not expire, so neither `expires_in` nor a `refresh-token` is
+    > provided. Use `revokeToken` to invalidate a token.
+- `granted-scopes`:
+  - Scopes for which the user has granted permissions.
+  - Type: `string[]`.
+- `user-openstreetmap`:
+  - User basic info retrieved from OpenStreetMap.
+  - Type:
+    ```
+    {
+      id: number
+      display_name: string
+      account_created: string
+      description?: string
+      company?: string
+      social_links: { url: string; platform: string }[]
+      contributor_terms: { agreed: boolean; pd: boolean }
+      img: { href?: string }
+      roles: string[]
+      changesets: { count: number }
+      traces: { count: number }
+      blocks: {
+        received: { count: number; active: number }
+        issued?: { count: number; active: number }
+      }
+      home?: { lat: number; lon: number; zoom: number }
+      languages?: string[]
+      messages: {
+        received: { count: number; unread: number }
+        sent: { count: number }
+      }
+      email?: string
+    }
+    ```
+    > `email` is only present when the `read_email` scope has been granted, and `issued` blocks are
+    > only present for moderators.
+
+> [!NOTE]
+> To access this data, utilize the `c.get` method within the callback of the upcoming HTTP request
+> handler.
+
+```ts
+app.get('/openstreetmap', (c) => {
+  const token = c.get('token')
+  const grantedScopes = c.get('granted-scopes')
+  const user = c.get('user-openstreetmap')
+
+  return c.json({
+    token,
+    grantedScopes,
+    user,
+  })
+})
+```
+
+#### Revoke Token
+
+Since OpenStreetMap access tokens never expire on their own, revoke them when the user signs out of
+your app. The `revokeToken` method accepts the `client_id`, `client_secret` and the `token` as
+parameters.
+
+```ts
+import { openstreetmapAuth, revokeToken } from '@hono/oauth-providers/openstreetmap'
+
+app.post('/openstreetmap/revoke', async (c) => {
+  const revoked = await revokeToken(client_id, client_secret, token)
+
+  return c.json({ revoked })
+})
+```
+
 ## Advance Usage
 
 ### Customize `redirect_uri`

--- a/packages/oauth-providers/deno.json
+++ b/packages/oauth-providers/deno.json
@@ -10,6 +10,7 @@
     "./google": "./src/providers/google/index.ts",
     "./linkedin": "./src/providers/linkedin/index.ts",
     "./msentra": "./src/providers/msentra/index.ts",
+    "./openstreetmap": "./src/providers/openstreetmap/index.ts",
     "./twitch": "./src/providers/twitch/index.ts",
     "./x": "./src/providers/x/index.ts"
   },

--- a/packages/oauth-providers/mocks.ts
+++ b/packages/oauth-providers/mocks.ts
@@ -16,6 +16,10 @@ import type {
   MSEntraUser,
 } from './src/providers/msentra'
 import type {
+  OpenStreetMapErrorResponse,
+  OpenStreetMapTokenResponse,
+} from './src/providers/openstreetmap'
+import type {
   TwitchErrorResponse,
   TwitchTokenResponse,
   TwitchTokenSuccess,
@@ -235,6 +239,30 @@ export const handlers = [
       return HttpResponse.json(msentraCodeError)
     }
   ),
+  // OpenStreetMap
+  http.post('https://www.openstreetmap.org/oauth2/token', async ({ request }) => {
+    const body = new URLSearchParams(await request.text())
+    // OpenStreetMap only supports the authorization code flow, with PKCE.
+    if (body.get('code') === dummyCode && body.get('code_verifier')) {
+      return HttpResponse.json(openStreetMapToken)
+    }
+    return HttpResponse.json(openStreetMapCodeError, { status: 400 })
+  }),
+  http.get('https://api.openstreetmap.org/api/0.6/user/details.json', ({ request }) => {
+    if (request.headers.get('authorization') !== `Bearer ${openStreetMapToken.access_token}`) {
+      // The OpenStreetMap API answers with a plain text body on error.
+      return HttpResponse.text(openStreetMapUserError, { status: 401 })
+    }
+    return HttpResponse.json(openStreetMapUserResponse)
+  }),
+  http.post('https://www.openstreetmap.org/oauth2/revoke', async ({ request }) => {
+    const body = new URLSearchParams(await request.text())
+    if (body.get('token') !== openStreetMapToken.access_token) {
+      return HttpResponse.json(openStreetMapRevokeTokenError, { status: 403 })
+    }
+    // RFC 7009 mandates an empty 200 response for a successful revocation.
+    return HttpResponse.json({}, { status: 200 })
+  }),
 ]
 
 export const dummyCode = '4/0AfJohXl9tS46EmTA6u9x3pJQiyCNyahx4DLJaeJelzJ0E5KkT4qJmCtjq9n3FxBvO40ofg'
@@ -613,3 +641,84 @@ export const msentraCodeError = {
   error_description: 'AADSTS1234567: Invalid request.',
   error_codes: [1234567],
 }
+
+// OpenStreetMap access tokens do not expire, so the token response carries
+// neither `expires_in` nor `refresh_token`.
+export const openStreetMapToken = {
+  access_token: 'JvKtCjxJs0h1rDxHNCyoW2LqTNsMUHQPfQ8m1nsRtUw',
+  token_type: 'Bearer',
+  scope: 'read_prefs write_api read_email',
+  created_at: 1727000000,
+} satisfies OpenStreetMapTokenResponse
+
+export const openStreetMapUser = {
+  id: 1234,
+  display_name: 'hono-osm-user',
+  account_created: '2013-04-01T12:34:56Z',
+  description: 'An OpenStreetMap contributor.',
+  company: 'Hono',
+  social_links: [
+    {
+      url: 'https://hono.dev',
+      platform: 'website',
+    },
+  ],
+  contributor_terms: {
+    agreed: true,
+    pd: false,
+  },
+  img: {
+    href: 'https://www.openstreetmap.org/attachments/users/images/000/001/234/original/avatar.png',
+  },
+  roles: [],
+  changesets: {
+    count: 4321,
+  },
+  traces: {
+    count: 12,
+  },
+  blocks: {
+    received: {
+      count: 0,
+      active: 0,
+    },
+  },
+  home: {
+    lat: 35.681236,
+    lon: 139.767125,
+    zoom: 12,
+  },
+  languages: ['ja', 'en'],
+  messages: {
+    received: {
+      count: 7,
+      unread: 1,
+    },
+    sent: {
+      count: 3,
+    },
+  },
+  email: 'example@openstreetmap.org',
+}
+
+export const openStreetMapUserResponse = {
+  version: '0.6',
+  generator: 'OpenStreetMap server',
+  copyright: 'OpenStreetMap and contributors',
+  attribution: 'https://www.openstreetmap.org/copyright',
+  license: 'https://opendatacommons.org/licenses/odbl/1-0/',
+  user: openStreetMapUser,
+}
+
+export const openStreetMapCodeError = {
+  error: 'invalid_grant',
+  error_description:
+    'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.',
+} satisfies OpenStreetMapErrorResponse
+
+export const openStreetMapUserError = "Couldn't authenticate you"
+
+export const openStreetMapRevokeTokenError = {
+  error: 'unauthorized_client',
+  error_description: 'The client is not authorized to perform this request.',
+} satisfies OpenStreetMapErrorResponse

--- a/packages/oauth-providers/mocks.ts
+++ b/packages/oauth-providers/mocks.ts
@@ -243,8 +243,13 @@ export const handlers = [
   http.post('https://www.openstreetmap.org/oauth2/token', async ({ request }) => {
     const body = new URLSearchParams(await request.text())
     // OpenStreetMap only supports the authorization code flow, with PKCE.
-    if (body.get('code') === dummyCode && body.get('code_verifier')) {
-      return HttpResponse.json(openStreetMapToken)
+    if (body.get('code_verifier')) {
+      if (body.get('code') === dummyCode) {
+        return HttpResponse.json(openStreetMapToken)
+      }
+      if (body.get('code') === openStreetMapRejectedCode) {
+        return HttpResponse.json(openStreetMapRejectedToken)
+      }
     }
     return HttpResponse.json(openStreetMapCodeError, { status: 400 })
   }),
@@ -645,10 +650,18 @@ export const msentraCodeError = {
 // OpenStreetMap access tokens do not expire, so the token response carries
 // neither `expires_in` nor `refresh_token`.
 export const openStreetMapToken = {
-  access_token: 'JvKtCjxJs0h1rDxHNCyoW2LqTNsMUHQPfQ8m1nsRtUw',
+  access_token: 'openstreetmapd0mmy4cc3sst0k3n',
   token_type: 'Bearer',
   scope: 'read_prefs write_api read_email',
   created_at: 1727000000,
+} satisfies OpenStreetMapTokenResponse
+
+// A code that exchanges fine but yields a token the API no longer accepts, as
+// happens once the user revokes the application.
+export const openStreetMapRejectedCode = 'osm-code-for-a-rejected-token'
+export const openStreetMapRejectedToken = {
+  ...openStreetMapToken,
+  access_token: 'openstreetmapr3j3ct3d4cc3sst0k3n',
 } satisfies OpenStreetMapTokenResponse
 
 export const openStreetMapUser = {

--- a/packages/oauth-providers/package.json
+++ b/packages/oauth-providers/package.json
@@ -29,6 +29,7 @@
     "./google": "./src/providers/google/index.ts",
     "./linkedin": "./src/providers/linkedin/index.ts",
     "./msentra": "./src/providers/msentra/index.ts",
+    "./openstreetmap": "./src/providers/openstreetmap/index.ts",
     "./twitch": "./src/providers/twitch/index.ts",
     "./x": "./src/providers/x/index.ts",
     "./package.json": "./package.json"
@@ -67,6 +68,10 @@
         "import": "./dist/msentra/index.mjs",
         "require": "./dist/msentra/index.cjs"
       },
+      "./openstreetmap": {
+        "import": "./dist/openstreetmap/index.mjs",
+        "require": "./dist/openstreetmap/index.cjs"
+      },
       "./twitch": {
         "import": "./dist/twitch/index.mjs",
         "require": "./dist/twitch/index.cjs"
@@ -103,6 +108,9 @@
       ],
       "msentra": [
         "./dist/providers/msentra/index.d.ts"
+      ],
+      "openstreetmap": [
+        "./dist/providers/openstreetmap/index.d.ts"
       ]
     }
   },

--- a/packages/oauth-providers/src/index.test.ts
+++ b/packages/oauth-providers/src/index.test.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { HttpResponse, http } from 'msw'
 import { setupServer } from 'msw/node'
 import {
   discordCodeError,
@@ -23,6 +24,11 @@ import {
   msentraRefreshToken,
   msentraToken,
   msentraUser,
+  openStreetMapCodeError,
+  openStreetMapRevokeTokenError,
+  openStreetMapToken,
+  openStreetMapUser,
+  openStreetMapUserError,
   xCodeError,
   xRefreshToken,
   xRefreshTokenError,
@@ -54,6 +60,8 @@ import { linkedinAuth } from './providers/linkedin'
 import type { LinkedInUser } from './providers/linkedin'
 import type { MSEntraUser } from './providers/msentra'
 import { msentraAuth, refreshToken as msentraRefresh } from './providers/msentra'
+import type { OpenStreetMapUser } from './providers/openstreetmap'
+import { openstreetmapAuth, revokeToken as openstreetmapRevoke } from './providers/openstreetmap'
 import type { TwitchUser } from './providers/twitch'
 import {
   twitchAuth,
@@ -483,6 +491,59 @@ describe('OAuth Middleware', () => {
       tenant_id: 'fake-tenant-id',
       refresh_token: 'wrong-refresh-token',
     })
+    return c.json(response)
+  })
+
+  // OpenStreetMap
+  app.use(
+    '/openstreetmap',
+    openstreetmapAuth({
+      client_id,
+      client_secret,
+      scope: ['read_prefs', 'write_api', 'read_email'],
+    })
+  )
+  app.use(
+    '/openstreetmap-custom-redirect',
+    openstreetmapAuth({
+      client_id,
+      client_secret,
+      scope: ['read_prefs'],
+      redirect_uri: 'http://localhost:3000/openstreetmap',
+    })
+  )
+  app.use(
+    '/openstreetmap-custom-state',
+    openstreetmapAuth({
+      client_id,
+      client_secret,
+      scope: ['read_prefs'],
+      state: 'test-state',
+    })
+  )
+  app.get('/openstreetmap', (c) => {
+    const token = c.get('token')
+    const refreshToken = c.get('refresh-token')
+    const user = c.get('user-openstreetmap')
+    const grantedScopes = c.get('granted-scopes')
+
+    return c.json({
+      token,
+      refreshToken,
+      grantedScopes,
+      user,
+    })
+  })
+  app.get('/openstreetmap/revoke', async (c) => {
+    const response = await openstreetmapRevoke(
+      client_id,
+      client_secret,
+      openStreetMapToken.access_token
+    )
+    return c.json(response)
+  })
+  app.get('/openstreetmap/revoke/error', async (c) => {
+    const response = await openstreetmapRevoke(client_id, client_secret, 'wrong-token')
     return c.json(response)
   })
 
@@ -1161,6 +1222,135 @@ describe('OAuth Middleware', () => {
         expect(res).not.toBeNull()
         expect(res.status).toBe(400)
         expect(await res.text()).toBe(msentraCodeError.error)
+      })
+    })
+  })
+
+  describe('openstreetmapAuth middleware', () => {
+    describe('middleware', () => {
+      it('Should redirect', async () => {
+        const res = await app.request('/openstreetmap')
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(302)
+
+        const redirectUrl = new URL(res.headers.get('location') ?? '')
+        expect(redirectUrl.origin.concat(redirectUrl.pathname)).toBe(
+          'https://www.openstreetmap.org/oauth2/authorize'
+        )
+        expect(redirectUrl.searchParams.get('response_type')).toBe('code')
+        expect(redirectUrl.searchParams.get('client_id')).toBe(client_id)
+        expect(redirectUrl.searchParams.get('scope')).toBe('read_prefs write_api read_email')
+      })
+
+      it('Should redirect with a PKCE challenge', async () => {
+        const res = await app.request('/openstreetmap')
+
+        const redirectUrl = new URL(res.headers.get('location') ?? '')
+        expect(redirectUrl.searchParams.get('code_challenge_method')).toBe('S256')
+        expect(redirectUrl.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9\-_]{43}$/)
+        // The verifier has to survive the round trip to the token endpoint.
+        expect(res.headers.get('set-cookie')).toContain('code-verifier=')
+      })
+
+      it('Should redirect to custom redirect_uri', async () => {
+        const res = await app.request('/openstreetmap-custom-redirect')
+
+        expect(res.status).toBe(302)
+        const redirectUrl = new URL(res.headers.get('location') ?? '')
+        expect(redirectUrl.searchParams.get('redirect_uri')).toBe(
+          'http://localhost:3000/openstreetmap'
+        )
+      })
+
+      it('Should redirect with custom state', async () => {
+        const res = await app.request('/openstreetmap-custom-state')
+
+        expect(res.status).toBe(302)
+        const redirectUrl = new URL(res.headers.get('location') ?? '')
+        expect(redirectUrl.searchParams.get('state')).toBe('test-state')
+      })
+
+      it('Prevent CSRF attack', async () => {
+        const res = await app.request(`/openstreetmap?code=${dummyCode}&state=malware-state`, {
+          headers: { cookie: 'state=valid-state' },
+        })
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(401)
+      })
+
+      it('Prevent login CSRF when state is omitted', async () => {
+        const res = await app.request(`/openstreetmap?code=${dummyCode}`, {
+          headers: { cookie: 'state=valid-state' },
+        })
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(401)
+      })
+
+      it('Should throw error for invalid code', async () => {
+        const res = await app.request(
+          '/openstreetmap?code=9348ffdsd-sdsdbad-code&state=valid-state',
+          { headers: { cookie: 'state=valid-state; code-verifier=valid-code-verifier' } }
+        )
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(400)
+        expect(await res.text()).toBe(openStreetMapCodeError.error_description)
+      })
+
+      it('Should throw error when the API rejects the token', async () => {
+        server.use(
+          http.get('https://api.openstreetmap.org/api/0.6/user/details.json', () =>
+            HttpResponse.text(openStreetMapUserError, { status: 401 })
+          )
+        )
+
+        const res = await app.request(`/openstreetmap?code=${dummyCode}&state=valid-state`, {
+          headers: { cookie: 'state=valid-state; code-verifier=valid-code-verifier' },
+        })
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(400)
+        expect(await res.text()).toBe(openStreetMapUserError)
+      })
+
+      it('Should work with received code', async () => {
+        const res = await app.request(`/openstreetmap?code=${dummyCode}&state=valid-state`, {
+          headers: { cookie: 'state=valid-state; code-verifier=valid-code-verifier' },
+        })
+        const response = (await res.json()) as {
+          token: Token
+          refreshToken: Token
+          user: OpenStreetMapUser
+          grantedScopes: string[]
+        }
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(200)
+        expect(response.user).toEqual(openStreetMapUser)
+        expect(response.grantedScopes).toEqual(['read_prefs', 'write_api', 'read_email'])
+        // OpenStreetMap access tokens neither expire nor come with a refresh token.
+        expect(response.token).toEqual({ token: openStreetMapToken.access_token })
+        expect(response.refreshToken).toBeUndefined()
+      })
+    })
+
+    describe('Revoke Token', () => {
+      it('Should revoke token', async () => {
+        const res = await app.request('/openstreetmap/revoke')
+
+        expect(res).not.toBeNull()
+        expect(await res.json()).toEqual(true)
+      })
+
+      it('Should return error for revoke', async () => {
+        const res = await app.request('/openstreetmap/revoke/error')
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(400)
+        expect(await res.text()).toBe(openStreetMapRevokeTokenError.error_description)
       })
     })
   })

--- a/packages/oauth-providers/src/index.test.ts
+++ b/packages/oauth-providers/src/index.test.ts
@@ -1,5 +1,4 @@
 import { Hono } from 'hono'
-import { HttpResponse, http } from 'msw'
 import { setupServer } from 'msw/node'
 import {
   discordCodeError,
@@ -25,6 +24,7 @@ import {
   msentraToken,
   msentraUser,
   openStreetMapCodeError,
+  openStreetMapRejectedCode,
   openStreetMapRevokeTokenError,
   openStreetMapToken,
   openStreetMapUser,
@@ -521,6 +521,9 @@ describe('OAuth Middleware', () => {
       state: 'test-state',
     })
   )
+  // Without the options the middleware falls back to the environment, which
+  // does not carry the OpenStreetMap credentials either.
+  app.use('/openstreetmap-no-credentials', openstreetmapAuth({ scope: ['read_prefs'] }))
   app.get('/openstreetmap', (c) => {
     const token = c.get('token')
     const refreshToken = c.get('refresh-token')
@@ -1301,19 +1304,24 @@ describe('OAuth Middleware', () => {
       })
 
       it('Should throw error when the API rejects the token', async () => {
-        server.use(
-          http.get('https://api.openstreetmap.org/api/0.6/user/details.json', () =>
-            HttpResponse.text(openStreetMapUserError, { status: 401 })
-          )
+        const res = await app.request(
+          `/openstreetmap?code=${openStreetMapRejectedCode}&state=valid-state`,
+          { headers: { cookie: 'state=valid-state; code-verifier=valid-code-verifier' } }
         )
-
-        const res = await app.request(`/openstreetmap?code=${dummyCode}&state=valid-state`, {
-          headers: { cookie: 'state=valid-state; code-verifier=valid-code-verifier' },
-        })
 
         expect(res).not.toBeNull()
         expect(res.status).toBe(400)
         expect(await res.text()).toBe(openStreetMapUserError)
+      })
+
+      it('Should throw error when the credentials are missing', async () => {
+        const res = await app.request('/openstreetmap-no-credentials')
+
+        expect(res).not.toBeNull()
+        expect(res.status).toBe(400)
+        expect(await res.text()).toBe(
+          'Required parameters were not found. Please provide them to proceed.'
+        )
       })
 
       it('Should work with received code', async () => {

--- a/packages/oauth-providers/src/providers/openstreetmap/authFlow.ts
+++ b/packages/oauth-providers/src/providers/openstreetmap/authFlow.ts
@@ -1,0 +1,129 @@
+import { HTTPException } from 'hono/http-exception'
+
+import type { Token } from '../../types'
+import { toQueryParams } from '../../utils/objectToQuery'
+import type {
+  OpenStreetMapErrorResponse,
+  OpenStreetMapScope,
+  OpenStreetMapTokenResponse,
+  OpenStreetMapUser,
+  OpenStreetMapUserResponse,
+} from './types'
+
+type OpenStreetMapAuthFlow = {
+  client_id: string
+  client_secret: string
+  redirect_uri: string
+  scope: OpenStreetMapScope[]
+  state: string
+  codeVerifier: string
+  codeChallenge: string
+  code: string | undefined
+}
+
+export class AuthFlow {
+  client_id: string
+  client_secret: string
+  redirect_uri: string
+  scope: string
+  state: string
+  code_verifier: string
+  code_challenge: string
+  code: string | undefined
+  token: Token | undefined
+  granted_scopes: string[] | undefined
+  user: Partial<OpenStreetMapUser> | undefined
+
+  constructor({
+    client_id,
+    client_secret,
+    redirect_uri,
+    scope,
+    state,
+    codeVerifier,
+    codeChallenge,
+    code,
+  }: OpenStreetMapAuthFlow) {
+    if (client_id === undefined || client_secret === undefined || scope === undefined) {
+      throw new HTTPException(400, {
+        message: 'Required parameters were not found. Please provide them to proceed.',
+      })
+    }
+
+    this.client_id = client_id
+    this.client_secret = client_secret
+    this.redirect_uri = redirect_uri
+    this.scope = scope.join(' ')
+    this.state = state
+    this.code_verifier = codeVerifier
+    this.code_challenge = codeChallenge
+    this.code = code
+    this.token = undefined
+    this.granted_scopes = undefined
+    this.user = undefined
+  }
+
+  redirect(): string {
+    const parsedOptions = toQueryParams({
+      response_type: 'code',
+      client_id: this.client_id,
+      redirect_uri: this.redirect_uri,
+      scope: this.scope,
+      state: this.state,
+      code_challenge: this.code_challenge,
+      code_challenge_method: 'S256',
+    })
+
+    return `https://www.openstreetmap.org/oauth2/authorize?${parsedOptions}`
+  }
+
+  private async getTokenFromCode(): Promise<void> {
+    const response = (await fetch('https://www.openstreetmap.org/oauth2/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: toQueryParams({
+        grant_type: 'authorization_code',
+        code: this.code,
+        redirect_uri: this.redirect_uri,
+        client_id: this.client_id,
+        client_secret: this.client_secret,
+        code_verifier: this.code_verifier,
+      }),
+    }).then((res) => res.json())) as OpenStreetMapTokenResponse | OpenStreetMapErrorResponse
+
+    if ('error' in response) {
+      throw new HTTPException(400, { message: response.error_description })
+    }
+
+    if ('access_token' in response) {
+      // OpenStreetMap access tokens do not expire, so there is no `expires_in`.
+      this.token = {
+        token: response.access_token,
+      }
+      this.granted_scopes = response.scope.split(' ')
+    }
+  }
+
+  async getUserData(): Promise<void> {
+    await this.getTokenFromCode()
+
+    // The OpenStreetMap API replies to errors with a plain text body, so the
+    // status has to be checked before parsing the response as JSON.
+    const response = await fetch('https://api.openstreetmap.org/api/0.6/user/details.json', {
+      headers: {
+        Authorization: `Bearer ${this.token?.token}`,
+      },
+    })
+
+    if (!response.ok) {
+      const message = (await response.text()).trim()
+      throw new HTTPException(400, { message: message || response.statusText })
+    }
+
+    const { user } = (await response.json()) as OpenStreetMapUserResponse
+
+    this.user = user
+  }
+}

--- a/packages/oauth-providers/src/providers/openstreetmap/index.ts
+++ b/packages/oauth-providers/src/providers/openstreetmap/index.ts
@@ -1,0 +1,11 @@
+import type { OAuthVariables } from '../../types'
+import type { OpenStreetMapUser } from './types'
+export { openstreetmapAuth } from './openstreetmapAuth'
+export { revokeToken } from './revokeToken'
+export * from './types'
+
+declare module 'hono' {
+  interface ContextVariableMap extends OAuthVariables {
+    'user-openstreetmap': Partial<OpenStreetMapUser> | undefined
+  }
+}

--- a/packages/oauth-providers/src/providers/openstreetmap/openstreetmapAuth.ts
+++ b/packages/oauth-providers/src/providers/openstreetmap/openstreetmapAuth.ts
@@ -1,0 +1,74 @@
+import type { MiddlewareHandler } from 'hono'
+import { env } from 'hono/adapter'
+import { getCookie, setCookie } from 'hono/cookie'
+import { HTTPException } from 'hono/http-exception'
+
+import { getCodeChallenge } from '../../utils/getCodeChallenge'
+import { getRandomState } from '../../utils/getRandomState'
+import { AuthFlow } from './authFlow'
+import type { OpenStreetMapScope } from './types'
+
+export function openstreetmapAuth(options: {
+  scope: OpenStreetMapScope[]
+  client_id?: string
+  client_secret?: string
+  state?: string
+  redirect_uri?: string
+}): MiddlewareHandler {
+  return async (c, next) => {
+    const newState = options.state ?? getRandomState()
+    const challenge = await getCodeChallenge()
+    const { OPENSTREETMAP_ID, OPENSTREETMAP_SECRET } = env<{
+      OPENSTREETMAP_ID?: string
+      OPENSTREETMAP_SECRET?: string
+    }>(c)
+
+    // Create new Auth instance
+    const auth = new AuthFlow({
+      client_id: options.client_id ?? (OPENSTREETMAP_ID as string),
+      client_secret: options.client_secret ?? (OPENSTREETMAP_SECRET as string),
+      redirect_uri: options.redirect_uri ?? c.req.url.split('?')[0],
+      scope: options.scope,
+      state: newState,
+      codeVerifier: getCookie(c, 'code-verifier') ?? challenge.codeVerifier,
+      codeChallenge: challenge.codeChallenge,
+      code: c.req.query('code'),
+    })
+
+    // Redirect to login dialog
+    if (!auth.code) {
+      setCookie(c, 'state', newState, {
+        maxAge: 60 * 10,
+        httpOnly: true,
+        path: '/',
+        secure: true,
+        sameSite: 'Lax',
+      })
+      setCookie(c, 'code-verifier', challenge.codeVerifier, {
+        maxAge: 60 * 10,
+        httpOnly: true,
+        path: '/',
+        secure: true,
+        sameSite: 'Lax',
+      })
+      return c.redirect(auth.redirect())
+    }
+
+    // Avoid CSRF attack by checking state
+    const storedState = getCookie(c, 'state')
+    const state = c.req.query('state')
+    if (!storedState || !state || state !== storedState) {
+      throw new HTTPException(401)
+    }
+
+    // Retrieve user data from OpenStreetMap
+    await auth.getUserData()
+
+    // Set return info
+    c.set('token', auth.token)
+    c.set('user-openstreetmap', auth.user)
+    c.set('granted-scopes', auth.granted_scopes)
+
+    await next()
+  }
+}

--- a/packages/oauth-providers/src/providers/openstreetmap/revokeToken.ts
+++ b/packages/oauth-providers/src/providers/openstreetmap/revokeToken.ts
@@ -1,0 +1,32 @@
+import { HTTPException } from 'hono/http-exception'
+
+import { toQueryParams } from '../../utils/objectToQuery'
+import type { OpenStreetMapErrorResponse } from './types'
+
+export async function revokeToken(
+  client_id: string,
+  client_secret: string,
+  token: string
+): Promise<boolean> {
+  const response = await fetch('https://www.openstreetmap.org/oauth2/revoke', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: toQueryParams({
+      token,
+      client_id,
+      client_secret,
+    }),
+  })
+
+  if (!response.ok) {
+    const error = (await response.json()) as Partial<OpenStreetMapErrorResponse>
+    throw new HTTPException(400, {
+      message: error.error_description ?? error.error ?? `Status code: ${response.status}`,
+    })
+  }
+
+  // RFC 7009 mandates an empty 200 response for a successful revocation.
+  return true
+}

--- a/packages/oauth-providers/src/providers/openstreetmap/types.ts
+++ b/packages/oauth-providers/src/providers/openstreetmap/types.ts
@@ -1,0 +1,95 @@
+export type OpenStreetMapScope =
+  | 'read_prefs'
+  | 'write_prefs'
+  | 'write_diary'
+  | 'write_api'
+  | 'write_changeset_comments'
+  | 'read_gpx'
+  | 'write_gpx'
+  | 'write_notes'
+  | 'write_redactions'
+  | 'write_blocks'
+  | 'consume_messages'
+  | 'send_messages'
+  // `read_email` is one of the privileged scopes, which OpenStreetMap only
+  // offers to applications registered by a site administrator.
+  | 'read_email'
+  | 'openid'
+
+export type OpenStreetMapErrorResponse = {
+  error: string
+  error_description: string
+  state?: string
+}
+
+// OpenStreetMap access tokens do not expire and no refresh token is issued,
+// so the response carries neither `expires_in` nor `refresh_token`.
+export type OpenStreetMapTokenResponse = {
+  access_token: string
+  token_type: string
+  scope: string
+  created_at: number
+}
+
+export type OpenStreetMapUser = {
+  id: number
+  display_name: string
+  account_created: string
+  description?: string
+  company?: string
+  social_links: {
+    url: string
+    platform: string
+  }[]
+  contributor_terms: {
+    agreed: boolean
+    pd: boolean
+  }
+  img: {
+    href?: string
+  }
+  roles: string[]
+  changesets: {
+    count: number
+  }
+  traces: {
+    count: number
+  }
+  blocks: {
+    received: {
+      count: number
+      active: number
+    }
+    // Only present for moderators.
+    issued?: {
+      count: number
+      active: number
+    }
+  }
+  home?: {
+    lat: number
+    lon: number
+    zoom: number
+  }
+  languages?: string[]
+  messages: {
+    received: {
+      count: number
+      unread: number
+    }
+    sent: {
+      count: number
+    }
+  }
+  // Only present when the `read_email` scope was granted.
+  email?: string
+}
+
+export type OpenStreetMapUserResponse = {
+  version: string
+  generator: string
+  copyright: string
+  attribution: string
+  license: string
+  user: OpenStreetMapUser
+}


### PR DESCRIPTION
Closes #2074.

Adds `openstreetmapAuth`, exported as `@hono/oauth-providers/openstreetmap`, plus a `revokeToken` helper.

```ts
import { Hono } from 'hono'
import { openstreetmapAuth } from '@hono/oauth-providers/openstreetmap'

const app = new Hono()

app.use(
  '/openstreetmap',
  openstreetmapAuth({
    client_id: process.env.OPENSTREETMAP_ID,
    client_secret: process.env.OPENSTREETMAP_SECRET,
    scope: ['read_prefs'],
  })
)

app.get('/openstreetmap', (c) => {
  return c.json({
    token: c.get('token'),
    grantedScopes: c.get('granted-scopes'),
    user: c.get('user-openstreetmap'),
  })
})
```

## Implementation notes

OpenStreetMap runs [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper), and a few of its
choices differ from the other providers in this package. Each decision below is backed by the
[authorization server metadata](https://www.openstreetmap.org/.well-known/oauth-authorization-server)
or by the [openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website) source.

**PKCE is always used, with the `S256` challenge method.** The server advertises
`code_challenge_methods_supported: ["plain", "S256"]`, and Doorkeeper requires a code verifier for
public clients. Sending the challenge unconditionally means the middleware works for both
confidential and public applications.

**No refresh token, and the access token carries no `expires_in`.** OpenStreetMap's Doorkeeper
config sets `access_token_expires_in nil` and leaves `use_refresh_token` disabled, so tokens do not
expire and no refresh token is ever issued. `token` is therefore `{ token: string }` and
`refresh-token` is not set. `revokeToken` is exported instead, since revocation is the only way to
invalidate a token.

**User details come from `GET /api/0.6/user/details.json`.** This carries much more than the OIDC
`userinfo` endpoint, but it needs the `read_prefs` scope — `api_ability.rb` has
`can :details, User if scopes.include?("read_prefs")` — so the README calls that out. The
OpenStreetMap API answers errors with a plain text body rather than JSON, so the response status is
checked before parsing (`authFlow.ts`).

**`skip_authorization` is excluded from `OpenStreetMapScope`,** and `read_email` is documented as
privileged. Both live in `PRIVILEGED_SCOPES` in `lib/oauth.rb` and are only offered to applications
registered by a site administrator, so `user-openstreetmap.email` is normally `undefined`.

## Testing

Unit tests use the existing msw setup: 11 cases covering the redirect URL and its PKCE parameters,
the custom `redirect_uri` and `state` options, CSRF protection (both a mismatched and an omitted
`state`), an invalid code, an API rejection of the token, the success path, and both revocation
outcomes.

Beyond that, the flow was run manually against the live openstreetmap.org authorization server —
authorization, token exchange, user lookup and revocation. The live response then corrected the
types: `contributor_terms.pd` and `messages` are unconditional in `_user.json.jbuilder` for a
request that gets past the `read_prefs` check, so both are required rather than optional.

One trap worth recording for anyone testing this locally: `force_ssl_in_redirect_uri` in
`doorkeeper.rb` only permits plain http for the hosts `127.0.0.1` and `::1`. A redirect URI of
`http://localhost:3000/...` is rejected at application registration time.

---

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
