### PR TITLE
fix(zod-openapi): return 415 for request bodies with undeclared content type

### DIFF
--- a/.changeset/heavy-lions-refuse.md
+++ b/.changeset/heavy-lions-refuse.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+fix: return 415 when a JSON or form request body's Content-Type matches none of the route's declared media types, instead of validating an empty object

--- a/.changeset/heavy-lions-refuse.md
+++ b/.changeset/heavy-lions-refuse.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': minor
+---
+
+fix: return 415 when a request body's Content-Type matches none of the route's declared media types, instead of skipping validation

--- a/packages/zod-openapi/README.md
+++ b/packages/zod-openapi/README.md
@@ -118,7 +118,9 @@ export default app
 ```
 
 > [!IMPORTANT]
-> The request must have the proper `Content-Type` to ensure the validation. For example, if you want to validate a JSON body, the request must have the `Content-Type` to `application/json` in the request. Otherwise, the value of `c.req.valid('json')` will be `{}`.
+> Request bodies are validated only for JSON and form media types with a Zod schema. Other declared media types, such as `application/xml`, reach the handler without validation.
+>
+> On a route with such a validator, a request that sends a body must declare a matching `Content-Type`. A body with a missing or unsupported `Content-Type` is rejected with `415 Unsupported Media Type`.
 >
 > ```ts
 > import { createRoute, z, OpenAPIHono } from '@hono/zod-openapi'
@@ -148,7 +150,7 @@ export default app
 >
 > app.openapi(route, (c) => {
 >   const validatedBody = c.req.valid('json')
->   return c.json(validatedBody) // validatedBody is {}
+>   return c.json(validatedBody)
 > })
 >
 > const res = await app.request('/books', {
@@ -157,11 +159,10 @@ export default app
 >   // The Content-Type header is lacking.
 > })
 >
-> const data = await res.json()
-> console.log(data) // {}
+> console.log(res.status) // 415
 > ```
 >
-> If you want to force validation of requests that do not have the proper `Content-Type`, set the value of `request.body.required` to `true`.
+> `request.body.required` controls whether the body may be absent. With the default `false`, a request with no body reaches the handler and `c.req.valid('json')` is `{}`. With `required: true`, an absent body fails validation with `400`.
 >
 > ```ts
 > const route = createRoute({

--- a/packages/zod-openapi/src/index.test.ts
+++ b/packages/zod-openapi/src/index.test.ts
@@ -3542,6 +3542,18 @@ describe('Media type gate for request bodies', () => {
     expect(await res.json()).toEqual({ idType: 'number' })
   })
 
+  it('Should match the content-type case-insensitively', async () => {
+    for (const required of [false, true]) {
+      const res = await createApp(required).request('/posts', {
+        method: 'POST',
+        body: JSON.stringify({ id: 123 }),
+        headers: { 'content-type': 'Application/JSON' },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ idType: 'number' })
+    }
+  })
+
   // The schema accepts {} so a skipped parse shows up as a 200 instead of a 400.
   describe('Malformed content types', () => {
     const LooseSchema = z.object({ id: z.string().optional() })
@@ -3588,6 +3600,16 @@ describe('Media type gate for request bodies', () => {
       const form = new FormData()
       form.append('id', '123')
       const res = await formApp.request('/posts', { method: 'POST', body: form })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ data: { id: '123' } })
+    })
+
+    it('Should validate an urlencoded form body with an uppercase content-type', async () => {
+      const res = await formApp.request('/posts', {
+        method: 'POST',
+        body: 'id=123',
+        headers: { 'content-type': 'APPLICATION/X-WWW-FORM-URLENCODED' },
+      })
       expect(res.status).toBe(200)
       expect(await res.json()).toEqual({ data: { id: '123' } })
     })

--- a/packages/zod-openapi/src/index.test.ts
+++ b/packages/zod-openapi/src/index.test.ts
@@ -3182,3 +3182,111 @@ describe('openapiRoutes', () => {
     // Let's verify type safety and runtime behaviors.
   })
 })
+
+describe('Media type gate for request bodies', () => {
+  const PostSchema = z.object({
+    id: z.number().openapi({}),
+  })
+
+  const createApp = (required: boolean) => {
+    const app = new OpenAPIHono()
+    app.openapi(
+      createRoute({
+        method: 'post',
+        path: '/posts',
+        request: {
+          body: {
+            content: {
+              'application/json': {
+                schema: PostSchema,
+              },
+            },
+            required,
+          },
+        },
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: z.object({ idType: z.string() }),
+              },
+            },
+            description: 'Post result',
+          },
+        },
+      }),
+      (c) => {
+        const data = c.req.valid('json')
+        return c.json({ idType: typeof data.id })
+      }
+    )
+    return app
+  }
+
+  const app = createApp(false)
+
+  it('Should return 415 when the content-type does not match the declared media types', async () => {
+    const res = await app.request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'text/plain' },
+    })
+    expect(res.status).toBe(415)
+  })
+
+  it('Should return 415 when a body is sent without a content-type', async () => {
+    const req = new Request('http://localhost/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+    })
+    req.headers.delete('content-type')
+    const res = await app.request(req)
+    expect(res.status).toBe(415)
+  })
+
+  it('Should return 200 when no body is sent and the body is optional', async () => {
+    const res = await app.request('/posts', { method: 'POST' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'undefined' })
+  })
+
+  it('Should return 200 when an empty body stream is sent without a content-type', async () => {
+    const req = new Request('http://localhost/posts', {
+      method: 'POST',
+      body: '',
+    })
+    req.headers.delete('content-type')
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'undefined' })
+  })
+
+  it('Should validate the body when the content-type matches', async () => {
+    const res = await app.request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'application/json' },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'number' })
+  })
+
+  it('Should accept a JSON content-type with a suffix', async () => {
+    const res = await app.request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'application/vnd.api+json' },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'number' })
+  })
+
+  it('Should return 415 when the body is required and the content-type does not match', async () => {
+    const res = await createApp(true).request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'text/plain' },
+    })
+    expect(res.status).toBe(415)
+  })
+})

--- a/packages/zod-openapi/src/index.test.ts
+++ b/packages/zod-openapi/src/index.test.ts
@@ -3416,3 +3416,297 @@ describe('QUERY method', () => {
     expect(doc.paths?.['/search']).toHaveProperty('query')
   })
 })
+
+describe('Media type gate for request bodies', () => {
+  const PostSchema = z.object({
+    id: z.number().openapi({}),
+  })
+
+  const createApp = (required: boolean) => {
+    const app = new OpenAPIHono()
+    app.openapi(
+      createRoute({
+        method: 'post',
+        path: '/posts',
+        request: {
+          body: {
+            content: {
+              'application/json': {
+                schema: PostSchema,
+              },
+            },
+            required,
+          },
+        },
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: z.object({ idType: z.string() }),
+              },
+            },
+            description: 'Post result',
+          },
+        },
+      }),
+      (c) => {
+        const data = c.req.valid('json')
+        return c.json({ idType: typeof data.id })
+      }
+    )
+    return app
+  }
+
+  const app = createApp(false)
+
+  it('Should return 415 when the content-type does not match the declared media types', async () => {
+    const res = await app.request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'text/plain' },
+    })
+    expect(res.status).toBe(415)
+  })
+
+  it('Should return 415 when a body is sent without a content-type', async () => {
+    const req = new Request('http://localhost/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+    })
+    req.headers.delete('content-type')
+    const res = await app.request(req)
+    expect(res.status).toBe(415)
+  })
+
+  it('Should return 200 when no body is sent and the body is optional', async () => {
+    const res = await app.request('/posts', { method: 'POST' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'undefined' })
+  })
+
+  it('Should return 200 when an empty body stream is sent without a content-type', async () => {
+    const req = new Request('http://localhost/posts', {
+      method: 'POST',
+      body: '',
+    })
+    req.headers.delete('content-type')
+    const res = await app.request(req)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'undefined' })
+  })
+
+  it('Should validate the body when the content-type matches', async () => {
+    const res = await app.request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'application/json' },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'number' })
+  })
+
+  it('Should accept a JSON content-type with a suffix', async () => {
+    const res = await app.request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'application/vnd.api+json' },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'number' })
+  })
+
+  it('Should return 415 when the body is required and the content-type does not match', async () => {
+    const res = await createApp(true).request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'text/plain' },
+    })
+    expect(res.status).toBe(415)
+  })
+
+  it('Should return 415 when a content-type is sent without a body', async () => {
+    const res = await app.request('/posts', {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+    })
+    expect(res.status).toBe(415)
+  })
+
+  it('Should accept a JSON content-type with parameters', async () => {
+    const res = await app.request('/posts', {
+      method: 'POST',
+      body: JSON.stringify({ id: 123 }),
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ idType: 'number' })
+  })
+
+  // The schema accepts {} so a skipped parse shows up as a 200 instead of a 400.
+  describe('Malformed content types', () => {
+    const LooseSchema = z.object({ id: z.string().optional() })
+    const responses = { 200: { description: 'Post result' } }
+
+    const jsonApp = new OpenAPIHono().openapi(
+      createRoute({
+        method: 'post',
+        path: '/posts',
+        request: { body: { content: { 'application/json': { schema: LooseSchema } } } },
+        responses,
+      }),
+      (c) => c.json({ data: c.req.valid('json') })
+    )
+    const formApp = new OpenAPIHono().openapi(
+      createRoute({
+        method: 'post',
+        path: '/posts',
+        request: { body: { content: { 'multipart/form-data': { schema: LooseSchema } } } },
+        responses,
+      }),
+      (c) => c.json({ data: c.req.valid('form') })
+    )
+
+    it('Should return 415 for application/jsonp', async () => {
+      const res = await jsonApp.request('/posts', {
+        method: 'POST',
+        body: JSON.stringify({ id: '123' }),
+        headers: { 'content-type': 'application/jsonp' },
+      })
+      expect(res.status).toBe(415)
+    })
+
+    it('Should return 415 for multipart/form-dataevil', async () => {
+      const res = await formApp.request('/posts', {
+        method: 'POST',
+        body: 'id=123',
+        headers: { 'content-type': 'multipart/form-dataevil' },
+      })
+      expect(res.status).toBe(415)
+    })
+
+    it('Should validate a multipart form body', async () => {
+      const form = new FormData()
+      form.append('id', '123')
+      const res = await formApp.request('/posts', { method: 'POST', body: form })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ data: { id: '123' } })
+    })
+  })
+
+  describe('Routes without a JSON or form validator', () => {
+    const createPassthroughApp = (content: Record<string, { schema: unknown }>) => {
+      const app = new OpenAPIHono()
+      app.openapi(
+        createRoute({
+          method: 'post',
+          path: '/posts',
+          request: { body: { content: content as never } },
+          responses: { 200: { description: 'Post result' } },
+        }),
+        async (c) => c.text(await c.req.text())
+      )
+      return app
+    }
+
+    it('Should not gate a route that only declares XML', async () => {
+      const res = await createPassthroughApp({ 'application/xml': { schema: z.string() } }).request(
+        '/posts',
+        {
+          method: 'POST',
+          body: 'hello',
+          headers: { 'content-type': 'text/plain' },
+        }
+      )
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('hello')
+    })
+
+    it('Should not gate a JSON route whose schema is not a Zod schema', async () => {
+      const res = await createPassthroughApp({
+        'application/json': { schema: { type: 'object' } },
+      }).request('/posts', {
+        method: 'POST',
+        body: 'hello',
+        headers: { 'content-type': 'text/plain' },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('hello')
+    })
+  })
+
+  describe('Routes declaring JSON and XML', () => {
+    const mixedApp = new OpenAPIHono()
+    mixedApp.openapi(
+      createRoute({
+        method: 'post',
+        path: '/posts',
+        request: {
+          body: {
+            content: {
+              'application/json': { schema: PostSchema },
+              'application/xml': { schema: z.string() },
+            },
+          },
+        },
+        responses: { 200: { description: 'Post result' } },
+      }),
+      (c) => c.json({ data: c.req.valid('json') })
+    )
+
+    it('Should accept declared XML without validating it', async () => {
+      const res = await mixedApp.request('/posts', {
+        method: 'POST',
+        body: '<post><id>7</id></post>',
+        headers: { 'content-type': 'application/xml' },
+      })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ data: {} })
+    })
+  })
+
+  describe('Body presence check', () => {
+    const rawApp = new OpenAPIHono()
+    rawApp.openapi(
+      createRoute({
+        method: 'post',
+        path: '/posts',
+        request: {
+          body: { content: { 'application/json': { schema: PostSchema } } },
+        },
+        responses: { 200: { description: 'Post result' } },
+      }),
+      async (c) => c.json({ raw: await c.req.raw.text() })
+    )
+
+    it('Should leave an empty body stream readable for the handler', async () => {
+      const req = new Request('http://localhost/posts', { method: 'POST', body: '' })
+      req.headers.delete('content-type')
+      const res = await rawApp.request(req)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ raw: '' })
+    })
+
+    it('Should return 415 after the first chunk of a body that never closes', async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{'))
+        },
+      })
+      const req = new Request('http://localhost/posts', {
+        method: 'POST',
+        body: stream,
+        duplex: 'half',
+      } as RequestInit)
+      req.headers.delete('content-type')
+      const res = await Promise.race([
+        app.request(req),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => {
+            reject(new Error('timed out'))
+          }, 1000)
+        }),
+      ])
+      expect(res.status).toBe(415)
+    })
+  })
+})

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -875,13 +875,13 @@ function addBasePathToDocument(document: Record<string, any>, basePath: string) 
 }
 
 function isJSONContentType(contentType: string) {
-  return /^application\/([a-z-\.]+\+)?json/.test(contentType)
+  return /^application\/([a-z-\.]+\+)?json/i.test(contentType)
 }
 
 // Mirrors hono/validator's checks. Anything looser lets Hono skip parsing and validate {}.
-const jsonRequestRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
-const multipartRequestRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
-const urlencodedRequestRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
+const jsonRequestRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/i
+const multipartRequestRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/i
+const urlencodedRequestRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/i
 
 function matchesMediaType(contentType: string, mediaType: string) {
   if (mediaType === '*/*') {
@@ -930,8 +930,8 @@ async function hasRequestBody(c: Context): Promise<boolean> {
 }
 
 function isFormContentType(contentType: string) {
+  const lower = contentType.toLowerCase()
   return (
-    contentType.startsWith('multipart/form-data') ||
-    contentType.startsWith('application/x-www-form-urlencoded')
+    lower.startsWith('multipart/form-data') || lower.startsWith('application/x-www-form-urlencoded')
   )
 }

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -27,6 +27,7 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 import type { H, MergePath, MergeSchemaPath } from 'hono/types'
 import type {
   ClientErrorStatusCode,
@@ -632,6 +633,21 @@ export class OpenAPIHono<
     const bodyContent = route.request?.body?.content
 
     if (bodyContent) {
+      const declaredMediaTypes = Object.keys(bodyContent)
+      const mediaTypeGate: MiddlewareHandler = async (c, next) => {
+        const contentType = c.req.header('content-type')
+        if (contentType) {
+          if (!declaredMediaTypes.some((mediaType) => matchesMediaType(contentType, mediaType))) {
+            throw new HTTPException(415, { message: 'Unsupported Media Type' })
+          }
+        } else if (c.req.raw.body !== null && (await c.req.arrayBuffer()).byteLength > 0) {
+          // Server adapters may attach an empty body stream to bodyless
+          // requests, so a non-null stream alone does not prove a body was sent.
+          throw new HTTPException(415, { message: 'Unsupported Media Type' })
+        }
+        await next()
+      }
+      validators.push(mediaTypeGate)
       for (const mediaType of Object.keys(bodyContent)) {
         if (!bodyContent[mediaType]) {
           continue
@@ -931,6 +947,25 @@ function addBasePathToDocument(document: Record<string, any>, basePath: string) 
 
 function isJSONContentType(contentType: string) {
   return /^application\/([a-z-\.]+\+)?json/.test(contentType)
+}
+
+// Mirrors how the body validators dispatch: a JSON media type accepts any
+// JSON content type, a form media type accepts any form content type.
+function matchesMediaType(contentType: string, mediaType: string) {
+  if (mediaType === '*/*') {
+    return true
+  }
+  if (isJSONContentType(mediaType)) {
+    return isJSONContentType(contentType)
+  }
+  if (isFormContentType(mediaType)) {
+    return isFormContentType(contentType)
+  }
+  const essence = contentType.split(';')[0].trim().toLowerCase()
+  if (mediaType.endsWith('/*')) {
+    return essence.startsWith(mediaType.slice(0, -1).toLowerCase())
+  }
+  return essence === mediaType.toLowerCase()
 }
 
 function isFormContentType(contentType: string) {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -27,6 +27,7 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 import type { H, MergePath, MergeSchemaPath } from 'hono/types'
 import type {
   ClientErrorStatusCode,
@@ -561,7 +562,26 @@ export class OpenAPIHono<
     const bodyContent = route.request?.body?.content
 
     if (bodyContent) {
-      for (const mediaType of Object.keys(bodyContent)) {
+      const declaredMediaTypes = Object.keys(bodyContent)
+      const hasBodyValidator = declaredMediaTypes.some((mediaType) => {
+        const schema = (bodyContent[mediaType] as ZodMediaTypeObject | undefined)?.schema
+        return isZod(schema) && (isJSONContentType(mediaType) || isFormContentType(mediaType))
+      })
+      if (hasBodyValidator) {
+        const mediaTypeGate: MiddlewareHandler = async (c, next) => {
+          const contentType = c.req.header('content-type')
+          if (contentType) {
+            if (!declaredMediaTypes.some((mediaType) => matchesMediaType(contentType, mediaType))) {
+              throw new HTTPException(415, { message: 'Unsupported Media Type' })
+            }
+          } else if (await hasRequestBody(c)) {
+            throw new HTTPException(415, { message: 'Unsupported Media Type' })
+          }
+          await next()
+        }
+        validators.push(mediaTypeGate)
+      }
+      for (const mediaType of declaredMediaTypes) {
         if (!bodyContent[mediaType]) {
           continue
         }
@@ -856,6 +876,57 @@ function addBasePathToDocument(document: Record<string, any>, basePath: string) 
 
 function isJSONContentType(contentType: string) {
   return /^application\/([a-z-\.]+\+)?json/.test(contentType)
+}
+
+// Mirrors hono/validator's checks. Anything looser lets Hono skip parsing and validate {}.
+const jsonRequestRegex = /^application\/([a-z-\.]+\+)?json(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
+const multipartRequestRegex = /^multipart\/form-data(;\s?boundary=[a-zA-Z0-9'"()+_,\-./:=?]+)?$/
+const urlencodedRequestRegex = /^application\/x-www-form-urlencoded(;\s*[a-zA-Z0-9\-]+\=([^;]+))*$/
+
+function matchesMediaType(contentType: string, mediaType: string) {
+  if (mediaType === '*/*') {
+    return true
+  }
+  if (isJSONContentType(mediaType)) {
+    return jsonRequestRegex.test(contentType)
+  }
+  if (isFormContentType(mediaType)) {
+    return multipartRequestRegex.test(contentType) || urlencodedRequestRegex.test(contentType)
+  }
+  const essence = contentType.split(';')[0].trim().toLowerCase()
+  if (mediaType.endsWith('/*')) {
+    return essence.startsWith(mediaType.slice(0, -1).toLowerCase())
+  }
+  return essence === mediaType.toLowerCase()
+}
+
+// Peek at a clone so the body stays readable downstream and a slow body costs one chunk.
+async function hasRequestBody(c: Context): Promise<boolean> {
+  const raw = c.req.raw
+  if (raw.body === null) {
+    return false
+  }
+  if (raw.bodyUsed) {
+    return (await c.req.arrayBuffer()).byteLength > 0
+  }
+  const body = raw.clone().body
+  if (body === null) {
+    return false
+  }
+  const reader = body.getReader()
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) {
+        return false
+      }
+      if (value.byteLength > 0) {
+        return true
+      }
+    }
+  } finally {
+    reader.cancel().catch(() => {})
+  }
 }
 
 function isFormContentType(contentType: string) {


### PR DESCRIPTION
Fixes #891.

Heads up: this could also have been fixed by defaulting `request.body.required` to `true`. I went the other way because that turns genuinely optional bodies into 400s and changes the emitted OpenAPI document. Close this if you'd rather have the simpler default.

## The bug

For an optional body, the generated middleware validates only when the `Content-Type` header matches a declared media type. Any other Content-Type skips validation and injects `{}` as the validated data. The client controls the header, so it can bypass validation on any route with an optional body.

This route is enough to reproduce it:

```ts
const route = createRoute({
  method: 'post',
  path: '/posts',
  request: {
    body: { content: { 'application/json': { schema: z.object({ id: z.number() }) } } }, // required defaults to false
  },
  responses: { 200: { description: 'ok' } },
})

const app = new OpenAPIHono()

app.openapi(route, (c) => {
  const data = c.req.valid('json') // typed as { id: number }
  return c.json({ data })
})
```

Sending the same body under different Content-Types. The `After` column is this PR:

| Body sent | `Content-Type` | Before | After |
|---|---|---|---|
| `{"id":7}` | `application/json` | 200 · `{"id":7}` | 200 · `{"id":7}` |
| `{"id":7}` | `application/vnd.api+json` | 200 · `{"id":7}` | 200 · `{"id":7}` |
| `{"id":7}` | `text/plain` | 200 · `{}` | 415 |
| `{"id":7}` | *(omitted)* | 200 · `{}` | 415 |
| `<post><id>7</id></post>` | `application/xml` | 200 · `{}` | 415 |
| `<post><id>7</id></post>` | `text/xml` | 200 · `{}` | 415 |
| *(none)* | *(omitted)* | 200 · `{}` | 200 · `{}` |
| `{"id":7}` *(required: true)* | `text/plain` | 400 | 415 |

`data` is typed `{ id: number }`, so `data.id` is a `number` to the compiler while the runtime value is `undefined`.
> XML was tested for the love of the game

That last row is the only behavior change beyond the fix itself: `required: true` with a mismatched Content-Type moves from 400 to 415. Hono's `validator()` already substitutes `{}` on a mismatch, so the schema was failing on an empty object rather than on the real problem.

## The fix

A gate runs before the body validators:

- Content-Type matches a declared media type -> validate as today.
- Content-Type matches no declared media type -> 415.
- No Content-Type, but a body was sent -> 415.
- No Content-Type and no body -> unchanged: `{}` passes through for optional bodies, and `required: true` still fails the schema with 400.

The issue thread proposed 400 for this case. This PR returns 415 because [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.16) defines it for exactly this situation. Switching to 400 is a one-line change if you prefer.

One gap: only JSON and form media types get a validator, so a route declaring `application/json` **and** `application/xml` still gets `{}` when sent XML. Rejecting that would break XML-only routes, which are legitimate, so it needs a call.

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)