### PR TITLE
feat(inertia): add always() for props that bypass partial reload filtering

### DIFF
--- a/.changeset/tall-onions-repeat.md
+++ b/.changeset/tall-onions-repeat.md
@@ -1,0 +1,5 @@
+---
+'@hono/inertia': minor
+---
+
+Add `always()` to mark a prop as always included. Props wrapped with it bypass both the `X-Inertia-Partial-Data` and `X-Inertia-Partial-Except` filters, so cross-cutting props such as validation errors or flash messages survive a partial reload. Mirrors `Inertia::always()` in `inertia-laravel`.

--- a/packages/inertia/README.md
+++ b/packages/inertia/README.md
@@ -223,6 +223,25 @@ Function props (`() => T | Promise<T>`) are evaluated lazily, so heavy data fetc
 
 A request is treated as a partial reload only when `X-Inertia-Partial-Component` matches the rendered component **and** at least one of `X-Inertia-Partial-Data` / `X-Inertia-Partial-Except` is present. Otherwise the request is processed as a normal Inertia visit and every prop — including function props — is resolved.
 
+### Always included props
+
+Some props are needed by the page no matter what the client asked for — validation errors, flash messages, the authenticated user. Wrap them with `always()` and they bypass both `X-Inertia-Partial-Data` and `X-Inertia-Partial-Except`:
+
+```ts
+import { always } from '@hono/inertia'
+
+app.get('/users', (c) =>
+  c.render('Users/Index', {
+    users: () => db.users.all(),
+    errors: always(getErrors(c)), // present even on a partial reload of `users`
+  })
+)
+```
+
+The wrapped value follows the same rules as a plain prop, so `always(() => getFlash(c))` defers the work until the prop is rendered.
+
+`always()` is a filter escape hatch rather than a prop type — wrap plain values or functions with it. Combining it with `defer()` is not supported, since a deferred prop is by definition absent from the initial response.
+
 ## Deferred props
 
 [Deferred props](https://inertiajs.com/deferred-props) move heavy data fetching off the critical path: the initial response advertises which props are pending, the page becomes interactive immediately, and the Inertia client then issues a follow-up partial reload to fill them in.

--- a/packages/inertia/src/index.test.ts
+++ b/packages/inertia/src/index.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import type { PageObject, ScrollDescriptor } from './index'
-import { deepMerge, defer, inertia, merge, prepend, scroll } from './index'
+import { always, deepMerge, defer, inertia, merge, prepend, scroll } from './index'
 
 describe('inertia', () => {
   describe('full page (non Inertia request)', () => {
@@ -575,6 +575,117 @@ describe('inertia', () => {
       expect(calls.sort()).toEqual(['a', 'b'])
       const body = (await res.json()) as { props: Record<string, unknown> }
       expect(body.props).toEqual({ a: 1, b: 2 })
+    })
+  })
+
+  describe('always props', () => {
+    const partialHeaders = (component: string, only?: string, except?: string) => {
+      const headers: Record<string, string> = {
+        'X-Inertia': 'true',
+        'X-Inertia-Version': 'v1',
+        'X-Inertia-Partial-Component': component,
+      }
+      if (only !== undefined) {
+        headers['X-Inertia-Partial-Data'] = only
+      }
+      if (except !== undefined) {
+        headers['X-Inertia-Partial-Except'] = except
+      }
+      return headers
+    }
+
+    it('keeps an always prop that is missing from X-Inertia-Partial-Data', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { a: 1, b: 2, errors: always({ name: 'required' }) }))
+
+      const res = await app.request('/', { headers: partialHeaders('Home', 'a') })
+
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ a: 1, errors: { name: 'required' } })
+    })
+
+    it('keeps an always prop listed in X-Inertia-Partial-Except', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { a: 1, errors: always({ name: 'required' }) }))
+
+      const res = await app.request('/', {
+        headers: partialHeaders('Home', undefined, 'errors'),
+      })
+
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ a: 1, errors: { name: 'required' } })
+    })
+
+    it('unwraps an always prop on a full visit', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { errors: always({ name: 'required' }) }))
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ errors: { name: 'required' } })
+    })
+
+    it('resolves a function wrapped with always during a partial reload', async () => {
+      const calls: string[] = []
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', {
+          heavy: () => {
+            calls.push('heavy')
+            return 'h'
+          },
+          flash: always(async () => {
+            calls.push('flash')
+            await new Promise((r) => setTimeout(r, 5))
+            return 'saved'
+          }),
+        })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Home', 'heavy') })
+
+      expect(calls.sort()).toEqual(['flash', 'heavy'])
+      const body = (await res.json()) as { props: Record<string, unknown> }
+      expect(body.props).toEqual({ heavy: 'h', flash: 'saved' })
+    })
+
+    it('emits merge metadata for an always prop wrapping merge()', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) =>
+        c.render('Home', { a: 1, feed: always(merge([{ id: 1 }], { matchOn: 'id' })) })
+      )
+
+      const res = await app.request('/', { headers: partialHeaders('Home', 'a') })
+
+      const body = (await res.json()) as PageObject
+      expect(body.props).toEqual({ a: 1, feed: [{ id: 1 }] })
+      expect(body.mergeProps).toEqual(['feed'])
+      expect(body.matchPropsOn).toEqual(['feed.id'])
+    })
+
+    it('does not emit any page metadata for a plain always prop', async () => {
+      const app = new Hono()
+      app.use(inertia({ version: 'v1' }))
+      app.get('/', (c) => c.render('Home', { errors: always({ name: 'required' }) }))
+
+      const res = await app.request('/', {
+        headers: { 'X-Inertia': 'true', 'X-Inertia-Version': 'v1' },
+      })
+
+      expect(await res.json()).toEqual({
+        component: 'Home',
+        props: { errors: { name: 'required' } },
+        url: '/',
+        version: 'v1',
+      })
     })
   })
 

--- a/packages/inertia/src/index.ts
+++ b/packages/inertia/src/index.ts
@@ -161,6 +161,62 @@ export const defer = <T>(resolver: () => T | Promise<T>, group = 'default'): T =
   return marker as unknown as T
 }
 
+const ALWAYS_MARKER = Symbol.for('@hono/inertia/always')
+
+/**
+ * Internal marker produced by {@link always}. The renderer detects this and
+ * skips the partial-reload filter for the prop, so the value is sent on every
+ * response regardless of `X-Inertia-Partial-Data` /
+ * `X-Inertia-Partial-Except`.
+ *
+ * The shape is intentionally opaque — only the type guard inside the renderer
+ * reads it. The factory returns `T` so usage at call sites is transparent.
+ */
+interface AlwaysProp<T = unknown> {
+  [ALWAYS_MARKER]: true
+  data: T
+}
+
+const isAlways = (value: unknown): value is AlwaysProp =>
+  typeof value === 'object' && value !== null && ALWAYS_MARKER in value
+
+/**
+ * Marks a prop as **always included**. Partial reloads normally send only the
+ * props listed in `X-Inertia-Partial-Data` (or everything except the ones in
+ * `X-Inertia-Partial-Except`); a prop wrapped with `always` bypasses both
+ * filters and is present on every response.
+ *
+ * Use it for cross-cutting props — validation errors, flash messages, the
+ * authenticated user — that a page needs even when the client asked for a
+ * single prop.
+ *
+ * The wrapped value follows the same resolution rules as a plain prop: pass a
+ * function to defer the work until the prop is actually rendered.
+ *
+ * `always` is a filter escape hatch, not a prop type — wrap plain values or
+ * functions with it. Combining it with {@link defer} is not supported, since
+ * a deferred prop is by definition absent from the initial response.
+ *
+ * @example
+ * ```ts
+ * app.get('/users', (c) =>
+ *   c.render('Users/Index', {
+ *     users: () => fetchUsers(),
+ *     errors: always(getErrors(c)), // sent even on a partial reload of `users`
+ *   }),
+ * )
+ * ```
+ *
+ * @see https://inertiajs.com/partial-reloads
+ */
+export const always = <T>(data: T): T => {
+  const marker: AlwaysProp<T> = {
+    [ALWAYS_MARKER]: true,
+    data,
+  }
+  return marker as unknown as T
+}
+
 const MERGE_MARKER = Symbol.for('@hono/inertia/merge')
 
 /**
@@ -511,6 +567,11 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       // fully sync — preserving the original `Response` (non-Promise) return
       // type for the common case.
       //
+      // Props wrapped with `always()` skip `isExcluded` entirely, mirroring
+      // `AlwaysProp` in inertia-laravel: it short circuits
+      // `shouldIncludeInPartialResponse` before either the `only` or the
+      // `except` header is consulted.
+      //
       // Deferred props are handled per visit kind:
       //   - initial visit (`!isPartial`): the resolver is skipped, the key
       //     is recorded in `deferredGroups`, and nothing is added to `kept`.
@@ -533,8 +594,13 @@ export const inertia = (options: InertiaOptions = {}): MiddlewareHandler => {
       const matchPropsOn: string[] = []
       const scrollProps: Record<string, ScrollDescriptor> = {}
       let needsAsync = false
-      for (const [key, value] of Object.entries(propsInput)) {
-        if (isExcluded(key)) {
+      for (const [key, raw] of Object.entries(propsInput)) {
+        // `always()` is unwrapped up front: it only opts the prop out of the
+        // partial-reload filter, then the inner value follows the same path as
+        // any other prop.
+        const forced = isAlways(raw)
+        const value = forced ? raw.data : raw
+        if (!forced && isExcluded(key)) {
           continue
         }
         if (isDeferred(value)) {


### PR DESCRIPTION
## Overview

Adds `always()`, a prop wrapper that bypasses partial reload filtering. This is item ① from #2110, and the foundation the shared data work (②) builds on.

## Motivation

Partial reloads narrow the response down to the props listed in `X-Inertia-Partial-Data` (or everything except the ones in `X-Inertia-Partial-Except`). Cross-cutting props — validation errors, flash messages, the authenticated user — are still needed by the page even when the client asked for a single prop, and there is currently no way to express that.

```ts
app.get('/users', (c) =>
  c.render('Users/Index', {
    users: () => db.users.all(),
    errors: always(getErrors(c)), // present even on a partial reload of `users`
  })
)
```

## Parity with inertia-laravel

`AlwaysProp` short circuits on the first condition of `shouldIncludeInPartialResponse`, so it bypasses **both** the `only` and the `except` header. This PR matches that.

```php
if (! $this->isPartial || $prop instanceof AlwaysProp || $parentWasResolved) {
    return true;
}
```

There is no `always` entry in `buildMetadata()`, so nothing is added to the page object.

## Implementation

Same marker approach as `defer()` / `merge()` / `scroll()`. The renderer unwraps the marker at the top of the prop loop, skips the filter, and lets the inner value fall through to the existing resolution path. As a result `always(() => ...)` still resolves lazily and `always(merge(...))` still emits its merge metadata. Wrapping a plain value keeps the synchronous fast path intact.

`always(defer(...))` is not supported: `AlwaysProp` is not `Deferrable` in inertia-laravel either, and "always present on the initial response" and "never present on the initial response" cannot both hold. This is documented in the README.

## Related

Item ① of #2110. Item ② (`share`) is being worked on by @nkfr26 in #2124 — shared data needs this to behave correctly under partial reloads, which is exactly why Laravel wraps `errors` in `always()`.

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `pnpm changeset` at the top of this repo and push the changeset
- [x] Follow [the contribution guide](https://github.com/hono/middleware?tab=readme-ov-file#how-to-contribute)
