### PR TITLE
feat: add @hono/pino-logger middleware

### DIFF
--- a/.changeset/add-pino-logger.md
+++ b/.changeset/add-pino-logger.md
@@ -1,0 +1,5 @@
+---
+"@hono/pino-logger": minor
+---
+
+Add `@hono/pino-logger` — production-ready Pino integration for Hono with request-bound child loggers, requestId correlation, and `onRequest`/`onResponse` lifecycle hooks.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "turbo": "^2.10.7",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typia": "^12.1.1",
+    "unrun": "^0.3.1",
     "vitest": "^4.1.7"
   },
   "packageManager": "pnpm@11.9.0"

--- a/packages/pino-logger/README.md
+++ b/packages/pino-logger/README.md
@@ -1,0 +1,74 @@
+# @hono/pino-logger
+
+Pino Logger middleware for [Hono](https://hono.dev).
+
+Provides a request-scoped logger on `c.var.logger` (or `c.get('logger')`) with full type safety, automatic response time measurement, and native integration with request IDs.
+
+## Install
+
+```bash
+npm install @hono/pino-logger pino
+```
+
+## Usage
+
+```typescript
+import { Hono } from 'hono'
+import { pinoLogger } from '@hono/pino-logger'
+import pino from 'pino'
+
+const logger = pino()
+const app = new Hono()
+
+app.use(pinoLogger({ logger }))
+
+app.get('/', (c) => {
+  const log = c.var.logger // request-bound logger
+  log.info('handling request')
+  return c.text('Hello!')
+})
+```
+
+### Request ID Correlation
+
+If the `hono/request-id` middleware is registered, or an `x-request-id` header is present, a child logger with the `reqId` will automatically be bound:
+
+```typescript
+import { Hono } from 'hono'
+import { requestId } from 'hono/request-id'
+import { pinoLogger } from '@hono/pino-logger'
+import pino from 'pino'
+
+const logger = pino()
+const app = new Hono()
+
+app.use(requestId())
+app.use(pinoLogger({ logger }))
+
+app.get('/', (c) => {
+  c.var.logger.info('this log entry includes reqId!')
+  return c.text('Hello!')
+})
+```
+
+### Custom Hooks
+
+You can customize how request start and end events are logged by providing `onRequest` and `onResponse` options:
+
+```typescript
+app.use(
+  pinoLogger({
+    logger,
+    onRequest: (log, c) => {
+      log.info({ path: c.req.path }, 'Incoming Request')
+    },
+    onResponse: (log, c, elapsedMs) => {
+      log.info({ status: c.res.status, elapsedMs }, 'Request Finished')
+    },
+  })
+)
+```
+
+## License
+
+MIT

--- a/packages/pino-logger/package.json
+++ b/packages/pino-logger/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@hono/pino-logger",
+  "version": "0.1.0",
+  "description": "Pino Logger middleware for Hono",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pnpm -w run build:pkg",
+    "lint": "eslint",
+    "typecheck": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "version:jsr": "pnpm -w run version:set $npm_package_version"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs"
+      },
+      "./package.json": "./package.json"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/honojs/middleware.git",
+    "directory": "packages/pino-logger"
+  },
+  "homepage": "https://github.com/honojs/middleware",
+  "peerDependencies": {
+    "hono": ">=4.0.0",
+    "pino": ">=8.0.0"
+  },
+  "devDependencies": {
+    "hono": "^4.11.5",
+    "pino": "^9.3.2",
+    "tsdown": "^0.22.3",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/packages/pino-logger/src/index.test.ts
+++ b/packages/pino-logger/src/index.test.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Hono } from 'hono'
+import type pino from 'pino'
+import { describe, expect, it, vi } from 'vitest'
+import { pinoLogger } from '.'
+
+describe('pinoLogger', () => {
+  it('should log request info and bind logger to context with default settings', async () => {
+    const mockChild = {
+      info: vi.fn(),
+    }
+    const mockLogger = {
+      child: vi.fn(() => mockChild),
+    } as unknown as pino.Logger
+
+    const app = new Hono()
+    app.use(pinoLogger({ logger: mockLogger }))
+    app.get('/', (c) => {
+      const logger = c.get('logger')
+      expect(logger).toBe(mockChild)
+      logger.info('inside handler')
+      return c.text('ok')
+    })
+
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+
+    expect(mockLogger.child).toHaveBeenCalledWith({})
+    expect(mockChild.info).toHaveBeenCalledWith('inside handler')
+    expect(mockChild.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: 'incoming request',
+        method: 'GET',
+        path: '/',
+      })
+    )
+    expect(mockChild.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: 'request completed',
+        method: 'GET',
+        path: '/',
+        status: 200,
+      })
+    )
+  })
+
+  it('should use custom contextKey', async () => {
+    const mockChild = {
+      info: vi.fn(),
+    }
+    const mockLogger = {
+      child: vi.fn(() => mockChild),
+    } as unknown as pino.Logger
+
+    const app = new Hono<{ Variables: { customLog: pino.Logger } }>()
+    app.use(pinoLogger({ logger: mockLogger, contextKey: 'customLog' }))
+    app.get('/', (c) => {
+      const logger = c.var.customLog
+      expect(logger).toBe(mockChild)
+      return c.text('ok')
+    })
+
+    const res = await app.request('/')
+    expect(res.status).toBe(200)
+  })
+
+  it('should append requestId to child logger', async () => {
+    const mockChild = {
+      info: vi.fn(),
+    }
+    const mockLogger = {
+      child: vi.fn(() => mockChild),
+    } as unknown as pino.Logger
+
+    const app = new Hono<{ Variables: { requestId: string } }>()
+    // Simulate setting requestId
+    app.use('*', async (c, next) => {
+      c.set('requestId', 'test-req-123')
+      await next()
+    })
+    app.use(pinoLogger({ logger: mockLogger }))
+    app.get('/', (c) => c.text('ok'))
+
+    await app.request('/')
+    expect(mockLogger.child).toHaveBeenCalledWith({ reqId: 'test-req-123' })
+  })
+
+  it('should fallback to x-request-id header if context requestId is missing', async () => {
+    const mockChild = {
+      info: vi.fn(),
+    }
+    const mockLogger = {
+      child: vi.fn(() => mockChild),
+    } as unknown as pino.Logger
+
+    const app = new Hono()
+    app.use(pinoLogger({ logger: mockLogger }))
+    app.get('/', (c) => c.text('ok'))
+
+    await app.request('/', {
+      headers: {
+        'x-request-id': 'header-req-456',
+      },
+    })
+    expect(mockLogger.child).toHaveBeenCalledWith({ reqId: 'header-req-456' })
+  })
+
+  it('should allow custom onRequest and onResponse hooks', async () => {
+    const mockChild = {}
+    const mockLogger = {
+      child: vi.fn(() => mockChild),
+    } as unknown as pino.Logger
+
+    const customOnRequest = vi.fn()
+    const customOnResponse = vi.fn()
+
+    const app = new Hono()
+    app.use(
+      pinoLogger({
+        logger: mockLogger,
+        onRequest: customOnRequest,
+        onResponse: customOnResponse,
+      })
+    )
+    app.get('/', (c) => c.text('ok'))
+
+    await app.request('/')
+    expect(customOnRequest).toHaveBeenCalledWith(mockChild, expect.any(Object))
+    expect(customOnResponse).toHaveBeenCalledWith(mockChild, expect.any(Object), expect.any(Number))
+  })
+})

--- a/packages/pino-logger/src/index.ts
+++ b/packages/pino-logger/src/index.ts
@@ -1,0 +1,88 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import pino from 'pino'
+import type { Logger } from 'pino'
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    logger: Logger
+  }
+}
+
+export type PinoEnv = {
+  Variables: {
+    logger: Logger
+  }
+}
+
+export interface PinoLoggerOptions {
+  /**
+   * The root Pino Logger instance.
+   * If not provided, a default Pino logger will be created.
+   */
+  logger?: Logger
+  /**
+   * The key used to store the logger instance on c.var.
+   * @default 'logger'
+   */
+  contextKey?: string
+  /**
+   * Optional custom request formatter function.
+   * Fires before the handler execution.
+   */
+  onRequest?: (logger: Logger, c: Context) => void | Promise<void>
+  /**
+   * Optional custom response formatter function.
+   * Fires after handler execution with the elapsed time in milliseconds.
+   */
+  onResponse?: (logger: Logger, c: Context, elapsedMs: number) => void | Promise<void>
+}
+
+const now = typeof performance !== 'undefined' ? () => performance.now() : () => Date.now()
+
+const defaultOnRequest = (logger: Logger, c: Context) => {
+  logger.info({
+    msg: 'incoming request',
+    method: c.req.method,
+    path: c.req.path,
+  })
+}
+
+const defaultOnResponse = (logger: Logger, c: Context, elapsedMs: number) => {
+  logger.info({
+    msg: 'request completed',
+    method: c.req.method,
+    path: c.req.path,
+    status: c.res.status,
+    elapsedMs,
+  })
+}
+
+export const pinoLogger = (opts?: PinoLoggerOptions): MiddlewareHandler => {
+  const rootLogger = opts?.logger ?? pino()
+  const contextKey = opts?.contextKey ?? 'logger'
+  const onRequest = opts?.onRequest ?? defaultOnRequest
+  const onResponse = opts?.onResponse ?? defaultOnResponse
+
+  return async (c, next) => {
+    const requestId = (c.get('requestId') as string | undefined) ?? c.req.header('x-request-id')
+    const logger = rootLogger.child(requestId ? { reqId: requestId } : {})
+
+    c.set(contextKey as never, logger as never)
+
+    const start = now()
+
+    if (onRequest) {
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      await (onRequest(logger, c) as unknown as Promise<void>)
+    }
+
+    await next()
+
+    const elapsedMs = now() - start
+
+    if (onResponse) {
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      await (onResponse(logger, c, elapsedMs) as unknown as Promise<void>)
+    }
+  }
+}

--- a/packages/pino-logger/tsconfig.build.json
+++ b/packages/pino-logger/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {},
+  "references": []
+}

--- a/packages/pino-logger/tsconfig.json
+++ b/packages/pino-logger/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/pino-logger/tsconfig.spec.json
+++ b/packages/pino-logger/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "outDir": "../../dist/packages/pino-logger",
+    "types": ["vitest/globals"]
+  },
+  "references": []
+}

--- a/packages/pino-logger/tsdown.config.ts
+++ b/packages/pino-logger/tsdown.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: 'src/index.ts',
+})

--- a/packages/pino-logger/vitest.config.ts
+++ b/packages/pino-logger/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {
+    globals: true,
+    include: ['src/**/*.test.ts'],
+    restoreMocks: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 0.3.21
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       turbo:
         specifier: ^2.10.7
         version: 2.10.7
@@ -68,6 +68,9 @@ importers:
       typia:
         specifier: ^12.1.1
         version: 12.1.1(@types/node@25.9.5)(@typescript/typescript6@6.0.2)
+      unrun:
+        specifier: ^0.3.1
+        version: 0.3.1
       vitest:
         specifier: ^4.1.7
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(msw@2.15.0(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(yaml@2.9.0))
@@ -91,7 +94,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -109,7 +112,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -133,7 +136,7 @@ importers:
         version: 19.2.8
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -151,7 +154,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -169,7 +172,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -199,7 +202,7 @@ importers:
         version: 0.3.21
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -223,7 +226,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -248,7 +251,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -276,7 +279,7 @@ importers:
         version: 19.2.8
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -294,7 +297,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -321,7 +324,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -348,7 +351,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -369,7 +372,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -411,7 +414,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -436,7 +439,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -458,7 +461,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -473,7 +476,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -488,7 +491,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -519,7 +522,7 @@ importers:
         version: 0.5.3(hono@4.12.28)(unstorage@1.17.5)
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -541,7 +544,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -566,7 +569,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -584,7 +587,7 @@ importers:
         version: 2.15.0(@types/node@25.9.5)(@typescript/typescript6@6.0.2)
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -609,7 +612,7 @@ importers:
         version: 9.0.3
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -643,7 +646,25 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(msw@2.15.0(@types/node@25.9.5)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@25.9.5)(esbuild@0.28.1)(yaml@2.9.0))
+
+  packages/pino-logger:
+    devDependencies:
+      hono:
+        specifier: ^4.11.5
+        version: 4.12.28
+      pino:
+        specifier: ^9.3.2
+        version: 9.14.0
+      tsdown:
+        specifier: ^0.22.3
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -661,7 +682,7 @@ importers:
         version: 15.1.3
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -682,7 +703,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -694,7 +715,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -721,7 +742,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -740,7 +761,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -762,7 +783,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -784,7 +805,7 @@ importers:
         version: 25.9.5
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -805,7 +826,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -829,7 +850,7 @@ importers:
         version: 10.3.1
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -850,7 +871,7 @@ importers:
         version: 12.43.1
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -865,7 +886,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -883,7 +904,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -901,7 +922,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -922,7 +943,7 @@ importers:
         version: 0.2.2
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       tsyringe:
         specifier: ^4.10.0
         version: 4.10.0
@@ -940,7 +961,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typebox:
         specifier: ^1.1.5
         version: 1.3.5
@@ -961,7 +982,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typebox:
         specifier: ^1.1.5
         version: 1.3.5
@@ -991,7 +1012,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -1012,7 +1033,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -1027,7 +1048,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -1055,7 +1076,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -1076,7 +1097,7 @@ importers:
         version: 4.12.28
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)
+        version: 0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -5761,6 +5782,9 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
@@ -5769,6 +5793,10 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pkce-challenge@5.0.1:
@@ -6446,6 +6474,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thread-stream@3.2.0:
+    resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
+
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
@@ -6742,6 +6773,16 @@ packages:
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
+
+  unrun@0.3.1:
+    resolution: {integrity: sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
 
   unstorage@1.17.5:
     resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
@@ -12123,6 +12164,10 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
@@ -12142,6 +12187,20 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
 
   pkce-challenge@5.0.1: {}
 
@@ -12995,6 +13054,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@3.2.0:
+    dependencies:
+      real-require: 0.2.0
+
   thread-stream@4.2.0:
     dependencies:
       real-require: 1.0.0
@@ -13065,7 +13128,7 @@ snapshots:
       picomatch: 4.0.5
       typescript: 6.0.3
 
-  tsdown@0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21):
+  tsdown@0.22.4(@arethetypeswrong/core@0.18.5)(@typescript/typescript6@6.0.2)(publint@0.3.21)(unrun@0.3.1):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -13086,6 +13149,7 @@ snapshots:
       '@arethetypeswrong/core': 0.18.5
       publint: 0.3.21
       typescript: '@typescript/typescript6@6.0.2'
+      unrun: 0.3.1
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -13319,6 +13383,10 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
+
+  unrun@0.3.1:
+    dependencies:
+      rolldown: 1.1.5
 
   unstorage@1.17.5:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     { "path": "packages/oauth-providers" },
     { "path": "packages/oidc-auth" },
     { "path": "packages/otel" },
+    { "path": "packages/pino-logger" },
     { "path": "packages/prometheus" },
     { "path": "packages/qwik-city" },
     { "path": "packages/react-compat" },


### PR DESCRIPTION
## Summary

Adds `@hono/pino-logger`, a production-ready structured logging middleware
that integrates Pino with Hono's context system.

## Motivation

The built-in Hono logger uses `console.log` and is development-only.
This middleware fills the production gap by providing:

- A request-bound child logger available as `c.var.logger` throughout
  the request lifecycle (typed via `ContextVariableMap`)
- Automatic `requestId` correlation (from `hono/request-id` or the
  `x-request-id` header)
- Structured JSON output via Pino with `onRequest`/`onResponse` hooks
- Zero breaking changes — fully additive new package

## Usage

```ts
import { Hono } from 'hono'
import { requestId } from 'hono/request-id'
import { pinoLogger } from '@hono/pino-logger'

const app = new Hono()
app.use(requestId())
app.use(pinoLogger())

app.get('/', (c) => {
  c.var.logger.info('handling request')
  return c.text('Hello!')
})
```

## Validation

| Check | Result |
|---|---|
| `pnpm typecheck` | ✅ 0 errors |
| `pnpm test --filter @hono/pino-logger` | ✅ 5/5 passed |
| Full workspace `pnpm test` | ✅ No regressions |
| `eslint packages/pino-logger` | ✅ Clean |
| `prettier --check packages/pino-logger` | ✅ Clean |
| CJS + ESM + `.d.ts` build | ✅ All 4 artifacts |
| Changeset | ✅ `.changeset/add-pino-logger.md` (minor) |

## Checklist

- [x] New package — no existing functionality changed
- [x] `pino` declared as `peerDependency` (>=8.0.0)
- [x] Unit tests for all behaviors
- [x] TypeScript types exported
- [x] Changeset added for versioning
- [x] README with usage examples included
