### PR TITLE
ci: include workspace dependencies in pnpm install filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           node-version-file: .tool-versions
           cache: 'pnpm'
-      - run: pnpm install --filter @hono/${{ matrix.package }}
+      - run: pnpm install --filter "@hono/${{ matrix.package }}..."
       - run: pnpm turbo --filter @hono/${{ matrix.package }} build
       - run: pnpm test --coverage --project @hono/${{ matrix.package }}
         id: test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .tool-versions
-      - run: pnpm install --filter @hono/${{ matrix.package }}
+      - run: pnpm install --filter "@hono/${{ matrix.package }}..."
       - run: pnpm turbo --filter @hono/${{ matrix.package }} build
       - run: pnpm test --coverage --project @hono/${{ matrix.package }}
         id: test


### PR DESCRIPTION
CI fails with `Cannot find module 'zod/v3'` when testing `@hono/zod-openapi`.

This is because `pnpm install --filter @hono/<package>` does not install devDependencies of workspace dependencies. `zod` is a devDependency of `@hono/zod-validator`, so it is missing.

The `...` suffix fixes this. It installs workspace dependencies too.

Found in #1988.

### The author should do the following, if applicable

- [ ] Add tests
- [x] Run tests
- [ ] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
