### PR TITLE
feat(inertia): add Shared Data support

### DIFF
--- a/.changeset/happy-papers-repeat.md
+++ b/.changeset/happy-papers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@hono/inertia': minor
+---
+
+Add support for shared data through the `share` option in `inertia()`. Shared data can be returned synchronously or asynchronously, is merged into page props, and is included in `PageProps` type inference.

--- a/.changeset/happy-papers-repeat.md
+++ b/.changeset/happy-papers-repeat.md
@@ -2,4 +2,10 @@
 '@hono/inertia': minor
 ---
 
+feat(inertia): add shared props through a `share` callback
+
 Shared props are combined with page props, with page props taking precedence when keys overlap. They are processed in the same way as props passed to `c.render()` and included in `PageProps` type inference. Their top-level keys are exposed through `sharedProps` page metadata.
+
+fix(inertia): correct the `c.render()` return type
+
+Change the return type of `c.render()` to `Response | Promise<Response>` so it correctly represents render results that involve asynchronous work.

--- a/.changeset/happy-papers-repeat.md
+++ b/.changeset/happy-papers-repeat.md
@@ -2,4 +2,4 @@
 '@hono/inertia': minor
 ---
 
-Add support for shared data through the `share` option in `inertia()`. Shared data can be returned synchronously or asynchronously, is merged into page props, and is included in `PageProps` type inference.
+Shared props are combined with page props, with page props taking precedence when keys overlap. They are processed in the same way as props passed to `c.render()` and included in `PageProps` type inference. Their top-level keys are exposed through `sharedProps` page metadata.

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -62,14 +62,23 @@ Use `share` to add data to every page. It accepts a callback that receives the c
 To include shared data in `PageProps` type inference, chain `inertia()` when creating the app.
 
 ```ts
-const app = new Hono()
+import type { Context } from 'hono'
+
+type Session = { user: { id: string } }
+type SissionEnv = { Variables: { session: Session | null } }
+
+const app = new Hono<SissionEnv>()
 
 const routes = app
+  .use((c, next) => {
+    c.set('session', null)
+    return next()
+  })
   .use(
     inertia({
-      share: (c) => ({
-        path: c.req.path,
+      share: (c: Context<SissionEnv>) => ({
         appName: 'App Name',
+        session: c.get('session'),
       }),
     })
   )

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -57,26 +57,26 @@ export default routes
 
 ### Shared Data
 
-Use `share` to add data to every page. It accepts a callback that receives the current Hono context and may be asynchronous. Shared data is shallow-merged before page props, so page-specific props override duplicate keys.
+Use `share` to add data to every page. It accepts a synchronous callback that receives the current Hono context and returns shared props. Shared props are combined with page props, with page props taking precedence when keys overlap. They are processed in the same way as props passed to `c.render()`.
 
 To include shared data in `PageProps` type inference, chain `inertia()` when creating the app.
 
 ```ts
 import type { Context } from 'hono'
 
-type Session = { user: { id: string } }
-type SissionEnv = { Variables: { session: Session | null } }
+type Session = { user: { name: string } }
+type SessionEnv = { Variables: { session: Session | null } }
 
-const app = new Hono<SissionEnv>()
+const app = new Hono<SessionEnv>()
 
 const routes = app
   .use((c, next) => {
-    c.set('session', null)
+    c.set('session', { user: { name: 'John Doe' } })
     return next()
   })
   .use(
     inertia({
-      share: (c: Context<SissionEnv>) => ({
+      share: (c: Context<SessionEnv>) => ({
         appName: 'App Name',
         session: c.get('session'),
       }),
@@ -84,6 +84,8 @@ const routes = app
   )
   .get('/', (c) => c.render('Home'))
 ```
+
+The page object includes `sharedProps`, an array of top-level keys registered by `share`. It is omitted when no shared keys exist.
 
 ### React + Vite (`vite-ssr-components`) example
 
@@ -369,7 +371,7 @@ export default defineConfig({
 | ---------- | ---------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `version`  | `string \| null`                         | `null`                                        | Asset version. Stale `X-Inertia-Version` on a GET request triggers a `409 Conflict` with an `X-Inertia-Location` header so the client does a full reload. |
 | `rootView` | `(page, c) => string \| Promise<string>` | Minimal HTML shell embedding the page object. | HTML document for the initial (non Inertia) request.                                                                                                      |
-| `share`    | `(c: Context<E>) => V \| Promise<V>`     | `undefined`                                   | Shared data included with every page. Page-specific props override duplicate keys.                                                                        |
+| `share`    | `(c: Context<E>) => V`                   | `undefined`                                   | Shared data included with every page. Page-specific props override duplicate keys.                                                                        |
 
 ## Example app
 

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -55,38 +55,6 @@ const routes = app
 export default routes
 ```
 
-### Shared Data
-
-Use `share` to add data to every page. It accepts a synchronous callback that receives the current Hono context and returns shared props. Shared props are combined with page props, with page props taking precedence when keys overlap. They are processed in the same way as props passed to `c.render()`.
-
-To include shared data in `PageProps` type inference, chain `inertia()` when creating the app.
-
-```ts
-import type { Context } from 'hono'
-
-type Session = { user: { name: string } }
-type SessionEnv = { Variables: { session: Session | null } }
-
-const app = new Hono<SessionEnv>()
-
-const routes = app
-  .use((c, next) => {
-    c.set('session', { user: { name: 'John Doe' } })
-    return next()
-  })
-  .use(
-    inertia({
-      share: (c: Context<SessionEnv>) => ({
-        appName: 'App Name',
-        session: c.get('session'),
-      }),
-    })
-  )
-  .get('/', (c) => c.render('Home'))
-```
-
-The page object includes `sharedProps`, an array of top-level keys registered by `share`. It is omitted when no shared keys exist.
-
 ### React + Vite (`vite-ssr-components`) example
 
 Pair `@hono/inertia` with [`vite-ssr-components`](https://github.com/yusukebe/vite-ssr-components) to wire up Vite's HMR client and module scripts during development. The `<ViteClient />`, `<Script />` and `<Link />` helpers emit the right tags in both dev and production builds.
@@ -237,6 +205,38 @@ app.put('/users/:id', async (c) => {
 The Inertia protocol requires redirects issued from `PUT`, `PATCH`, and `DELETE` requests to use [`303 See Other`](https://inertiajs.com/redirects): with a `302` the client replays the original method against the redirect target instead of following it with a `GET`. The middleware rewrites `302` to `303` for those methods on Inertia requests, so `c.redirect` needs no special casing.
 
 Non-Inertia requests, `POST` redirects, and explicit statuses such as `307` are left untouched.
+
+## Shared Data
+
+Use `share` to add data to every page. It accepts a synchronous callback that receives the current Hono context and returns shared props. Shared props are combined with page props, with page props taking precedence when keys overlap. They are processed in the same way as props passed to `c.render()`.
+
+To include shared data in `PageProps` type inference, chain `inertia()` when creating the app.
+
+```ts
+import type { Context } from 'hono'
+
+type Session = { user: { name: string } }
+type SessionEnv = { Variables: { session: Session | null } }
+
+const app = new Hono<SessionEnv>()
+
+const routes = app
+  .use((c, next) => {
+    c.set('session', { user: { name: 'John Doe' } })
+    return next()
+  })
+  .use(
+    inertia({
+      share: (c: Context<SessionEnv>) => ({
+        appName: 'App Name',
+        session: c.get('session'),
+      }),
+    })
+  )
+  .get('/', (c) => c.render('Home'))
+```
+
+The `page.sharedProps` field contains an array of top-level keys registered by `share`. The Inertia client uses these keys during instant visits.
 
 ## Partial reloads
 

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -55,6 +55,27 @@ const routes = app
 export default routes
 ```
 
+### Shared Data
+
+Use `share` to add data to every page. It accepts a callback that receives the current Hono context and may be asynchronous. Shared data is shallow-merged before page props, so page-specific props override duplicate keys.
+
+To include shared data in `PageProps` type inference, chain `inertia()` when creating the app.
+
+```ts
+const app = new Hono()
+
+const routes = app
+  .use(
+    inertia({
+      share: (c) => ({
+        path: c.req.path,
+        appName: 'App Name',
+      }),
+    })
+  )
+  .get('/', (c) => c.render('Home'))
+```
+
 ### React + Vite (`vite-ssr-components`) example
 
 Pair `@hono/inertia` with [`vite-ssr-components`](https://github.com/yusukebe/vite-ssr-components) to wire up Vite's HMR client and module scripts during development. The `<ViteClient />`, `<Script />` and `<Link />` helpers emit the right tags in both dev and production builds.
@@ -339,6 +360,7 @@ export default defineConfig({
 | ---------- | ---------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `version`  | `string \| null`                         | `null`                                        | Asset version. Stale `X-Inertia-Version` on a GET request triggers a `409 Conflict` with an `X-Inertia-Location` header so the client does a full reload. |
 | `rootView` | `(page, c) => string \| Promise<string>` | Minimal HTML shell embedding the page object. | HTML document for the initial (non Inertia) request.                                                                                                      |
+| `share`    | `(c: Context<E>) => V \| Promise<V>`     | `undefined`                                   | Shared data included with every page. Page-specific props override duplicate keys.                                                                        |
 
 ## Example app
 

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -123,6 +123,62 @@ describe('inertia', () => {
     })
   })
 
+  describe('shared props', () => {
+    it('includes shared props and lets page props override duplicate keys', async () => {
+      const app = new Hono()
+      app.use(
+        inertia({
+          share: () => ({
+            static: 'value',
+            lazy: () => Promise.resolve({ id: 0 }),
+            duplicated: 0,
+          }),
+        })
+      )
+      app.get('/', (c) => c.render('Home', { duplicated: 'string', own: true }))
+
+      const res = await app.request('/', { headers: { 'X-Inertia': 'true' } })
+
+      const body = (await res.json()) as PageObject
+      expect(body.props).toEqual({
+        static: 'value',
+        lazy: { id: 0 },
+        duplicated: 'string',
+        own: true,
+      })
+    })
+
+    it('resolves shared props from an asynchronous callback', async () => {
+      const app = new Hono()
+      // eslint-disable-next-line @typescript-eslint/require-await
+      app.use(inertia({ share: async (c) => ({ path: c.req.path }) }))
+      app.get('/', (c) => c.render('Home'))
+
+      const res = await app.request('/', { headers: { 'X-Inertia': 'true' } })
+
+      const body = (await res.json()) as PageObject
+      expect(body.props).toEqual({ path: '/' })
+    })
+
+    it('filters shared props during a partial reload', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1', share: () => ({ id: 0 }) }))
+      app.get('/', (c) => c.render('Home', { partial: 'reload' }))
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Inertia': 'true',
+          'X-Inertia-Version': 'v1',
+          'X-Inertia-Partial-Component': 'Home',
+          'X-Inertia-Partial-Data': 'partial',
+        },
+      })
+
+      const body = (await res.json()) as PageObject
+      expect(body.props).toEqual({ partial: 'reload' })
+    })
+  })
+
   describe('Inertia (XHR) request', () => {
     it('responds with JSON page object and Inertia headers', async () => {
       const app = new Hono()

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -174,6 +174,24 @@ describe('inertia', () => {
       expect(body.props).toEqual({ session: { user: { name: 'John Doe' } } })
     })
 
+    it('supports the curried form with an explicit Env', async () => {
+      type Session = { user: { name: string } }
+      type SessionEnv = { Variables: { session: Session | null } }
+
+      const app = new Hono<SessionEnv>()
+      app.use((c, next) => {
+        c.set('session', null)
+        return next()
+      })
+      app.use(inertia<SessionEnv>()({ share: (c) => ({ session: c.get('session') }) }))
+      app.get('/', (c) => c.render('Home'))
+
+      const res = await app.request('/', { headers: { 'X-Inertia': 'true' } })
+
+      const body = (await res.json()) as PageObject
+      expect(body.props).toEqual({ session: null })
+    })
+
     it('keeps shared prop keys in metadata during a partial reload', async () => {
       const app = new Hono()
       app.use(inertia({ version: 'v1', share: () => ({ id: 0 }) }))

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import { describe, expect, it } from 'vitest'
 import type { PageObject, ScrollDescriptor } from './index'
 import { deepMerge, defer, inertia, merge, prepend, scroll } from './index'
@@ -33,6 +34,7 @@ describe('inertia', () => {
             seen.push(page)
             return `<!DOCTYPE html><html><body data-url="${c.req.path}">${page.component}</body></html>`
           },
+          share: () => ({ appName: 'App Name' }),
         })
       )
       app.get('/posts/:id', (c) => c.render('Posts/Show', { id: c.req.param('id') }))
@@ -47,9 +49,10 @@ describe('inertia', () => {
       expect(seen).toHaveLength(1)
       expect(seen[0]).toEqual({
         component: 'Posts/Show',
-        props: { id: '42' },
+        props: { appName: 'App Name', id: '42' },
         url: '/posts/42?ref=test',
         version: 'v1',
+        sharedProps: ['appName'],
       })
     })
 
@@ -146,21 +149,31 @@ describe('inertia', () => {
         duplicated: 'string',
         own: true,
       })
+      expect(body.sharedProps).toEqual(['static', 'lazy', 'duplicated'])
     })
 
-    it('resolves shared props from an asynchronous callback', async () => {
-      const app = new Hono()
-      // eslint-disable-next-line @typescript-eslint/require-await
-      app.use(inertia({ share: async (c) => ({ path: c.req.path }) }))
+    it('reads shared props from values set by later middleware', async () => {
+      type Session = { user: { name: string } }
+      type SessionEnv = { Variables: { session: Session | null } }
+      const app = new Hono<SessionEnv>()
+      app.use(
+        inertia({
+          share: (c: Context<SessionEnv>) => ({ session: c.get('session') }),
+        })
+      )
+      app.use((c, next) => {
+        c.set('session', { user: { name: 'John Doe' } })
+        return next()
+      })
       app.get('/', (c) => c.render('Home'))
 
       const res = await app.request('/', { headers: { 'X-Inertia': 'true' } })
 
       const body = (await res.json()) as PageObject
-      expect(body.props).toEqual({ path: '/' })
+      expect(body.props).toEqual({ session: { user: { name: 'John Doe' } } })
     })
 
-    it('filters shared props during a partial reload', async () => {
+    it('keeps shared prop keys in metadata during a partial reload', async () => {
       const app = new Hono()
       app.use(inertia({ version: 'v1', share: () => ({ id: 0 }) }))
       app.get('/', (c) => c.render('Home', { partial: 'reload' }))
@@ -176,6 +189,17 @@ describe('inertia', () => {
 
       const body = (await res.json()) as PageObject
       expect(body.props).toEqual({ partial: 'reload' })
+      expect(body.sharedProps).toEqual(['id'])
+    })
+
+    it('omits shared prop metadata when no shared keys exist', async () => {
+      const app = new Hono()
+      app.use(inertia({ share: () => ({}) }))
+      app.get('/', (c) => c.render('Home'))
+
+      const res = await app.request('/', { headers: { 'X-Inertia': 'true' } })
+
+      expect((await res.json()) as PageObject).not.toHaveProperty('sharedProps')
     })
   })
 

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -155,6 +155,7 @@ describe('inertia', () => {
     it('reads shared props from values set by later middleware', async () => {
       type Session = { user: { name: string } }
       type SessionEnv = { Variables: { session: Session | null } }
+
       const app = new Hono<SessionEnv>()
       app.use(
         inertia({

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -203,6 +203,34 @@ describe('inertia', () => {
     })
   })
 
+  describe('render return value', () => {
+    it('returns a Response when props do not need async resolution', async () => {
+      let rendered: unknown
+      const app = new Hono().use(inertia()).get('/', (c) => {
+        const response = c.render('Home', { message: 'hello' })
+        rendered = response
+        return response
+      })
+
+      await app.request('/')
+
+      expect(rendered).toBeInstanceOf(Response)
+    })
+
+    it('returns a Promise when props need async resolution', async () => {
+      let rendered: unknown
+      const app = new Hono().use(inertia()).get('/', (c) => {
+        const response = c.render('Home', { message: () => Promise.resolve('hello') })
+        rendered = response
+        return response
+      })
+
+      await app.request('/')
+
+      expect(rendered).toBeInstanceOf(Promise)
+    })
+  })
+
   describe('Inertia (XHR) request', () => {
     it('responds with JSON page object and Inertia headers', async () => {
       const app = new Hono()

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -8,7 +8,8 @@
  * full HTML document for initial page loads.
  */
 
-import type { Context, MiddlewareHandler, TypedResponse } from 'hono'
+import type { Context, Env, MiddlewareHandler, TypedResponse } from 'hono'
+import type { InertiaSharedEnv } from './page-props'
 
 /**
  * Inertia page object sent to the client.
@@ -386,7 +387,7 @@ export const scroll = <T>(options: ScrollOptions<T>): T[] => {
   return marker as unknown as T[]
 }
 
-export interface InertiaOptions {
+export interface InertiaOptions<E extends Env = Env, V = Record<string, never>> {
   /**
    * Asset version. When an Inertia GET request's `X-Inertia-Version` header
    * does not match this value, the middleware short circuits with a
@@ -405,6 +406,15 @@ export interface InertiaOptions {
    * object into `<div id="app" data-page="...">`.
    */
   rootView?: RootView
+
+  /**
+   * Shared props included on every rendered page.
+   *
+   * Provide a callback that receives the current Hono context and returns the
+   * shared props synchronously or asynchronously.
+   * Page-specific props take precedence when a key exists in both objects.
+   */
+  share?: (c: Context<E>) => V | Promise<V>
 }
 
 /**
@@ -459,9 +469,12 @@ const defaultRootView: RootView = (page) =>
  * app.get('/', (c) => c.render('Home', { message: 'Hello' }))
  * ```
  */
-export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
+export const inertia = <E extends Env = Env, V = Record<string, never>>(
+  options: InertiaOptions<E, V> = {}
+): MiddlewareHandler<InertiaSharedEnv<V>> => {
   const version: string | null = options.version ?? null
   const rootView: RootView = options.rootView ?? defaultRootView
+  const share = options.share
 
   return async function inertia(c, next) {
     if (c.req.header('X-Inertia') && c.req.method === 'GET') {
@@ -473,11 +486,15 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       }
     }
 
-    c.setRenderer(((
+    c.setRenderer((async (
       component: string,
       propsInput: Record<string, unknown> = {},
       options: RenderOptions = {}
     ) => {
+      const sharedProps = share ? await share(c as unknown as Context<E>) : {}
+      // Merge shared props first so page-specific props override duplicate keys.
+      const mergedProps = { ...sharedProps, ...propsInput }
+
       // Use the Referer for non-GET requests to keep the original URL.
       // Override with options.url if provided.
       const url = (() => {
@@ -506,10 +523,8 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
         (onlyKeys !== null && !onlyKeys.includes(key)) ||
         (exceptKeys !== null && exceptKeys.includes(key))
 
-      // Collect kept entries and decide sync vs async resolution. When no
-      // function-valued or deferred prop is encountered, the renderer stays
-      // fully sync — preserving the original `Response` (non-Promise) return
-      // type for the common case.
+      // Collect kept entries and decide which values need
+      // asynchronous resolution before the response is sent.
       //
       // Deferred props are handled per visit kind:
       //   - initial visit (`!isPartial`): the resolver is skipped, the key
@@ -533,7 +548,7 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       const matchPropsOn: string[] = []
       const scrollProps: Record<string, ScrollDescriptor> = {}
       let needsAsync = false
-      for (const [key, value] of Object.entries(propsInput)) {
+      for (const [key, value] of Object.entries(mergedProps)) {
         if (isExcluded(key)) {
           continue
         }
@@ -719,7 +734,7 @@ declare module 'hono' {
       component: C,
       props?: P,
       options?: RenderOptions
-    ): Response & TypedResponse<{ component: C; props: ResolvedProps<P> }, 200, 'html'>
+    ): Promise<Response & TypedResponse<{ component: C; props: ResolvedProps<P> }, 200, 'html'>>
   }
   interface NotFoundResponse extends Response, TypedResponse<string, 404, 'text'> {}
 }

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -21,6 +21,8 @@ export type PageObject<P = Record<string, unknown>> = {
   props: P
   url: string
   version: string | null
+  /** Top-level keys registered by `share`. Omitted when no shared keys exist. */
+  sharedProps?: string[]
   /**
    * Deferred prop keys grouped by their fetch group. Present only on initial
    * (non-partial) responses when at least one prop was marked with
@@ -387,7 +389,10 @@ export const scroll = <T>(options: ScrollOptions<T>): T[] => {
   return marker as unknown as T[]
 }
 
-export interface InertiaOptions<E extends Env = Env, V = Record<string, never>> {
+export interface InertiaOptions<
+  E extends Env = Env,
+  V extends Record<string, unknown> = Record<string, never>,
+> {
   /**
    * Asset version. When an Inertia GET request's `X-Inertia-Version` header
    * does not match this value, the middleware short circuits with a
@@ -410,11 +415,11 @@ export interface InertiaOptions<E extends Env = Env, V = Record<string, never>> 
   /**
    * Shared props included on every rendered page.
    *
-   * Provide a callback that receives the current Hono context and returns the
-   * shared props synchronously or asynchronously.
-   * Page-specific props take precedence when a key exists in both objects.
+   * Accepts a synchronous callback that receives the current Hono context and returns shared props.
+   * Shared props are combined with page props, with page props taking precedence
+   * when keys overlap. They are processed in the same way as props passed to `c.render()`.
    */
-  share?: (c: Context<E>) => V | Promise<V>
+  share?: (c: Context<E>) => V
 }
 
 /**
@@ -469,7 +474,10 @@ const defaultRootView: RootView = (page) =>
  * app.get('/', (c) => c.render('Home', { message: 'Hello' }))
  * ```
  */
-export const inertia = <E extends Env = Env, V = Record<string, never>>(
+export const inertia = <
+  E extends Env = Env,
+  V extends Record<string, unknown> = Record<string, never>,
+>(
   options: InertiaOptions<E, V> = {}
 ): MiddlewareHandler<InertiaSharedEnv<V>> => {
   const version: string | null = options.version ?? null
@@ -486,12 +494,13 @@ export const inertia = <E extends Env = Env, V = Record<string, never>>(
       }
     }
 
-    c.setRenderer((async (
+    c.setRenderer(((
       component: string,
       propsInput: Record<string, unknown> = {},
       options: RenderOptions = {}
     ) => {
-      const sharedProps = share ? await share(c as unknown as Context<E>) : {}
+      const sharedProps = share ? share(c as unknown as Context<E>) : {}
+      const sharedPropKeys = Object.keys(sharedProps)
       // Merge shared props first so page-specific props override duplicate keys.
       const mergedProps = { ...sharedProps, ...propsInput }
 
@@ -618,6 +627,9 @@ export const inertia = <E extends Env = Env, V = Record<string, never>>(
           props: resolvedProps,
           url: url.pathname + url.search,
           version,
+        }
+        if (sharedPropKeys.length > 0) {
+          page.sharedProps = sharedPropKeys
         }
         if (!isPartial && Object.keys(deferredGroups).length > 0) {
           page.deferredProps = deferredGroups

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -740,13 +740,16 @@ export interface RenderOptions {
   url?: string
 }
 
+type RenderResponse<C extends PageName, P> = Response &
+  TypedResponse<{ component: C; props: ResolvedProps<P> }, 200, 'html'>
+
 declare module 'hono' {
   interface ContextRenderer {
     <C extends PageName, P = Record<string, never>>(
       component: C,
       props?: P,
       options?: RenderOptions
-    ): Promise<Response & TypedResponse<{ component: C; props: ResolvedProps<P> }, 200, 'html'>>
+    ): RenderResponse<C, P> | Promise<RenderResponse<C, P>>
   }
   interface NotFoundResponse extends Response, TypedResponse<string, 404, 'text'> {}
 }

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -389,9 +389,11 @@ export const scroll = <T>(options: ScrollOptions<T>): T[] => {
   return marker as unknown as T[]
 }
 
+type EmptySharedProps = Record<string, never>
+
 export interface InertiaOptions<
   E extends Env = Env,
-  V extends Record<string, unknown> = Record<string, never>,
+  V extends Record<string, unknown> = EmptySharedProps,
 > {
   /**
    * Asset version. When an Inertia GET request's `X-Inertia-Version` header
@@ -455,28 +457,10 @@ const defaultRootView: RootView = (page) =>
   </body>
 </html>`
 
-/**
- * Inertia.js middleware for Hono.
- *
- * Sets up `c.render(component, props)` to respond according to the Inertia
- * protocol: JSON page objects for `X-Inertia` requests, props JSON for
- * `Accept: application/json` requests, full HTML otherwise.
- *
- * @example
- * ```ts
- * import { Hono } from 'hono'
- * import { inertia } from '@hono/inertia'
- *
- * const app = new Hono()
- *
- * app.use(inertia())
- *
- * app.get('/', (c) => c.render('Home', { message: 'Hello' }))
- * ```
- */
-export const inertia = <
+/** Creates the configured Inertia middleware implementation. */
+const createInertia = <
   E extends Env = Env,
-  V extends Record<string, unknown> = Record<string, never>,
+  V extends Record<string, unknown> = EmptySharedProps,
 >(
   options: InertiaOptions<E, V> = {}
 ): MiddlewareHandler<InertiaSharedEnv<V>> => {
@@ -698,6 +682,79 @@ export const inertia = <
 
     return c.res
   }
+}
+
+type CurriedInertia<E extends Env> = <V extends Record<string, unknown> = EmptySharedProps>(
+  options: InertiaOptions<E, V>
+) => MiddlewareHandler<InertiaSharedEnv<V>>
+
+/**
+ * Inertia.js middleware for Hono.
+ *
+ * Sets up `c.render(component, props)` to respond according to the Inertia
+ * protocol: JSON page objects for `X-Inertia` requests, props JSON for
+ * `Accept: application/json` requests, full HTML otherwise.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono'
+ * import { inertia } from '@hono/inertia'
+ *
+ * const app = new Hono()
+ *
+ * app.use(inertia())
+ *
+ * app.get('/', (c) => c.render('Home', { message: 'Hello' }))
+ * ```
+ */
+// inertia(options)
+export function inertia<E extends Env = Env, V extends Record<string, unknown> = EmptySharedProps>(
+  options: InertiaOptions<E, V> | undefined
+): MiddlewareHandler<InertiaSharedEnv<V>>
+
+// inertia()
+export function inertia(): MiddlewareHandler<InertiaSharedEnv<EmptySharedProps>>
+
+// inertia<E>()(options)
+export function inertia<E extends Env>(): CurriedInertia<E>
+
+export function inertia<E extends Env, V extends Record<string, unknown>>(
+  // inertia(options) / inertia()
+  ...args: [InertiaOptions<E, V> | undefined] | []
+): MiddlewareHandler<InertiaSharedEnv<V>> | CurriedInertia<E> {
+  // inertia(options)
+  if (args.length === 1) {
+    return createInertia<E, V>(args[0])
+  }
+
+  // inertia()
+  const middleware = createInertia()
+
+  function dispatch(
+    // app.use(inertia())
+    // Hono invokes `dispatch` with (c, next)
+    ...args: Parameters<typeof middleware>
+  ): ReturnType<typeof middleware>
+
+  function dispatch<Shared extends Record<string, unknown> = EmptySharedProps>(
+    // inertia<E>()(options)
+    options: InertiaOptions<E, Shared>
+  ): MiddlewareHandler<InertiaSharedEnv<Shared>>
+
+  function dispatch<Shared extends Record<string, unknown>>(
+    // dispatch(c, next) / dispatch(options)
+    ...args: Parameters<typeof middleware> | [InertiaOptions<E, Shared>]
+  ): ReturnType<typeof middleware> | MiddlewareHandler<InertiaSharedEnv<Shared>> {
+    // app.use(inertia()) -> dispatch(c, next)
+    if (args.length === 2) {
+      return middleware(...args)
+    }
+
+    // inertia<E>()(options)
+    return createInertia<E, Shared>(args[0])
+  }
+
+  return dispatch
 }
 
 /**

--- a/packages/inertia/src/page-props.test.ts
+++ b/packages/inertia/src/page-props.test.ts
@@ -70,6 +70,11 @@ describe('PagePropsFor', () => {
     }>()
   })
 
+  it('requires share callbacks to return props synchronously', () => {
+    // @ts-expect-error Shared props are returned synchronously.
+    inertia({ share: async () => ({ session: await Promise.resolve(null) }) })
+  })
+
   it('merges shared props and prefers page props for duplicate keys', () => {
     const _app = new Hono()
       .use(

--- a/packages/inertia/src/page-props.test.ts
+++ b/packages/inertia/src/page-props.test.ts
@@ -70,6 +70,19 @@ describe('PagePropsFor', () => {
     }>()
   })
 
+  it('infers shared props from the curried share callback', () => {
+    type Session = { user: { name: string } }
+    type SessionEnv = { Variables: { session: Session | null } }
+
+    const _app = new Hono()
+      .use(inertia<SessionEnv>()({ share: (c) => ({ session: c.get('session') }) }))
+      .get('/', (c) => c.render('CurriedShared'))
+
+    expectTypeOf<PagePropsFor<typeof _app, 'CurriedShared'>>().toEqualTypeOf<{
+      session: { user: { name: string } } | null
+    }>()
+  })
+
   it('requires share callbacks to return props synchronously', () => {
     // @ts-expect-error Shared props are returned synchronously.
     inertia({ share: async () => ({ session: await Promise.resolve(null) }) })

--- a/packages/inertia/src/page-props.test.ts
+++ b/packages/inertia/src/page-props.test.ts
@@ -1,41 +1,44 @@
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import { describe, expectTypeOf, it } from 'vitest'
-import type { PageProps } from './page-props'
+import type { PagePropsFor } from './page-props'
 import { inertia } from './index'
 
-const _app = new Hono()
-  .use(inertia())
-  .get('/lazy-props', (c) => c.render('LazyProps', { lazy: () => Promise.resolve({ id: 0 }) }))
-  .get('/without-props', (c) => c.render('WithoutProps'))
-  .get(
-    '/union-with-empty-props',
-    (c) => c.render('UnionWithEmptyProps'),
-    (c) => c.render('UnionWithEmptyProps', { kind: 'ok' as const, value: 0 }),
-    (c) => c.render('UnionWithEmptyProps', { kind: 'ng' as const, error: 'message' })
-  )
-  .get(
-    '/union-without-empty-props',
-    (c) => c.render('UnionWithoutEmptyProps', { a: 0 }),
-    (c) => c.render('UnionWithoutEmptyProps', { b: 'string' })
-  )
+describe('PagePropsFor', () => {
+  it('restricts component names to the app routes', () => {
+    const _app = new Hono().use(inertia()).get('/', (c) => c.render('Exists'))
 
-declare module '@hono/inertia' {
-  interface AppRegistry {
-    app: typeof _app
-  }
-}
+    // @ts-expect-error Unknown is not rendered by _app.
+    type UnknownPageProps = PagePropsFor<typeof _app, 'Unknown'>
 
-describe('PageProps', () => {
+    expectTypeOf<UnknownPageProps>().toBeNever()
+  })
+
   it('resolves lazy props', () => {
-    expectTypeOf<PageProps<'LazyProps'>>().toEqualTypeOf<{ lazy: { id: number } }>()
+    const _app = new Hono()
+      .use(inertia())
+      .get('/', (c) => c.render('LazyProps', { lazy: () => Promise.resolve({ id: 0 }) }))
+
+    expectTypeOf<PagePropsFor<typeof _app, 'LazyProps'>>().toEqualTypeOf<{
+      lazy: { id: number }
+    }>()
   })
 
   it('normalizes renders without props to {}', () => {
-    expectTypeOf<PageProps<'WithoutProps'>>().toEqualTypeOf<{}>()
+    const _app = new Hono().use(inertia()).get('/', (c) => c.render('WithoutProps'))
+
+    expectTypeOf<PagePropsFor<typeof _app, 'WithoutProps'>>().toEqualTypeOf<{}>()
   })
 
   it('normalizes unions with empty props', () => {
-    expectTypeOf<PageProps<'UnionWithEmptyProps'>>().toEqualTypeOf<
+    const _app = new Hono().use(inertia()).get(
+      '/',
+      (c) => c.render('UnionWithEmptyProps'),
+      (c) => c.render('UnionWithEmptyProps', { kind: 'ok' as const, value: 0 }),
+      (c) => c.render('UnionWithEmptyProps', { kind: 'ng' as const, error: 'message' })
+    )
+
+    expectTypeOf<PagePropsFor<typeof _app, 'UnionWithEmptyProps'>>().toEqualTypeOf<
       | { kind: 'ok'; value: number }
       | { kind: 'ng'; error: string }
       | { kind?: never; value?: never; error?: never }
@@ -43,8 +46,75 @@ describe('PageProps', () => {
   })
 
   it('preserves unions without empty props', () => {
-    expectTypeOf<PageProps<'UnionWithoutEmptyProps'>>().toEqualTypeOf<
+    const _app = new Hono().use(inertia()).get(
+      '/',
+      (c) => c.render('UnionWithoutEmptyProps', { a: 0 }),
+      (c) => c.render('UnionWithoutEmptyProps', { b: 'string' })
+    )
+
+    expectTypeOf<PagePropsFor<typeof _app, 'UnionWithoutEmptyProps'>>().toEqualTypeOf<
       { a: number } | { b: string }
+    >()
+  })
+
+  it('infers shared props from a share callback with an explicit Env', () => {
+    type Session = { user: { name: string } }
+    type SessionEnv = { Variables: { session: Session | null } }
+
+    const _app = new Hono()
+      .use(inertia({ share: (c: Context<SessionEnv>) => ({ session: c.get('session') }) }))
+      .get('/', (c) => c.render('Shared'))
+
+    expectTypeOf<PagePropsFor<typeof _app, 'Shared'>>().toEqualTypeOf<{
+      session: { user: { name: string } } | null
+    }>()
+  })
+
+  it('merges shared props and prefers page props for duplicate keys', () => {
+    const _app = new Hono()
+      .use(
+        inertia({
+          share: () => ({
+            static: 'value',
+            lazy: () => Promise.resolve({ id: 0 }),
+            duplicated: 0,
+          }),
+        })
+      )
+      .get('/', (c) => c.render('MergedProps', { duplicated: 'string', own: true }))
+
+    expectTypeOf<PagePropsFor<typeof _app, 'MergedProps'>>().toEqualTypeOf<{
+      static: string
+      lazy: { id: number }
+      duplicated: string
+      own: boolean
+    }>()
+  })
+
+  it('merges shared props into unions without empty props', () => {
+    const _app = new Hono().use(inertia({ share: () => ({ value: 'shared' }) })).get(
+      '/',
+      (c) => c.render('UnionWithoutEmptyProps', { kind: 'ok' as const, value: 0 }),
+      (c) => c.render('UnionWithoutEmptyProps', { kind: 'ng' as const, error: 'message' })
+    )
+
+    expectTypeOf<PagePropsFor<typeof _app, 'UnionWithoutEmptyProps'>>().toEqualTypeOf<
+      { kind: 'ok'; value: number } | { kind: 'ng'; value: string; error: string }
+    >()
+  })
+
+  it('merges shared props into unions with empty props', () => {
+    const _app = new Hono().use(inertia({ share: () => ({ value: 'shared' }) })).get(
+      '/',
+      (c) => c.render('UnionWithEmptyProps'),
+      (c) => c.render('UnionWithEmptyProps', { kind: 'ok' as const, value: 0 }),
+      (c) => c.render('UnionWithEmptyProps', { kind: 'ng' as const, error: 'message' })
+    )
+
+    expectTypeOf<PagePropsFor<typeof _app, 'UnionWithEmptyProps'>>().toEqualTypeOf<
+      | { value: string; kind?: never; error?: never }
+      | { kind: 'ok'; value: number }
+      | { kind: 'ng'; value: string; error: string }
     >()
   })
 })

--- a/packages/inertia/src/page-props.ts
+++ b/packages/inertia/src/page-props.ts
@@ -1,12 +1,14 @@
 /**
  * @module
- * Type helpers that derive page prop types from a Hono app's route schema.
+ * Type helpers that derive page prop types from a Hono app's route schema and shared props.
  *
  * Users augment {@link AppRegistry} (typically from a generated `pages.gen.ts`
  * file) so that {@link PageProps} can resolve the props for a given page name.
  */
 
+import type { HonoBase } from 'hono/hono-base'
 import type { ExtractSchema } from 'hono/types'
+import type { ResolvedProps } from './index'
 
 /**
  * Augment this interface to register a Hono app instance for type-safe page props.
@@ -24,7 +26,32 @@ import type { ExtractSchema } from 'hono/types'
  */
 export interface AppRegistry {}
 
+const SHARE_KEY: unique symbol = Symbol()
+
+/**
+ * Internal environment marker added by {@link inertia} for shared props.
+ *
+ * Used to infer shared props from a Hono app type.
+ *
+ * @internal
+ */
+export type InertiaSharedEnv<V> = {
+  Variables: {
+    [SHARE_KEY]: V
+  }
+}
+
 type RegisteredApp = AppRegistry extends { app: infer A } ? A : never
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AppEnv<App> = App extends HonoBase<infer E, any, any, any> ? E : never
+
+type SharedProps<App> =
+  AppEnv<App> extends InertiaSharedEnv<infer V>
+    ? V extends Record<string, never>
+      ? {}
+      : ResolvedProps<V>
+    : {}
 
 type Distribute<T> = T extends infer U ? U : never
 
@@ -53,9 +80,9 @@ type AllKeys<T> = T extends unknown ? keyof T : never
  * Props-less renders are normalized to the other renders' keys as optional `never`,
  * so access keeps working while the value may still be `undefined`.
  */
-type NormalizeProps<T, All = T> =
+type NormalizeProps<T, Shared, All = T> =
   T extends Record<string, never>
-    ? { [K in AllKeys<Exclude<All, Record<string, never>>>]?: never }
+    ? { [K in Exclude<AllKeys<Exclude<All, Record<string, never>>>, keyof Shared>]?: never }
     : T
 
 /**
@@ -64,6 +91,26 @@ type NormalizeProps<T, All = T> =
  */
 type Simplify<T> = { [K in keyof T]: T[K] } & {}
 
+type MergeProps<Shared, Own> = Own extends unknown ? Simplify<Omit<Shared, keyof Own> & Own> : never
+
+/**
+ * Resolves page props from an explicit Hono app type.
+ *
+ * Kept internal so type tests can define isolated apps
+ * without relying on the global {@link AppRegistry}.
+ *
+ * @internal
+ */
+export type PagePropsFor<
+  App,
+  C extends RenderOutput<App>['component'] = RenderOutput<App>['component'],
+> = C extends unknown
+  ? MergeProps<
+      SharedProps<App>,
+      NormalizeProps<Extract<RenderOutput<App>, { component: C }>['props'], SharedProps<App>>
+    >
+  : never
+
 /**
  * Resolves the props type for a given Inertia page component name.
  *
@@ -71,6 +118,4 @@ type Simplify<T> = { [K in keyof T]: T[K] } & {}
  */
 export type PageProps<
   C extends RenderOutput<RegisteredApp>['component'] = RenderOutput<RegisteredApp>['component'],
-> = C extends unknown
-  ? Simplify<NormalizeProps<Extract<RenderOutput<RegisteredApp>, { component: C }>['props']>>
-  : never
+> = PagePropsFor<RegisteredApp, C>


### PR DESCRIPTION
## Overview

Add a `share` option to `inertia()` so that props shared across pages can be configured with a synchronous callback. Asynchronous values can still use the existing lazy function props mechanism.

## Changes

### feat(inertia): add shared props through a `share` callback

- Accept a synchronous callback that receives the current Hono context and returns shared props
- Combine shared props with page props, with page-specific props taking precedence when keys overlap
- Process shared props in the same way as props passed to `c.render()`, including lazy function props
- Infer shared prop types from the return value of `share` and include them in `PageProps`
- Add `sharedProps` page metadata containing the top-level keys returned by `share`

### fix(inertia): correct the `c.render()` return type

- Update the `c.render()` type to `Response | Promise<Response>` and add tests for both return paths

### Tests and documentation

- Add runtime and type tests for shared props, partial reloads, `sharedProps`, and `c.render()` return values
- Update the README with shared data, type inference, and `sharedProps` documentation

## Inferring types from the `share` callback return value

```ts
import { Hono, type Context } from 'hono'
import { inertia } from '@hono/inertia'

type Session = { user: { name: string } }
type SessionEnv = { Variables: { session: Session | null } }

const app = new Hono<SessionEnv>()

const route = app
  .use((c, next) => {
    c.set('session', { user: { name: 'John Doe' } })
    await next()
  })
  .use(
    inertia({
      share: (c: Context<SessionEnv>) => ({
        session: c.get('session'),
      }),
    })
  )
```

The shared props type is inferred from the return value of the `share` callback:

```ts
{ session: Session | null }
```

The inferred type is passed to the `inertia` middleware through `Env` and reflected in the page props of `c.render()`. The shared props type does not need to be specified separately. Type tests use `PagePropsFor` to verify page props for each app without relying on the global `AppRegistry`.

## Shared props for apps mounted with `.route()`

When another app (sub-app) is mounted on a parent app with `.route()`, the `inertia({ share })` configured on the sub-app works at runtime. However, the `share` type defined in the sub-app's middleware is not propagated to the parent app's `PageProps`.

To include the sub-app's shared data in `PageProps`, the data must be passed explicitly as props to `c.render()`. `provide` is a middleware helper that stores the shared data in the `Context` and makes it reusable from each handler.

In the non-curried form, `Context<SubEnv>` is explicitly specified as the provider parameter, as in `provide('shared', (c: Context<SubEnv>) => ...)`. In the curried form, `provide<SubEnv>()` provides the type for the provider's `Context`.

<details>
<summary>Example implementation of `provide`</summary>

```ts
import type { Context, Env, MiddlewareHandler } from 'hono'

type ProvidedEnv<K extends PropertyKey, V> = {
  Variables: Record<K, V>
}

type Provider<E extends Env, V> = (c: Context<E>) => V | Promise<V>

type Provide<E extends Env> = <K extends PropertyKey, V>(
  key: K,
  provider: Provider<E, V>
) => MiddlewareHandler<ProvidedEnv<K, V>>

// provide(key, provider)
function provide<E extends Env, K extends PropertyKey, V>(
  key: K,
  provider: Provider<E, V>
): MiddlewareHandler<ProvidedEnv<K, V>>

// provide()
function provide<E extends Env>(): Provide<E>

function provide<E extends Env, K extends PropertyKey, V>(
  ...args: [] | [K, Provider<E, V>]
): Provide<E> | MiddlewareHandler<ProvidedEnv<K, V>> {
  const create: Provide<E> = (key, provider) => async (c, next) => {
    c.set(key, await provider(c as unknown as Context<E>))
    return next()
  }

  if (args.length === 0) {
    return create
  }

  return create(...args)
}
```

</details>

```ts
type Session = { user: { name: string } }
type SubEnv = { Variables: { session: Session | null } }

const sub = new Hono<SubEnv>()
  .use((c, next) => {
    c.set('session', { user: { name: 'John Doe' } })
    await next()
  })
  .use(
    provide<SubEnv>()('shared', (c) => ({
      session: c.get('session'),
    }))
  )
  .get('/dashboard', (c) => {
    return c.render('Sub/Dashboard', {
      ...c.get('shared'),
      message: 'sub',
    })
  })

const app = new Hono<SessionEnv>()

const route = app.use(inertia()).route('/sub', sub)
```

Since `provide` is a generic middleware helper that does not affect Inertia's functionality, a PoC PR is planned for the main Hono repository.

## Curried form

By using currying, `Context` does not need to be imported; `inertia<SessionEnv>()` types the `Context` passed to the `share` callback.
The curried form is being developed on a separate branch. If adopted, it will either be included in this PR or split into a separate PR.

URL: https://github.com/nkfr26/middleware/commit/8feaef58ca15c34074b643a38a2db635547dd93b

```ts
type Session = { user: { id: string } }
type SessionEnv = { Variables: { session: Session | null } }

const app = new Hono<SessionEnv>().use(
  inertia<SessionEnv>()({
    share: (c) => ({
      session: c.get('session'),
    }),
  })
)
```

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/honojs/middleware?tab=readme-ov-file#how-to-contribute)