### PR TITLE
fix(inertia): send redirects with a URL fragment as an Inertia location

### DIFF
--- a/.changeset/light-eels-tickle.md
+++ b/.changeset/light-eels-tickle.md
@@ -1,0 +1,7 @@
+---
+'@hono/inertia': patch
+---
+
+fix(inertia): send redirects with a URL fragment as an Inertia location, and always set `Vary: X-Inertia`
+
+A browser follows a redirect without sending the fragment to the server, so `c.redirect('/users#profile')` lost `#profile`. Inertia requests now get a `409` with `X-Inertia-Redirect` so the client navigates in JavaScript, where the fragment survives. Prefetch requests are exempt. `Vary: X-Inertia` is now set on every response, not just the ones that went through `c.render`.

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -255,6 +255,106 @@ describe('inertia', () => {
     })
   })
 
+  describe('redirects with a URL fragment', () => {
+    const fragmentApp = () =>
+      new Hono()
+        .use(inertia())
+        .get('/go', (c) => c.redirect('/users#profile'))
+        .put('/users/1', (c) => c.redirect('/users#profile'))
+        .get('/plain', (c) => c.redirect('/users'))
+
+    it('converts it into a 409 with X-Inertia-Redirect', async () => {
+      const res = await fragmentApp().request('/go', {
+        headers: { 'X-Inertia': 'true' },
+      })
+
+      expect(res.status).toBe(409)
+      expect(res.headers.get('X-Inertia-Redirect')).toBe('/users#profile')
+      expect(res.headers.get('Location')).toBeNull()
+      expect(res.headers.get('Vary')).toBe('X-Inertia')
+      expect(await res.text()).toBe('')
+    })
+
+    it('applies after the 302 to 303 rewrite', async () => {
+      const res = await fragmentApp().request('/users/1', {
+        method: 'PUT',
+        headers: { 'X-Inertia': 'true' },
+      })
+
+      expect(res.status).toBe(409)
+      expect(res.headers.get('X-Inertia-Redirect')).toBe('/users#profile')
+    })
+
+    it('leaves fragment-less redirects untouched', async () => {
+      const res = await fragmentApp().request('/plain', {
+        headers: { 'X-Inertia': 'true' },
+      })
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('X-Inertia-Redirect')).toBeNull()
+    })
+
+    it('leaves non Inertia requests untouched', async () => {
+      const res = await fragmentApp().request('/go')
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/users#profile')
+    })
+
+    for (const headers of [
+      { Purpose: 'prefetch' },
+      { 'Sec-Purpose': 'prefetch' },
+      { 'X-Purpose': 'preview' },
+    ]) {
+      const [name] = Object.keys(headers)
+      it(`leaves prefetches untouched (${name})`, async () => {
+        const res = await fragmentApp().request('/go', {
+          headers: { 'X-Inertia': 'true', ...headers },
+        })
+
+        expect(res.status).toBe(302)
+        expect(res.headers.get('X-Inertia-Redirect')).toBeNull()
+      })
+    }
+  })
+
+  describe('Vary', () => {
+    it('is set on responses that never reach the renderer', async () => {
+      const app = new Hono()
+        .use(inertia())
+        .put('/users/1', (c) => c.redirect('/users'))
+        .get('/boom', () => new Response('nope', { status: 500 }))
+
+      const redirect = await app.request('/users/1', {
+        method: 'PUT',
+        headers: { 'X-Inertia': 'true' },
+      })
+      expect(redirect.headers.get('Vary')).toBe('X-Inertia')
+
+      const error = await app.request('/boom')
+      expect(error.headers.get('Vary')).toBe('X-Inertia')
+    })
+
+    it('keeps the Accept the renderer already set', async () => {
+      const app = new Hono().use(inertia()).get('/', (c) => c.render('Home', {}))
+
+      const res = await app.request('/', { headers: { 'X-Inertia': 'true' } })
+
+      expect(res.headers.get('Vary')).toBe('Accept, X-Inertia')
+    })
+
+    it('is set on the version mismatch 409', async () => {
+      const app = new Hono().use(inertia({ version: '2' })).get('/', (c) => c.render('Home', {}))
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '1' },
+      })
+
+      expect(res.status).toBe(409)
+      expect(res.headers.get('Vary')).toBe('X-Inertia')
+    })
+  })
+
   describe('page.url resolution', () => {
     it('uses c.req.url for GET requests', async () => {
       const app = new Hono()

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -469,6 +469,7 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       const current = version ?? ''
       if (requested !== current) {
         c.header('X-Inertia-Location', c.req.url)
+        c.header('Vary', 'X-Inertia')
         return c.body(null, 409)
       }
     }
@@ -657,21 +658,78 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
 
     await next()
 
+    // The same URL yields a JSON page object for Inertia requests and a full
+    // HTML document otherwise, so every response varies on `X-Inertia` -- not
+    // just the ones that went through `c.render`. Redirects and errors never
+    // reach the renderer, and caching those without `Vary` would let a proxy
+    // serve an Inertia response to a browser navigation.
+    varyOnInertia(c)
+
+    if (!c.req.header('X-Inertia')) {
+      return c.res
+    }
+
     // Redirects issued from PUT / PATCH / DELETE must be 303, not 302: a 302
     // makes the client replay the original method against the redirect target,
     // while 303 forces the follow-up request to be a GET.
     // https://inertiajs.com/redirects
     if (
-      c.req.header('X-Inertia') &&
       c.res.status === 302 &&
       (c.req.method === 'PUT' || c.req.method === 'PATCH' || c.req.method === 'DELETE')
     ) {
       c.res = new Response(c.res.body, { status: 303, headers: c.res.headers })
     }
 
+    // A browser follows a redirect without ever sending the fragment to the
+    // server, so `Location: /users#profile` would drop `#profile`. Hand the
+    // location to the client instead and let it navigate in JavaScript, where
+    // the fragment survives. Prefetches are exempt: they must not navigate.
+    if (REDIRECT_STATUSES.has(c.res.status) && !isPrefetch(c)) {
+      const location = c.res.headers.get('Location')
+      if (location?.includes('#')) {
+        // Assigning `c.res` rather than returning: `compose` ignores a
+        // middleware's return value once the response is finalized. The
+        // setter copies the remaining headers (`Vary`) onto the new response.
+        c.res.headers.delete('Location')
+        c.res = new Response(null, { status: 409, headers: { 'X-Inertia-Redirect': location } })
+      }
+    }
+
     return c.res
   }
 }
+
+/**
+ * Statuses that carry a `Location` header. Mirrors Symfony's
+ * `Response::isRedirect`, which `inertia-laravel` gates the fragment check on.
+ */
+const REDIRECT_STATUSES = new Set([201, 301, 302, 303, 307, 308])
+
+/**
+ * Add `X-Inertia` to the response's `Vary` header, keeping any value the
+ * renderer already set (it also varies on `Accept`).
+ */
+const varyOnInertia = (c: Context): void => {
+  const current = c.res.headers.get('Vary')
+  if (
+    current
+      ?.toLowerCase()
+      .split(',')
+      .some((field) => field.trim() === 'x-inertia')
+  ) {
+    return
+  }
+  c.header('Vary', current ? `${current}, X-Inertia` : 'X-Inertia')
+}
+
+/**
+ * Whether the request is a prefetch. Mirrors Laravel's `Request::prefetch`,
+ * which `inertia-laravel` uses to skip the fragment redirect.
+ */
+const isPrefetch = (c: Context): boolean =>
+  c.req.header('X-Purpose')?.toLowerCase() === 'preview' ||
+  c.req.header('Purpose')?.toLowerCase() === 'prefetch' ||
+  c.req.header('Sec-Purpose')?.toLowerCase() === 'prefetch'
 
 /**
  * Registry of valid Inertia page component names.


### PR DESCRIPTION
## Summary

Implements the two cases from `inertia-laravel`'s `Middleware::handle` that `@hono/inertia` was missing. Follow-up to @nkfr26's review on #2109.

**① Redirects containing a URL fragment**

A browser follows a redirect without ever sending the fragment to the server, so the `#profile` in `c.redirect('/users#profile')` is lost. `inertia-laravel` detects this and returns a `409` with `X-Inertia-Redirect`, letting the client navigate in JavaScript, where the fragment survives.

Prefetch requests are exempt: a prefetch only warms the cache for a later visit and must not navigate on the spot.

**② `Vary: X-Inertia` missing on most responses**

The same URL yields a JSON page object for Inertia requests and a full HTML document otherwise, so every response varies on `X-Inertia`. Today the header is only set on responses that went through `c.render` — redirects and errors never reach the renderer. A proxy caching one of those could serve an Inertia response to a plain browser navigation.

`inertia-laravel` sets it right after `$next($request)`, before the early return, on every response. This is the gap I noted as "separate gap, follow-up" in #2109.

## Protocol behaviour

| Request | Handler returns | Before | After |
| --- | --- | --- | --- |
| with `X-Inertia` | `302` + `Location: /users#profile` | `302` | **`409` + `X-Inertia-Redirect`** |
| with `X-Inertia` + `Purpose: prefetch` | same | `302` | `302` |
| without `X-Inertia` | same | `302` | `302` |
| with `X-Inertia` | `302` + `Location: /users` | `302` | `302` |
| any | redirect / error | no `Vary` | **`Vary: X-Inertia`** |
| any | `c.render(...)` | `Vary: Accept, X-Inertia` | unchanged |

The statuses considered are `201` / `301` / `302` / `303` / `307` / `308`, matching Symfony's `Response::isRedirect()`, which is what `inertia-laravel` gates the fragment check on.

Prefetch detection mirrors Laravel's `Request::prefetch()`: `X-Purpose: preview`, `Purpose: prefetch`, or `Sec-Purpose: prefetch`.

## Implementation

As @nkfr26 suggested, the `X-Inertia` header check became an early return, so additional branches don't nest. The order now matches `inertia-laravel`:

```
await next()
  ↓ Vary on every response
  ↓ no X-Inertia → early return
  ↓ 302 → 303 (PUT/PATCH/DELETE)   ← #2109
  ↓ redirect with a fragment → 409
```

As a result the `302` → `303` condition no longer needs `c.req.header('X-Inertia') &&`.

The `409` is built by assigning `c.res` rather than returning it: `compose` ignores a middleware's return value once the response is finalized (the same reason the `303` in #2109 was an assignment). The `c.res` setter also copies the previous headers onto the new response, so `Location` is deleted beforehand — `Vary`, on the other hand, is carried over by that same mechanism.

The `Vary` helper does not clobber the `Accept, X-Inertia` the renderer already set: it appends `X-Inertia` only when absent. The version-mismatch `409` returns before `next()`, so it sets the header on its own.

## Out of scope

The other case @nkfr26 raised — the empty-response fallback:

```php
if ($response->isOk() && empty($response->getContent())) {
    $response = $this->onEmptyResponse($request, $response);   // Redirect::back()
}
```

I left this out. `Redirect::back()` resolves the previous URL from the session, with `Referer` only as a fallback. `@hono/inertia` has no session, so it would have to rely on `Referer` alone — which does not match Laravel's behaviour and puts a user-controlled value straight into `Location`. I'd rather track it as a separate issue.

## Test plan

- [x] redirect with a fragment → `409` + `X-Inertia-Redirect`, `Location` dropped, `Vary` kept
- [x] applies after the `303` rewrite (`PUT` + fragment → `409`)
- [x] fragment-less redirects untouched
- [x] non-Inertia requests untouched
- [x] all three prefetch headers (`Purpose` / `Sec-Purpose` / `X-Purpose`) untouched
- [x] `Vary: X-Inertia` on redirects and errors
- [x] the renderer's `Accept, X-Inertia` preserved
- [x] `Vary` on the version-mismatch `409`
- [x] full suite (81 tests), typecheck, lint, format

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)
