### PR TITLE
perf(zod-openapi): Flatten batched route schemas

### DIFF
--- a/.changeset/flat-routes-scale.md
+++ b/.changeset/flat-routes-scale.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Flatten batched route type inference so large `openapiRoutes` tuples do not hit TypeScript's recursive instantiation limit.

--- a/packages/zod-openapi/eslint-suppressions.json
+++ b/packages/zod-openapi/eslint-suppressions.json
@@ -26,7 +26,7 @@
       "count": 1
     },
     "@typescript-eslint/no-unsafe-member-access": {
-      "count": 4
+      "count": 7
     },
     "@typescript-eslint/no-unsafe-return": {
       "count": 1

--- a/packages/zod-openapi/src/index.test.ts
+++ b/packages/zod-openapi/src/index.test.ts
@@ -3282,6 +3282,11 @@ describe('openapiRoutes', () => {
 
     const app = new OpenAPIHono().openapiRoutes(routes)
 
+    const client = hc<typeof app>('http://localhost')
+    expectTypeOf(client.enabled.$get).toBeFunction()
+    // @ts-expect-error addRoute: false excludes the route from the RPC schema
+    client.disabled.$get
+
     const enabledRes = await app.request('/enabled')
     expect(enabledRes.status).toBe(200)
 
@@ -3291,6 +3296,53 @@ describe('openapiRoutes', () => {
     // The route should technically still be in OpenAPI definitions
     // if `hide: true` is not set, but the actual Hono router won't have it.
     // Let's verify type safety and runtime behaviors.
+  })
+
+  it('Should preserve empty and widened batch RPC behavior', () => {
+    const route = defineOpenAPIRoute({
+      route: createRoute({
+        method: 'get',
+        path: '/widened',
+        responses: {
+          200: {
+            description: 'Widened route',
+          },
+        },
+      }),
+      handler: (c) => c.body(null, 200),
+    })
+
+    const emptyApp = new OpenAPIHono().openapiRoutes([] as const)
+    const emptyClient = hc<typeof emptyApp>('http://localhost')
+    // @ts-expect-error an empty batch exposes no RPC routes
+    emptyClient.missing.$get
+
+    const widenedRoutes: (typeof route)[] = [route]
+    const widenedApp = new OpenAPIHono().openapiRoutes(widenedRoutes)
+    const widenedClient = hc<typeof widenedApp>('http://localhost')
+    // @ts-expect-error widened arrays retain the existing empty RPC schema
+    widenedClient.widened.$get
+  })
+
+  it('Should typecheck batches beyond the recursive instantiation limit', () => {
+    const route = defineOpenAPIRoute({
+      route: createRoute({
+        method: 'get',
+        path: '/large-batch',
+        responses: {
+          200: {
+            description: 'Large batch route',
+          },
+        },
+      }),
+      handler: (c) => c.body(null, 200),
+    })
+    const routes10 = [route, route, route, route, route, route, route, route, route, route] as const
+    const routes50 = [...routes10, ...routes10, ...routes10, ...routes10, ...routes10] as const
+
+    const app = new OpenAPIHono().openapiRoutes(routes50)
+    const client = hc<typeof app>('http://localhost')
+    expectTypeOf(client['large-batch'].$get).toBeFunction()
   })
 })
 

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -367,26 +367,37 @@ type HookFromRoute<R extends RouteConfig, E extends Env> =
   | Hook<ComputeInput<R>, E, ConvertPathType<R['path']>, RouteHandlerResponse<R> | undefined>
   | undefined
 
-// Recursive Helper: Merge Schemas for the Return Type
+// Merge each batch entry's schema into one normalized route map.
+type SchemaFromRoute<Entry, BasePath extends string> = Entry extends {
+  route: infer R extends RouteConfig
+  addRoute?: infer AddRoute
+}
+  ? [AddRoute] extends [false]
+    ? {}
+    : ToSchema<
+        R['method'],
+        MergePath<BasePath, ConvertPathType<R['path']>>,
+        ComputeInput<R>,
+        RouteConfigToTypedResponse<R>
+      >
+  : {}
+
+type UnionToIntersection<T> = (T extends unknown ? (value: T) => void : never) extends (
+  value: infer Intersection
+) => void
+  ? Intersection
+  : never
+
+type NormalizeSchema<S> = { [Path in keyof S]: S[Path] }
+
 type SchemaFromRoutes<
   Routes extends readonly { route: RouteConfig; addRoute?: boolean }[],
   BasePath extends string,
-> = Routes extends readonly [infer Head, ...infer Tail]
-  ? Head extends { route: infer R extends RouteConfig; addRoute?: infer AddRoute }
-    ? ([AddRoute] extends [false]
-        ? {}
-        : ToSchema<
-            R['method'],
-            MergePath<BasePath, ConvertPathType<R['path']>>,
-            ComputeInput<R>,
-            RouteConfigToTypedResponse<R>
-          >) &
-        SchemaFromRoutes<
-          Tail extends readonly { route: RouteConfig; addRoute?: boolean }[] ? Tail : [],
-          BasePath
-        >
-    : {}
-  : {}
+> = number extends Routes['length']
+  ? {}
+  : Routes extends readonly []
+    ? {}
+    : NormalizeSchema<UnionToIntersection<SchemaFromRoute<Routes[number], BasePath>>>
 
 export type OpenAPIRoute<
   R extends RouteConfig = RouteConfig,


### PR DESCRIPTION
`openapiRoutes()` currently builds its RPC schema by recursively peeling the route tuple. The expensive part comes from this type shape, shortened to show the recursion:

```ts
type SchemaFromRoutes<Routes, BasePath> =
  Routes extends readonly [infer Head, ...infer Tail]
    ? SchemaFromRoute<Head, BasePath> &
        SchemaFromRoutes<Tail, BasePath>
    : {}
```

That produces a right-nested intersection like `Route1Schema & (Route2Schema & (Route3Schema & ...))`. This change projects every route independently, intersects the resulting union once, and normalizes only the top-level path map:

```ts
type SchemaFromRoutes<Routes, BasePath> =
  number extends Routes['length']
    ? {}
    : Routes extends readonly []
      ? {}
      : NormalizeSchema<
          UnionToIntersection<SchemaFromRoute<Routes[number], BasePath>>
        >
```

## TypeScript 6 and 7 benchmarks

These use consumers of each checkout's built declarations. Check times are medians from nine interleaved fresh compiler processes on Node 26.8.1, using TypeScript 6.0.2 and 7.0.2.

### TypeScript 6

| Routes | Before inst. | After inst. | Before check | After check |
|---:|---:|---:|---:|---:|
| 10 | 319,281 | 312,435 | 340 ms | 340 ms |
| 25 | 403,360 | 381,932 | 410 ms | 390 ms |
| 100 | TS2589 | 731,507 | TS2589 | 690 ms |

### TypeScript 7

| Routes | Before inst. | After inst. | Before check | After check |
|---:|---:|---:|---:|---:|
| 10 | 307,726 | 300,880 | 136 ms | 129 ms |
| 25 | 391,805 | 370,377 | 157 ms | 148 ms |
| 100 | TS2589 | 719,952 | TS2589 | 259 ms |

At 25 routes this removes 5.3-5.5% of compiler instantiations and improves median check time by 4.9-5.7%. The 100-route cases fail with TS2589 before the change and complete successfully after it on both compiler generations.
