### PR TITLE
revert(zod-openapi): export local z binding

### DIFF
--- a/.changeset/few-cooks-mix.md
+++ b/.changeset/few-cooks-mix.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Revert the local z binding export because it causes zod types to degrade to any when built with tsdown.

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -41,7 +41,7 @@ import { mergePath } from 'hono/utils/url'
 import type { OpenAPIObject } from 'openapi3-ts/oas30'
 import type { OpenAPIObject as OpenAPIV31bject } from 'openapi3-ts/oas31'
 import type { ZodType, ZodError } from 'zod'
-import * as zodModule from 'zod'
+import { z } from 'zod'
 import { isZod } from './zod-typeguard'
 
 type MaybePromise<T> = Promise<T> | T
@@ -913,18 +913,8 @@ export const createRoute = <P extends string, R extends Omit<RouteConfig, 'path'
   return Object.defineProperty(route, 'getRoutingPath', { enumerable: false })
 }
 
-// `zodModule.z`, not the `z` alias below: the alias compiles to a binding
-// declared at that point, which this call precedes.
-extendZodWithOpenApi(zodModule.z)
-// An alias declaration, not `export { z }`: re-exporting the imported binding
-// lets a bundler resolve `import { z } from '@hono/zod-openapi'` straight to zod
-// and drop the edge to this module, so the `extendZodWithOpenApi` call above can
-// evaluate after the schemas that need it — `.openapi()` is then undefined at
-// runtime under esbuild code splitting (#2051). This compiles to a binding local
-// to this module, which keeps that edge, while an alias — unlike `const z = zod`
-// — still carries zod's type namespace, so `z.infer` and friends keep working.
-export import z = zodModule.z
-export { extendZodWithOpenApi }
+extendZodWithOpenApi(z)
+export { extendZodWithOpenApi, z }
 
 function addBasePathToDocument(document: Record<string, any>, basePath: string) {
   const updatedPaths: Record<string, any> = {}


### PR DESCRIPTION
Fixes https://github.com/honojs/middleware/issues/2078

This reverts commit https://github.com/kamaal111/hono-middleware/commit/fc0377c5595bde3147d181e5013a3fc710175e40.

Original commit title that has been reverted:
fix(zod-openapi): export local z binding so OpenAPI patch is not tree-shaken (https://github.com/honojs/middleware/pull/2069)

This commit is being reverted because its use-case is not yet supported
by `rolldown-plugin-dts` which is a subdependency of `tsdown` in this
project. Its impact is that the zod types have decraded and is resulting
in types resulting in `any` which causes the typescript compiler to
error in strict mode

### The author should do the following, if applicable

- [x]  ~~Add tests~~ not relevant
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
