### PR TITLE
perf(zod-validator): optimize header validation

### DIFF
--- a/.changeset/spicy-weeks-know.md
+++ b/.changeset/spicy-weeks-know.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-validator': patch
+---
+
+Cached case-insensitive header schema metadata when creating validator middleware.

--- a/packages/zod-validator/src/index.ts
+++ b/packages/zod-validator/src/index.ts
@@ -136,20 +136,24 @@ function zValidatorFunction<
 ):
   | MiddlewareHandler<E, P, V, ZodValidatorFailureResponse<T>>
   | MiddlewareHandler<E, P, V, ExtractValidationResponse<HookFn>> {
+  const caseInsensitiveKeymap =
+    target === 'header' && ('_def' in schema || '_zod' in schema)
+      ? Object.fromEntries(
+          // @ts-expect-error the schema is a Zod Schema
+          Object.keys('in' in schema ? schema.in.shape : schema.shape).map((key) => [
+            key.toLowerCase(),
+            key,
+          ])
+        )
+      : undefined
+
   // @ts-expect-error not typed well
   return validator(target, async (value: ValidationTargets[Target], c) => {
     let validatorValue = value
 
     // in case where our `target` === `header`, Hono parses all of the headers into lowercase.
     // this might not match the Zod schema, so we want to make sure that we account for that when parsing the schema.
-    if ((target === 'header' && '_def' in schema) || (target === 'header' && '_zod' in schema)) {
-      // create an object that maps lowercase schema keys to lowercase
-      // @ts-expect-error the schema is a Zod Schema
-      const schemaKeys = Object.keys('in' in schema ? schema.in.shape : schema.shape)
-      const caseInsensitiveKeymap = Object.fromEntries(
-        schemaKeys.map((key) => [key.toLowerCase(), key])
-      )
-
+    if (caseInsensitiveKeymap) {
       validatorValue = Object.fromEntries(
         Object.entries(value).map(([key, value]) => [caseInsensitiveKeymap[key] || key, value])
       )

--- a/packages/zod-validator/src/v3.test.ts
+++ b/packages/zod-validator/src/v3.test.ts
@@ -476,6 +476,30 @@ describe('Only Types', () => {
 })
 
 describe('Case-Insensitive Headers', () => {
+  it('Should inspect the header schema shape only once', async () => {
+    const app = new Hono()
+    const headerSchema = z.object({
+      Authorization: z.string(),
+    })
+    const shape = headerSchema.shape
+    let shapeInspections = 0
+    Object.defineProperty(headerSchema, 'shape', {
+      value: new Proxy(shape, {
+        ownKeys(target) {
+          shapeInspections++
+          return Reflect.ownKeys(target)
+        },
+      }),
+    })
+
+    app.get('/', zValidator('header', headerSchema), (c) => c.json(c.req.valid('header')))
+
+    await app.request('/', { headers: { Authorization: 'Bearer token' } })
+    await app.request('/', { headers: { Authorization: 'Bearer token' } })
+
+    expect(shapeInspections).toBe(1)
+  })
+
   it('Should ignore the case for headers in the Zod schema and return 200', () => {
     const app = new Hono()
     const headerSchema = z.object({

--- a/packages/zod-validator/src/v4.test.ts
+++ b/packages/zod-validator/src/v4.test.ts
@@ -481,6 +481,30 @@ describe('Only Types', () => {
 })
 
 describe('Case-Insensitive Headers', () => {
+  it('Should inspect the header schema shape only once', async () => {
+    const app = new Hono()
+    const headerSchema = z.object({
+      Authorization: z.string(),
+    })
+    const shape = headerSchema.shape
+    let shapeInspections = 0
+    Object.defineProperty(headerSchema, 'shape', {
+      value: new Proxy(shape, {
+        ownKeys(target) {
+          shapeInspections++
+          return Reflect.ownKeys(target)
+        },
+      }),
+    })
+
+    app.get('/', zValidator('header', headerSchema), (c) => c.json(c.req.valid('header')))
+
+    await app.request('/', { headers: { Authorization: 'Bearer token' } })
+    await app.request('/', { headers: { Authorization: 'Bearer token' } })
+
+    expect(shapeInspections).toBe(1)
+  })
+
   it('Should ignore the case for headers in the Zod schema and return 200', () => {
     const app = new Hono()
     const headerSchema = z.object({


### PR DESCRIPTION
## Summary

- cache the case-insensitive header key mapping when creating validator middleware instead of rebuilding it for every request
- avoid repeatedly inspecting the header schema shape during validation
- add regression tests for both Zod 3 and Zod 4

## Benchmark

Benchmarks use Zod 4.4.3 with 20-field schemas and report median throughput.

The before and after implementations were measured in separate Node.js processes across 10 paired runs, with five samples per process.

### Header validation

The end-to-end Hono benchmark uses mixed-case schema keys and lowercase request headers.

| Implementation |    Throughput |
| -------------- | ------------: |
| Before         |  86,699 ops/s |
| After          | 123,357 ops/s |
| Improvement    |    **+42.3%** |

The improvement comes from building the case-insensitive key mapping once when the middleware is created instead of inspecting the schema and rebuilding the mapping for every request.

The 95% confidence interval was `+35.2%` to `+48.6%`.

### Invalid query validation

A separate-process paired benchmark was used as a control to check whether moving the header metadata initialization affected non-header validation.

| Implementation |   Throughput |
| -------------- | -----------: |
| Before         | 38,695 ops/s |
| After          | 39,704 ops/s |
| Difference     |    **+2.6%** |

The 95% confidence interval was `-1.8%` to `+7.8%`, indicating no meaningful performance change outside the header-validation path.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
