### PR TITLE
perf(zod-openapi): Reuse route response projections

### DIFF
--- a/.changeset/quick-fluent-types.md
+++ b/.changeset/quick-fluent-types.md
@@ -2,4 +2,4 @@
 '@hono/zod-openapi': patch
 ---
 
-Reuse projected response types across fluent route handlers and returned schemas to reduce TypeScript checker work.
+Reuse projected response types between `openapi()` route handlers and returned schemas to reduce TypeScript checker work.

--- a/.changeset/quick-fluent-types.md
+++ b/.changeset/quick-fluent-types.md
@@ -1,0 +1,5 @@
+---
+'@hono/zod-openapi': patch
+---
+
+Reuse projected response types across fluent route handlers and returned schemas to reduce TypeScript checker work.

--- a/packages/zod-openapi/src/handler.test-d.ts
+++ b/packages/zod-openapi/src/handler.test-d.ts
@@ -263,6 +263,11 @@ describe('supports async handler', () => {
     void handlerA
     void handlerB
 
+    const routeUnion: typeof routeA | typeof routeB = Math.random() > 0.5 ? routeA : routeB
+    new OpenAPIHono().openapi(routeUnion, (c) =>
+      Math.random() > 0.5 ? c.json({ a: 'x' }, 200) : c.json({ b: 1 }, 201)
+    )
+
     // @ts-expect-error a raw Response is not allowed when every member declares a schema
     const invalid: RouteHandler<typeof routeA | typeof routeB> = () => new Response('nope')
     void invalid

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -195,6 +195,24 @@ type RouteHandlerResponse<R extends RouteConfig> = R extends {
   ? MaybePromise<RouteConfigToTypedResponse<R>>
   : MaybePromise<RouteConfigToTypedResponse<R>> | MaybePromise<Response>
 
+// The fluent openapi() signature needs the projected response for both contextual
+// handler checking and the returned Hono schema. Bind it inside one internal alias
+// without introducing an inference-blocking public generic.
+type BoundRouteResponseTypes<R extends RouteConfig> = R extends RouteConfig
+  ? [RouteConfigToTypedResponse<R>] extends [infer Output]
+    ? {
+        output: Output
+        handler: R extends {
+          responses: {
+            [statusCode: number]: { content: { [mediaType: string]: ZodMediaTypeObject } }
+          }
+        }
+          ? MaybePromise<Output>
+          : MaybePromise<Output> | MaybePromise<Response>
+      }
+    : never
+  : never
+
 export type Hook<T, E extends Env, P extends string, R> = (
   result: { target: keyof ValidationTargets } & (
     | {
@@ -485,12 +503,12 @@ export class OpenAPIHono<
       P,
       I,
       // If a response type is defined, only the typed response is allowed.
-      RouteHandlerResponse<R>
+      BoundRouteResponseTypes<R>['handler']
     >,
-    hook: Hook<I, E, P, RouteHandlerResponse<R> | undefined> | undefined = undefined // eslint-disable-line @typescript-eslint/no-useless-default-assignment
+    hook: Hook<I, E, P, BoundRouteResponseTypes<R>['handler'] | undefined> | undefined = undefined // eslint-disable-line @typescript-eslint/no-useless-default-assignment
   ): OpenAPIHono<
     E,
-    S & ToSchema<R['method'], MergePath<BasePath, P>, I, RouteConfigToTypedResponse<R>>,
+    S & ToSchema<R['method'], MergePath<BasePath, P>, I, BoundRouteResponseTypes<R>['output']>,
     BasePath
   > => {
     if (!hide) {

--- a/packages/zod-openapi/src/index.ts
+++ b/packages/zod-openapi/src/index.ts
@@ -195,7 +195,7 @@ type RouteHandlerResponse<R extends RouteConfig> = R extends {
   ? MaybePromise<RouteConfigToTypedResponse<R>>
   : MaybePromise<RouteConfigToTypedResponse<R>> | MaybePromise<Response>
 
-// The fluent openapi() signature needs the projected response for both contextual
+// The openapi() signature needs the projected response for both contextual
 // handler checking and the returned Hono schema. Bind it inside one internal alias
 // without introducing an inference-blocking public generic.
 type BoundRouteResponseTypes<R extends RouteConfig> = R extends RouteConfig


### PR DESCRIPTION
`openapi()` currently builds the response type twice: once to check the handler and again for the returned Hono schema. Chaining routes makes TypeScript repeat that work at every step.

This change calculates the response once and shares it between both uses. It avoids adding a public generic or `NoInfer`, so inline status literals and union routes keep inferring as before. This is separate from #2115, which changes `openapiRoutes()`.

## TypeScript 6 and 7 benchmarks

These benchmarks import each checkout's built declarations. `Server` keeps the accumulated app type; `+ hc` also resolves every client endpoint. Times are the median of nine alternating runs on Node 26.8.1 with TypeScript 6.0.2 and 7.0.2.

### TypeScript 6

| Graph | Before inst. | After inst. | Before check | After check |
|---|---:|---:|---:|---:|
| 10 server | 179,149 | 127,913 | 300 ms | 240 ms |
| 10 + `hc` | 375,948 | 324,128 | 390 ms | 350 ms |
| 25 server | 272,757 | 156,661 | 370 ms | 270 ms |
| 25 + `hc` | 527,950 | 411,270 | 490 ms | 410 ms |
| 100 server | 762,309 | 321,913 | 710 ms | 440 ms |
| 100 + `hc` | 1,312,023 | 871,043 | 1,070 ms | 770 ms |

### TypeScript 7

| Graph | Before inst. | After inst. | Before check | After check |
|---|---:|---:|---:|---:|
| 10 server | 168,190 | 116,398 | 108 ms | 79 ms |
| 10 + `hc` | 364,955 | 312,579 | 153 ms | 129 ms |
| 25 server | 261,798 | 145,146 | 128 ms | 89 ms |
| 25 + `hc` | 516,957 | 399,721 | 195 ms | 157 ms |
| 100 server | 751,350 | 310,398 | 266 ms | 152 ms |
| 100 + `hc` | 1,301,030 | 859,494 | 408 ms | 300 ms |

At 100 routes, server-only checks use 57.8-58.7% fewer instantiations and finish 38.0-42.9% faster. When every `hc` endpoint is resolved, they use 33.6-33.9% fewer instantiations and finish 26.5-28.0% faster. Compiler memory is also 19.9-35.7% lower across those cases.
