### PR TITLE
fix(inertia): return 303 for redirects from PUT/PATCH/DELETE

### DIFF
--- a/.changeset/tidy-pugs-repeat.md
+++ b/.changeset/tidy-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@hono/inertia': patch
+---
+
+Rewrite `302` redirects to `303` for `PUT`, `PATCH`, and `DELETE` Inertia requests, so the client follows them with a `GET` instead of replaying the original method against the redirect target.

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -191,6 +191,21 @@ When the `Referer` header is unavailable (e.g. under a `no-referrer` Referrer-Po
 app.post('/users', (c) => c.render('Users/New', {}, { url: '/users/new' }))
 ```
 
+## Redirects
+
+Redirect the way you normally would in Hono:
+
+```ts
+app.put('/users/:id', async (c) => {
+  await updateUser(c.req.param('id'), await c.req.parseBody())
+  return c.redirect('/users')
+})
+```
+
+The Inertia protocol requires redirects issued from `PUT`, `PATCH`, and `DELETE` requests to use [`303 See Other`](https://inertiajs.com/redirects): with a `302` the client replays the original method against the redirect target instead of following it with a `GET`. The middleware rewrites `302` to `303` for those methods on Inertia requests, so `c.redirect` needs no special casing.
+
+Non-Inertia requests, `POST` redirects, and explicit statuses such as `307` are left untouched.
+
 ## Partial reloads
 
 Inertia's [partial reloads](https://inertiajs.com/partial-reloads) let a single visit re-fetch only a subset of the page's props, leaving the rest as they were. `@hono/inertia` honors the `X-Inertia-Partial-Component`, `X-Inertia-Partial-Data`, and `X-Inertia-Partial-Except` headers transparently — the route signature stays the same.

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -194,6 +194,67 @@ describe('inertia', () => {
     })
   })
 
+  describe('redirects', () => {
+    const redirectApp = () =>
+      new Hono()
+        .use(inertia())
+        .put('/users/1', (c) => c.redirect('/users'))
+        .patch('/users/1', (c) => c.redirect('/users'))
+        .delete('/users/1', (c) => c.redirect('/users'))
+        .post('/users', (c) => c.redirect('/users'))
+
+    for (const method of ['PUT', 'PATCH', 'DELETE'] as const) {
+      it(`converts a 302 into a 303 on ${method}`, async () => {
+        const res = await redirectApp().request('/users/1', {
+          method,
+          headers: { 'X-Inertia': 'true' },
+        })
+
+        expect(res.status).toBe(303)
+        expect(res.headers.get('Location')).toBe('/users')
+      })
+    }
+
+    it('leaves POST redirects at 302', async () => {
+      const res = await redirectApp().request('/users', {
+        method: 'POST',
+        headers: { 'X-Inertia': 'true' },
+      })
+
+      expect(res.status).toBe(302)
+    })
+
+    it('leaves non Inertia requests untouched', async () => {
+      const res = await redirectApp().request('/users/1', { method: 'PUT' })
+
+      expect(res.status).toBe(302)
+    })
+
+    it('leaves other redirect statuses untouched', async () => {
+      const app = new Hono().use(inertia()).put('/users/1', (c) => c.redirect('/users', 307))
+
+      const res = await app.request('/users/1', {
+        method: 'PUT',
+        headers: { 'X-Inertia': 'true' },
+      })
+
+      expect(res.status).toBe(307)
+    })
+
+    it('leaves rendered responses untouched', async () => {
+      const app = new Hono()
+        .use(inertia())
+        .put('/users/1', (c) => c.render('Users/Edit', { id: '1' }))
+
+      const res = await app.request('/users/1', {
+        method: 'PUT',
+        headers: { 'X-Inertia': 'true' },
+      })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
   describe('page.url resolution', () => {
     it('uses c.req.url for GET requests', async () => {
       const app = new Hono()

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -655,7 +655,21 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       ).then((entries) => respond(Object.fromEntries(entries)))
     }) as Parameters<typeof c.setRenderer>[0])
 
-    return next()
+    await next()
+
+    // Redirects issued from PUT / PATCH / DELETE must be 303, not 302: a 302
+    // makes the client replay the original method against the redirect target,
+    // while 303 forces the follow-up request to be a GET.
+    // https://inertiajs.com/redirects
+    if (
+      c.req.header('X-Inertia') &&
+      c.res.status === 302 &&
+      (c.req.method === 'PUT' || c.req.method === 'PATCH' || c.req.method === 'DELETE')
+    ) {
+      c.res = new Response(c.res.body, { status: 303, headers: c.res.headers })
+    }
+
+    return c.res
   }
 }
 


### PR DESCRIPTION
## Summary

Redirects issued from `PUT`, `PATCH`, and `DELETE` handlers are returned as `302`. Per the [Fetch spec](https://fetch.spec.whatwg.org/#http-redirect-fetch), a `302` only downgrades `POST` to `GET` — for the other methods the client replays the original method against the redirect target. So `c.redirect('/users')` inside `app.put('/users/:id')` makes the Inertia client issue `PUT /users` instead of `GET /users`.

The Inertia protocol [requires `303` here](https://inertiajs.com/redirects), and `inertia-laravel` performs the same rewrite in its middleware.

Reproduced with a plain Node server and `fetch`, no Inertia involved:

```
PUT  → 302:  PUT /update-302   →  PUT /target    💥
PUT  → 303:  PUT /update-303   →  GET /target    ✅
POST → 302:  POST /update-302  →  GET /target    (already correct)
```

## Protocol behaviour

| Request | Handler returns | Before | After |
| --- | --- | --- | --- |
| `PUT` / `PATCH` / `DELETE` + `X-Inertia` | `302` | `302` | **`303`** |
| `POST` + `X-Inertia` | `302` | `302` | `302` |
| any method, no `X-Inertia` | `302` | `302` | `302` |
| `PUT` + `X-Inertia` | `307` / `308` | unchanged | unchanged |
| `PUT` + `X-Inertia` | `c.render(...)` | `200` | `200` |

## Implementation

The middleware now awaits `next()` and rewrites the status on the way out.

| Scope | |
| --- | --- |
| `302` → `303` for `PUT` / `PATCH` / `DELETE` on Inertia requests | ✅ |
| Non-Inertia requests left untouched | ✅ |
| `POST` left untouched (a `302` already becomes a `GET`) | ✅ |
| Other statuses (`301`, `307`, `308`, `200`) left untouched | ✅ |
| `Vary` on responses that don't go through `c.render` | ❌ separate gap, follow-up |

The gating matches `inertia-laravel`'s `Middleware::handle`: the Inertia header must be present, and only `302` is rewritten.

`return next()` became `await next()` + `return c.res`. The explicit return keeps `noImplicitReturns` satisfied now that the version-mismatch branch is no longer the only path returning a value.

## Test plan

- [x] `302` → `303` for `PUT`, `PATCH`, `DELETE`
- [x] `POST` stays `302`
- [x] non-Inertia `PUT` stays `302`
- [x] `307` stays `307`
- [x] a rendered `PUT` response stays `200`
- [x] full suite (71 tests), typecheck, lint, format

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
