### PR TITLE
fix(inertia): normalize empty props in PageProps

### DIFF
--- a/.changeset/fast-kings-reply.md
+++ b/.changeset/fast-kings-reply.md
@@ -1,0 +1,5 @@
+---
+'@hono/inertia': patch
+---
+
+Normalize the props resolved by `PageProps`: renders without props now resolve to `{}`, and when the same page is rendered with and without props by different handlers, the props are made optional.

--- a/.changeset/fast-kings-reply.md
+++ b/.changeset/fast-kings-reply.md
@@ -2,4 +2,4 @@
 '@hono/inertia': patch
 ---
 
-Normalize the props resolved by `PageProps`: renders without props now resolve to `{}`, and when the same page is rendered with and without props by different handlers, the props are made optional.
+Normalize the props resolved by `PageProps`: renders without props now resolve to `{}`, and when the same page is rendered with and without props by different handlers, the props-less variant shares the other renders' keys as optional `never`, so absent props must be accessed with `?.`.

--- a/packages/inertia/src/page-props.test.ts
+++ b/packages/inertia/src/page-props.test.ts
@@ -5,17 +5,13 @@ import { inertia } from './index'
 
 const _app = new Hono()
   .use(inertia())
-  .get('/with-props', (c) => c.render('WithProps', { lazy: () => Promise.resolve({ id: 0 }) }))
+  .get('/lazy-props', (c) => c.render('LazyProps', { lazy: () => Promise.resolve({ id: 0 }) }))
   .get('/without-props', (c) => c.render('WithoutProps'))
-  .post(
-    '/optional-props',
-    (c) => c.render('OptionalProps', { errors: { email: 'invalid' } }),
-    (c) => c.render('OptionalProps')
-  )
   .get(
     '/union-props',
-    (c) => c.render('UnionProps', { a: 0 }),
-    (c) => c.render('UnionProps', { b: 'string' })
+    (c) => c.render('UnionProps'),
+    (c) => c.render('UnionProps', { kind: 'ok' as const, value: 0 }),
+    (c) => c.render('UnionProps', { kind: 'ng' as const, error: 'message' })
   )
 
 declare module '@hono/inertia' {
@@ -25,19 +21,19 @@ declare module '@hono/inertia' {
 }
 
 describe('PageProps', () => {
-  it('resolves lazy prop values', () => {
-    expectTypeOf<PageProps<'WithProps'>>().toEqualTypeOf<{ lazy: { id: number } }>()
+  it('resolves lazy props', () => {
+    expectTypeOf<PageProps<'LazyProps'>>().toEqualTypeOf<{ lazy: { id: number } }>()
   })
 
-  it('collapses the props of a render without props to {}', () => {
+  it('normalizes renders without props to {}', () => {
     expectTypeOf<PageProps<'WithoutProps'>>().toEqualTypeOf<{}>()
   })
 
-  it('makes the props optional when multiple handlers render the same page with and without props', () => {
-    expectTypeOf<PageProps<'OptionalProps'>>().toEqualTypeOf<{ errors?: { email: string } }>()
-  })
-
-  it('keeps non-empty props from multiple handlers', () => {
-    expectTypeOf<PageProps<'UnionProps'>>().toEqualTypeOf<{ a: number } | { b: string }>()
+  it('normalizes union types', () => {
+    expectTypeOf<PageProps<'UnionProps'>>().toEqualTypeOf<
+      | { kind: 'ok'; value: number }
+      | { kind: 'ng'; error: string }
+      | { kind?: never; value?: never; error?: never }
+    >()
   })
 })

--- a/packages/inertia/src/page-props.test.ts
+++ b/packages/inertia/src/page-props.test.ts
@@ -8,10 +8,15 @@ const _app = new Hono()
   .get('/lazy-props', (c) => c.render('LazyProps', { lazy: () => Promise.resolve({ id: 0 }) }))
   .get('/without-props', (c) => c.render('WithoutProps'))
   .get(
-    '/union-props',
-    (c) => c.render('UnionProps'),
-    (c) => c.render('UnionProps', { kind: 'ok' as const, value: 0 }),
-    (c) => c.render('UnionProps', { kind: 'ng' as const, error: 'message' })
+    '/union-with-empty-props',
+    (c) => c.render('UnionWithEmptyProps'),
+    (c) => c.render('UnionWithEmptyProps', { kind: 'ok' as const, value: 0 }),
+    (c) => c.render('UnionWithEmptyProps', { kind: 'ng' as const, error: 'message' })
+  )
+  .get(
+    '/union-without-empty-props',
+    (c) => c.render('UnionWithoutEmptyProps', { a: 0 }),
+    (c) => c.render('UnionWithoutEmptyProps', { b: 'string' })
   )
 
 declare module '@hono/inertia' {
@@ -29,11 +34,17 @@ describe('PageProps', () => {
     expectTypeOf<PageProps<'WithoutProps'>>().toEqualTypeOf<{}>()
   })
 
-  it('normalizes union types', () => {
-    expectTypeOf<PageProps<'UnionProps'>>().toEqualTypeOf<
+  it('normalizes unions with empty props', () => {
+    expectTypeOf<PageProps<'UnionWithEmptyProps'>>().toEqualTypeOf<
       | { kind: 'ok'; value: number }
       | { kind: 'ng'; error: string }
       | { kind?: never; value?: never; error?: never }
+    >()
+  })
+
+  it('preserves unions without empty props', () => {
+    expectTypeOf<PageProps<'UnionWithoutEmptyProps'>>().toEqualTypeOf<
+      { a: number } | { b: string }
     >()
   })
 })

--- a/packages/inertia/src/page-props.test.ts
+++ b/packages/inertia/src/page-props.test.ts
@@ -1,0 +1,43 @@
+import { Hono } from 'hono'
+import { describe, expectTypeOf, it } from 'vitest'
+import type { PageProps } from './page-props'
+import { inertia } from './index'
+
+const _app = new Hono()
+  .use(inertia())
+  .get('/with-props', (c) => c.render('WithProps', { lazy: () => Promise.resolve({ id: 0 }) }))
+  .get('/without-props', (c) => c.render('WithoutProps'))
+  .post(
+    '/optional-props',
+    (c) => c.render('OptionalProps', { errors: { email: 'invalid' } }),
+    (c) => c.render('OptionalProps')
+  )
+  .get(
+    '/union-props',
+    (c) => c.render('UnionProps', { a: 0 }),
+    (c) => c.render('UnionProps', { b: 'string' })
+  )
+
+declare module '@hono/inertia' {
+  interface AppRegistry {
+    app: typeof _app
+  }
+}
+
+describe('PageProps', () => {
+  it('resolves lazy prop values', () => {
+    expectTypeOf<PageProps<'WithProps'>>().toEqualTypeOf<{ lazy: { id: number } }>()
+  })
+
+  it('collapses the props of a render without props to {}', () => {
+    expectTypeOf<PageProps<'WithoutProps'>>().toEqualTypeOf<{}>()
+  })
+
+  it('makes the props optional when multiple handlers render the same page with and without props', () => {
+    expectTypeOf<PageProps<'OptionalProps'>>().toEqualTypeOf<{ errors?: { email: string } }>()
+  })
+
+  it('keeps non-empty props from multiple handlers', () => {
+    expectTypeOf<PageProps<'UnionProps'>>().toEqualTypeOf<{ a: number } | { b: string }>()
+  })
+})

--- a/packages/inertia/src/page-props.ts
+++ b/packages/inertia/src/page-props.ts
@@ -49,6 +49,22 @@ type RenderOutput<App> =
       : never
     : never
 
+type NonEmptyProps<T> = T extends Record<string, never> ? never : T
+
+type NormalizeProps<T> = [T] extends [never]
+  ? never
+  : [NonEmptyProps<T>] extends [never]
+    ? {}
+    : [Extract<T, Record<string, never>>] extends [never]
+      ? NonEmptyProps<T>
+      : Partial<NonEmptyProps<T>>
+
+/**
+ * Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
+ * @copyright from sindresorhus/type-fest
+ */
+type Simplify<T> = { [K in keyof T]: T[K] } & {}
+
 /**
  * Resolves the props type for a given Inertia page component name.
  *
@@ -56,4 +72,6 @@ type RenderOutput<App> =
  */
 export type PageProps<
   C extends RenderOutput<RegisteredApp>['component'] = RenderOutput<RegisteredApp>['component'],
-> = Extract<RenderOutput<RegisteredApp>, { component: C }>['props']
+> = C extends unknown
+  ? Simplify<NormalizeProps<Extract<RenderOutput<RegisteredApp>, { component: C }>['props']>>
+  : never

--- a/packages/inertia/src/page-props.ts
+++ b/packages/inertia/src/page-props.ts
@@ -53,9 +53,10 @@ type AllKeys<T> = T extends unknown ? keyof T : never
  * Props-less renders are normalized to the other renders' keys as optional `never`,
  * so access keeps working while the value may still be `undefined`.
  */
-type NormalizeProps<T, All = T> = T extends Record<string, never>
-  ? { [K in AllKeys<Exclude<All, Record<string, never>>>]?: never }
-  : T
+type NormalizeProps<T, All = T> =
+  T extends Record<string, never>
+    ? { [K in AllKeys<Exclude<All, Record<string, never>>>]?: never }
+    : T
 
 /**
  * Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aid with assignability.

--- a/packages/inertia/src/page-props.ts
+++ b/packages/inertia/src/page-props.ts
@@ -47,18 +47,18 @@ type RenderOutput<App> =
       : never
     : never
 
-type NonEmptyProps<T> = T extends Record<string, never> ? never : T
-
-type NormalizeProps<T> = [T] extends [never]
-  ? never
-  : [NonEmptyProps<T>] extends [never]
-    ? {}
-    : [Extract<T, Record<string, never>>] extends [never]
-      ? T
-      : Partial<NonEmptyProps<T>>
+type AllKeys<T> = T extends unknown ? keyof T : never
 
 /**
- * Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aide with assignability.
+ * Props-less renders are normalized to the other renders' keys as optional `never`,
+ * so access keeps working while the value may still be `undefined`.
+ */
+type NormalizeProps<T, All = T> = T extends Record<string, never>
+  ? { [K in AllKeys<Exclude<All, Record<string, never>>>]?: never }
+  : T
+
+/**
+ * Useful to flatten the type output to improve type hints shown in editors. And also to transform an interface into a type to aid with assignability.
  * @copyright from sindresorhus/type-fest
  */
 type Simplify<T> = { [K in keyof T]: T[K] } & {}

--- a/packages/inertia/src/page-props.ts
+++ b/packages/inertia/src/page-props.ts
@@ -54,7 +54,7 @@ type NormalizeProps<T> = [T] extends [never]
   : [NonEmptyProps<T>] extends [never]
     ? {}
     : [Extract<T, Record<string, never>>] extends [never]
-      ? NonEmptyProps<T>
+      ? T
       : Partial<NonEmptyProps<T>>
 
 /**

--- a/packages/inertia/src/page-props.ts
+++ b/packages/inertia/src/page-props.ts
@@ -28,16 +28,14 @@ type RegisteredApp = AppRegistry extends { app: infer A } ? A : never
 
 type Distribute<T> = T extends infer U ? U : never
 
+type MethodOutput<MethodSchema> = MethodSchema extends { output: infer O } ? Distribute<O> : never
+
 type AllOutputs<App> = Distribute<
   {
     [Path in keyof ExtractSchema<App> & string]: {
-      [
-        Method in keyof ExtractSchema<App>[Path] & string
-      ]: ExtractSchema<App>[Path][Method] extends {
-        output: infer O
-      }
-        ? Distribute<O>
-        : never
+      [Method in keyof ExtractSchema<App>[Path] & string]: MethodOutput<
+        ExtractSchema<App>[Path][Method]
+      >
     }[keyof ExtractSchema<App>[Path] & string]
   }[keyof ExtractSchema<App> & string]
 >


### PR DESCRIPTION
## What

Normalize the props resolved by `PageProps`:

- Renders without props resolve to `{}`.
- When multiple handlers render the same page, each handler's prop shape becomes its own member of the resulting union.
- When the page is rendered both with and without props, the props-less variant shares the other renders' keys as optional `never`, so absent props must be accessed with `?.`.

## Problem

- Props-less renders resolved to `Record<string, never>`: accessing nonexistent props produces no error.
- When the same page is rendered with and without props by different handlers, the merged props type is `Record<string, never> | { errors: Record<string, string> }`. Because `Record<string, never>` has an index signature, `props.errors` type-checks as always present, but the prop can be `undefined` at runtime when the props-less handler runs.

## Fix

Apply an internal `NormalizeProps` helper in `src/page-props.ts`:

- renders without props → `{}`
- mixed renders (same page, with and without props) → the props-less variant is rewritten to `{ [K in keyof OtherVariants]?: never }`, keeping existing property accesses valid while forcing `?.` for values that may be absent
- renders with different prop shapes keep their own union members

The normalized result is flattened with `Simplify`.
The helper is not exported, so the public d.ts surface is unchanged.

## Changes

- `src/page-props.ts` — normalization, `Simplify` flattening, `MethodOutput` distribution
- `src/page-props.test.ts` — type tests via `PageProps` + `AppRegistry`
- `.changeset/fast-kings-reply.md` — patch changeset

Type-only change.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)