### PR TITLE
perf(zod): upgrade to Zod 4.5 and optimize header validation

### DIFF
--- a/.changeset/zod-performance.md
+++ b/.changeset/zod-performance.md
@@ -1,0 +1,7 @@
+---
+'@hono/zod-openapi': minor
+'@hono/zod-validator': minor
+---
+
+Updated Zod 4 support to version 4.5.  
+Cached case-insensitive header schema metadata when creating validator middleware.

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=4.10.0",
-    "zod": "^4.0.0"
+    "zod": "^4.5.2"
   },
   "devDependencies": {
     "hono": "^4.11.5",
@@ -49,7 +49,7 @@
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vitest": "^4.1.7",
     "yaml": "^2.8.2",
-    "zod": "^4.2.1"
+    "zod": "^4.5.2"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^9.1.0",

--- a/packages/zod-validator/package.json
+++ b/packages/zod-validator/package.json
@@ -41,13 +41,13 @@
   "homepage": "https://github.com/honojs/middleware",
   "peerDependencies": {
     "hono": ">=4.11.2",
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^3.25.0 || ^4.5.2"
   },
   "devDependencies": {
     "hono": "^4.11.5",
     "tsdown": "^0.22.3",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vitest": "^4.1.7",
-    "zod": "^4.2.1"
+    "zod": "^4.5.2"
   }
 }

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -136,20 +136,24 @@ function zValidatorFunction<
 ):
   | MiddlewareHandler<E, P, V, ZodValidatorFailureResponse<T>>
   | MiddlewareHandler<E, P, V, ExtractValidationResponse<HookFn>> {
+  const caseInsensitiveKeymap =
+    target === 'header' && ('_def' in schema || '_zod' in schema)
+      ? Object.fromEntries(
+          // @ts-expect-error the schema is a Zod Schema
+          Object.keys('in' in schema ? schema.in.shape : schema.shape).map((key) => [
+            key.toLowerCase(),
+            key,
+          ])
+        )
+      : undefined
+
   // @ts-expect-error not typed well
   return validator(target, async (value: ValidationTargets[Target], c) => {
     let validatorValue = value
 
     // in case where our `target` === `header`, Hono parses all of the headers into lowercase.
     // this might not match the Zod schema, so we want to make sure that we account for that when parsing the schema.
-    if ((target === 'header' && '_def' in schema) || (target === 'header' && '_zod' in schema)) {
-      // create an object that maps lowercase schema keys to lowercase
-      // @ts-expect-error the schema is a Zod Schema
-      const schemaKeys = Object.keys('in' in schema ? schema.in.shape : schema.shape)
-      const caseInsensitiveKeymap = Object.fromEntries(
-        schemaKeys.map((key) => [key.toLowerCase(), key])
-      )
-
+    if (caseInsensitiveKeymap) {
       validatorValue = Object.fromEntries(
         Object.entries(value).map(([key, value]) => [caseInsensitiveKeymap[key] || key, value])
       )

--- a/packages/zod-validator/src/v3.test.ts
+++ b/packages/zod-validator/src/v3.test.ts
@@ -476,6 +476,30 @@ describe('Only Types', () => {
 })
 
 describe('Case-Insensitive Headers', () => {
+  it('Should inspect the header schema shape only once', async () => {
+    const app = new Hono()
+    const headerSchema = z.object({
+      Authorization: z.string(),
+    })
+    const shape = headerSchema.shape
+    let shapeInspections = 0
+    Object.defineProperty(headerSchema, 'shape', {
+      value: new Proxy(shape, {
+        ownKeys(target) {
+          shapeInspections++
+          return Reflect.ownKeys(target)
+        },
+      }),
+    })
+
+    app.get('/', zValidator('header', headerSchema), (c) => c.json(c.req.valid('header')))
+
+    await app.request('/', { headers: { Authorization: 'Bearer token' } })
+    await app.request('/', { headers: { Authorization: 'Bearer token' } })
+
+    expect(shapeInspections).toBe(1)
+  })
+
   it('Should ignore the case for headers in the Zod schema and return 200', () => {
     const app = new Hono()
     const headerSchema = z.object({

--- a/packages/zod-validator/src/v4.test.ts
+++ b/packages/zod-validator/src/v4.test.ts
@@ -481,6 +481,30 @@ describe('Only Types', () => {
 })
 
 describe('Case-Insensitive Headers', () => {
+  it('Should inspect the header schema shape only once', async () => {
+    const app = new Hono()
+    const headerSchema = z.object({
+      Authorization: z.string(),
+    })
+    const shape = headerSchema.shape
+    let shapeInspections = 0
+    Object.defineProperty(headerSchema, 'shape', {
+      value: new Proxy(shape, {
+        ownKeys(target) {
+          shapeInspections++
+          return Reflect.ownKeys(target)
+        },
+      }),
+    })
+
+    app.get('/', zValidator('header', headerSchema), (c) => c.json(c.req.valid('header')))
+
+    await app.request('/', { headers: { Authorization: 'Bearer token' } })
+    await app.request('/', { headers: { Authorization: 'Bearer token' } })
+
+    expect(shapeInspections).toBe(1)
+  })
+
   it('Should ignore the case for headers in the Zod schema and return 200', () => {
     const app = new Hono()
     const headerSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1042,7 +1042,7 @@ importers:
     dependencies:
       '@asteasolutions/zod-to-openapi':
         specifier: ^9.1.0
-        version: 9.1.0(zod@4.4.3)
+        version: 9.1.0(zod@4.5.2)
       '@hono/zod-validator':
         specifier: workspace:^
         version: link:../zod-validator
@@ -1066,8 +1066,8 @@ importers:
         specifier: ^2.8.2
         version: 2.9.0
       zod:
-        specifier: ^4.2.1
-        version: 4.4.3
+        specifier: ^4.5.2
+        version: 4.5.2
 
   packages/zod-validator:
     devDependencies:
@@ -1084,8 +1084,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-istanbul@4.1.10)(msw@2.15.0(@types/node@26.2.0)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@26.2.0)(esbuild@0.28.2)(yaml@2.9.0))
       zod:
-        specifier: ^4.2.1
-        version: 4.4.3
+        specifier: ^4.5.2
+        version: 4.5.2
 
 packages:
 
@@ -7570,6 +7570,9 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zod@4.5.2:
+    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -7619,10 +7622,10 @@ snapshots:
 
   '@ark/util@0.56.2': {}
 
-  '@asteasolutions/zod-to-openapi@9.1.0(zod@4.4.3)':
+  '@asteasolutions/zod-to-openapi@9.1.0(zod@4.5.2)':
     dependencies:
       openapi3-ts: 4.6.0
-      zod: 4.4.3
+      zod: 4.5.2
 
   '@auth/core@0.35.3':
     dependencies:
@@ -14627,5 +14630,7 @@ snapshots:
   zod@3.25.48: {}
 
   zod@4.4.3: {}
+
+  zod@4.5.2: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- upgrade Zod 4 support to Zod 4.5.2
- require Zod `^4.5.2` in `@hono/zod-openapi`
- require Zod `^3.25.0 || ^4.5.2` in `@hono/zod-validator`
- cache the case-insensitive header key mapping when creating validator middleware instead of rebuilding it for every request
- add regression tests for both Zod 3 and Zod 4

Zod 4.5.2 was released less than 24 hours ago and is currently being rejected by the repository's supply chain policy check, so this PR remains in draft status.

Once 24 hours have passed since the release, the following steps will be taken:

- Regenerate `pnpm-lock.yaml`
- Rerun package tests and policy checks
- Mark this PR as ready for review

## Benchmark

Benchmarks use 20-field schemas and report median throughput.

### Header validation

The end-to-end Hono benchmark uses mixed-case schema keys and lowercase request headers.

| Implementation | Throughput |
| --- | ---: |
| Before, Zod 4.5.2 | 78,743 ops/s |
| After, Zod 4.5.2 | 104,317 ops/s |
| Improvement | **+32.5%** |

The improvement comes from building the case-insensitive key mapping once when the middleware is created instead of inspecting the schema on every request.

### Invalid query validation

A separate-process paired benchmark was used to check whether moving the header metadata initialization affected non-header validation.

| Implementation | Throughput |
| --- | ---: |
| Before, Zod 4.5.2 | 65,231 ops/s |
| After, Zod 4.5.2 | 64,970 ops/s |
| Difference | **-0.4%** |

### Schema creation and retained memory

The following results compare Zod 4.4.3 and Zod 4.5.2 while creating 1,000 object schemas with 20 fields.

| Metric | Zod 4.4.3 | Zod 4.5.2 | Difference |
| --- | ---: | ---: | ---: |
| Schema creation | 1,676 schemas/s | 5,709 schemas/s | **3.41x faster** |
| Retained heap per schema | 326,820 bytes | 61,198 bytes | **81.3% less** |

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [ ] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
